### PR TITLE
Secrets with GnuPG support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ notifications:
     on_success: change
     on_failure: always
 
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y gnupg2
+
 # command to install dependencies
 install:
   - pip install -r requirements.txt

--- a/examples/inventory/targets/minikube-es.yml
+++ b/examples/inventory/targets/minikube-es.yml
@@ -3,6 +3,10 @@ classes:
   - component.elasticsearch
 
 parameters:
+  kapitan:
+    secrets:
+      recipients:
+        - dummy@recipient
   namespace: minikube-es
 
   elasticsearch:

--- a/kapitan/secrets.py
+++ b/kapitan/secrets.py
@@ -50,7 +50,6 @@ def secret_gpg_encrypt(gpg_obj, data, recipients, **kwargs):
 
 def secret_gpg_decrypt(gpg_obj, data, **kwargs):
     "decrypt data"
-    print kwargs
     return gpg_obj.decrypt(data, **kwargs)
 
 def secret_gpg_read(gpg_obj, secrets_path, token, **kwargs):

--- a/kapitan/secrets.py
+++ b/kapitan/secrets.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+#
+# Copyright 2017 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"secrets module"
+
+import errno
+import logging
+import os
+import re
+import gnupg
+
+logger = logging.getLogger(__name__)
+
+SECRET_TOKEN_PATTERN = r"(\?\([\w-\/]+\)\?)"
+SECRET_PATTERN = r"[\w-\/]+"
+
+def secret_gpg_backend():
+    "return gpg secret backend"
+    return gnupg.GPG()
+
+def secret_gpg_encrypt(gpg_obj, data, recipients):
+    return gpg_obj.encrypt(data, recipients)
+
+def secret_gpg_decrypt(gpg_obj, data):
+    return gpg_obj.decrypt(data)
+
+def secret_gpg_read(gpg_obj, secrets_path, secret_id):
+    pass
+
+def secret_gpg_write(gpg_obj, secrets_path, secret_id, data, recipients):
+    full_secret_path = os.path.join(secrets_path, secret_id)
+    secret_filename = os.path.basename(secret_id)
+    try:
+        os.makedirs(os.path.dirname(full_secret_path))
+    except OSError as ex:
+        # If directory exists, pass
+        if ex.errno == errno.EEXIST:
+            pass
+    with open(full_secret_path, "w") as fp:
+        enc = secret_gpg_encrypt(gpg_obj, data, recipients)
+        fp.write(enc.data)
+        logger.debug("Wrote secret %s at %s", secret_id, secrets_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ PyYAML==3.12
 Jinja2==2.9.4
 jsonschema==2.5.1
 reclass==1.4.1
+python-gnupg==0.4.1

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,57 @@
+#!/usr/bin/python
+#
+# Copyright 2017 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"secrets tests"
+import os
+import unittest
+import re
+import tempfile
+import gnupg
+from kapitan.secrets import secret_token_attributes, SECRET_TOKEN_TAG_PATTERN
+from kapitan.secrets import secret_gpg_write, secret_gpg_reveal
+
+GPG_HOME = tempfile.mkdtemp()
+GPG_OBJ = gnupg.GPG(gnupghome=GPG_HOME)
+SECRETS_HOME = tempfile.mkdtemp()
+KEY = GPG_OBJ.gen_key(GPG_OBJ.gen_key_input(key_type="RSA",
+                                            key_length=2048,
+                                            passphrase="testphrase"))
+class SecretsTest(unittest.TestCase):
+    def test_secret_token_attributes(self):
+        "grab attributes and compare to values"
+        token_tag = '?{gpg:secret/sauce}'
+        _token_tag, token = re.match(SECRET_TOKEN_TAG_PATTERN,
+                                     token_tag).groups()
+        self.assertEqual(_token_tag, token_tag)
+        backend, token_path = secret_token_attributes(token)
+        self.assertEqual((backend, token_path), ('gpg', 'secret/sauce'))
+
+    def test_gpg_secret_write_reveal(self):
+        "write secret, confirm secret file exists, reveal and compare content"
+        token = 'secret/sauce'
+        secret_gpg_write(GPG_OBJ, SECRETS_HOME, token, "super secret value",
+                         [KEY.fingerprint], passphrase="testphrase")
+        self.assertTrue(os.path.isfile(os.path.join(SECRETS_HOME, token)))
+
+        file_with_secret_tags = tempfile.mktemp()
+        file_revealed = tempfile.mktemp()
+        with open(file_with_secret_tags, 'w') as fp:
+            fp.write('I am a file with a ?{gpg:secret/sauce}')
+        with open(file_revealed, 'w') as fp:
+            secret_gpg_reveal(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
+                              output=fp)
+        with open(file_revealed) as fp:
+            self.assertEqual("I am a file with a super secret value", fp.read())

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -52,6 +52,6 @@ class SecretsTest(unittest.TestCase):
             fp.write('I am a file with a ?{gpg:secret/sauce}')
         with open(file_revealed, 'w') as fp:
             secret_gpg_reveal(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
-                              output=fp)
+                              output=fp, passphrase="testphrase")
         with open(file_revealed) as fp:
             self.assertEqual("I am a file with a super secret value", fp.read())


### PR DESCRIPTION
This exposes a new **secrets** command to help write and reveal secrets with the goal of avoiding any sensitive data in templates or compiled files.

Every new secret requires a token path and recipients which will be written to a file structure generated by the --write argument. 
The content of a secret token file contains the GnuPG encrypted secret data and a list of recipient fingerprints.

Example of encrypting the content of files/secret_sauce into the app1/secret1 token:
```
$ echo "super secret data" > files/secret_sauce
$ kapitan secrets --write app1/secret1 --recipients human@example.com -f files/secret_sauce
```

Tokens can be used in templates and inventory and will not be revealed when compiled. Any compiled file with secrets will contain the secret token tags instead. 
A token tag is in the form of  ?{backend:path/to/secret}. To refer to the secret above, use ?{gpg:app1/secret1}

To reveal secret, the --reveal argument will read a file and resolve the token tags by reading the file structure and decrypting (should the one revealing be a recipient) to stdout only.
The reason for stdout here is to discourage saving revealed files into disk and instead pipe their output into i.e. ```kubectl apply -f```

Example of revealing content with the app1/secret1 token:
```
$ echo "this string has ?{gpg:app1/secret1}" | kapitan secrets --reveal -f -
this string has super secret data
```

This solution does not do any key management. That is a problem that the user will need to do by managing his GnuPG keys and settings. The assumption with this solution is that the keys used for recipients are trusted (otherwise python-gnupg will fail).