### PR TITLE
new yaml_dump() native jsonnet function

### DIFF
--- a/kapitan/lib/kapitan.libjsonnet
+++ b/kapitan/lib/kapitan.libjsonnet
@@ -3,4 +3,5 @@
   file_read(name):: std.native("file_read")(name),
   inventory(target=std.extVar("target"), inv_path="inventory/"):: std.native("inventory")(target, inv_path),
   inventory_global(target=null, inv_path="inventory/"):: std.native("inventory")(target, inv_path),
+  yaml_dump(obj):: std.native("yaml_dump")(std.toString(obj)),
 }

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -44,8 +44,13 @@ def resource_callbacks(search_path):
                           partial(inventory, search_path)),
             "file_read": (("name",),
                           partial(read_file, search_path)),
+            "yaml_dump": (("obj",), yaml_dump),
            }
 
+def yaml_dump(obj):
+    "Dumps jsonnet obj as yaml"
+    _obj = json.loads(obj)
+    return yaml.safe_dump(_obj, default_flow_style=False)
 
 def jinja2_render_file(search_path, name, ctx):
     """

--- a/tests/test_jsonnet.py
+++ b/tests/test_jsonnet.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+#
+# Copyright 2017 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"jsonnet tests"
+import unittest
+from kapitan.resources import yaml_dump
+
+class JsonnetNativeFuncsTest(unittest.TestCase):
+    def test_yaml_dump(self):
+        "dump json string to yaml"
+        yaml = yaml_dump("{\"key\":\"value\"}")
+        self.assertEqual(yaml, "key: value\n")


### PR DESCRIPTION
This native function allows rendering jsonnet object into YAML in runtime. Especially handy when you need to render a ConfigMap where the data is YAML. 