### PR TITLE
set inventory() target to null/None to get all targets

### DIFF
--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -107,13 +107,16 @@ def inventory(search_path, target, inventory_path="inventory/"):
     """
     Reads inventory (set by inventory_path) in search_path.
     set nodes_uri to change reclass nodes_uri the default value
+    set target to None to return all target in the inventory
     Returns a dictionary with the inventory for target
     """
     full_inv_path = os.path.join(search_path, inventory_path)
 
-    inv_target = inventory_reclass(full_inv_path)["nodes"][target]
+    if target is None:
+        return inventory_reclass(full_inv_path)["nodes"]
 
-    return inv_target
+    return inventory_reclass(full_inv_path)["nodes"][target]
+
 
 
 @memoize

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -14,16 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"jinja2 filter tests"
+"inventory tests"
 import unittest
-import tempfile
-from kapitan.utils import render_jinja2_file
+from kapitan.resources import inventory
 
-class Jinja2FiltersTest(unittest.TestCase):
-    def test_sha256(self):
-        with tempfile.NamedTemporaryFile() as f:
-            f.write("{{text|sha256}}")
-            f.seek(0)
-            context = {"text":"this and that"}
-            digest = 'e863c1ac42619a2b429a08775a6acd89ff4c2c6b8dae12e3461a5fa63b2f92f5'
-            self.assertEqual(render_jinja2_file(f.name, context), digest)
+class InventoryTargetTest(unittest.TestCase):
+    def test_inventory_target(self):
+        inv = inventory("examples", "minikube-es")
+        self.assertEqual(inv["parameters"]["cluster"]["name"], "minikube")
+
+    def test_inventory_all_targets(self):
+        inv = inventory("examples", None)
+        self.assertNotEqual(inv.get("minikube-es"), None)


### PR DESCRIPTION
This will simply allow to call inventory(target=null) and return a view of all target in the inventory as opposed to the default current target.