### PR TITLE
Compiled secret tags

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -71,6 +71,8 @@ def main():
     compile_parser.add_argument('--parallelism', '-p', type=int,
                                 default=4, metavar='INT',
                                 help='Number of concurrent compile processes, default is 4')
+    compile_parser.add_argument('--secrets-path', help='set secrets path, default is "./secrets"',
+                                default='./secrets',)
 
     inventory_parser = subparser.add_parser('inventory', help='show inventory')
     inventory_parser.add_argument('--target-name', '-t', default='',
@@ -144,7 +146,8 @@ def main():
             worker = partial(compile_target_file,
                              search_path=search_path,
                              output_path=args.output_path,
-                             prune=(not args.no_prune))
+                             prune=(not args.no_prune),
+                             secrets_path=args.secrets_path)
             try:
                 pool.map(worker, args.target_file)
             except RuntimeError:

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -73,6 +73,9 @@ def main():
                                 help='Number of concurrent compile processes, default is 4')
     compile_parser.add_argument('--secrets-path', help='set secrets path, default is "./secrets"',
                                 default='./secrets',)
+    compile_parser.add_argument('--reveal',
+                                help='reveal secrets (warning: this will write sensitive data)',
+                                action='store_true', default=False)
 
     inventory_parser = subparser.add_parser('inventory', help='show inventory')
     inventory_parser.add_argument('--target-name', '-t', default='',
@@ -109,6 +112,8 @@ def main():
     secrets_parser.add_argument('--verbose', '-v',
                                 help='set verbose mode (warning: this will show sensitive data)',
                                 action='store_true', default=False)
+    secrets_parser.add_argument('--no-verify', help='do not verify secret hashes on reveal',
+                                action='store_true', default=False)
 
     args = parser.parse_args()
 
@@ -141,13 +146,16 @@ def main():
         else:
             logging.basicConfig(level=logging.INFO, format="%(message)s")
         search_path = os.path.abspath(args.search_path)
+        gpg_obj = secret_gpg_backend()
         if args.target_file:
             pool = multiprocessing.Pool(args.parallelism)
             worker = partial(compile_target_file,
                              search_path=search_path,
                              output_path=args.output_path,
                              prune=(not args.no_prune),
-                             secrets_path=args.secrets_path)
+                             secrets_path=args.secrets_path,
+                             secrets_reveal=args.reveal,
+                             gpg_obj=gpg_obj)
             try:
                 pool.map(worker, args.target_file)
             except RuntimeError:
@@ -190,8 +198,9 @@ def main():
             secret_gpg_write(gpg_obj, args.secrets_path, args.write, data, recipients)
         elif args.reveal:
             if args.file == '-':
-                secret_gpg_reveal(gpg_obj, args.secrets_path, None)
+                secret_gpg_reveal(gpg_obj, args.secrets_path, None, verify=(not args.no_verify))
             elif args.file:
                 # TODO if it is a directory, reveal every file there
                 with open(args.file) as fp:
-                    secret_gpg_reveal(gpg_obj, args.secrets_path, args.file)
+                    secret_gpg_reveal(gpg_obj, args.secrets_path, args.file,
+                                      verify=(not args.no_verify))

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -19,6 +19,7 @@
 import logging
 import os
 import errno
+import hashlib
 import json
 import re
 import shutil
@@ -27,6 +28,8 @@ import yaml
 
 from kapitan.resources import search_imports, resource_callbacks, inventory
 from kapitan.utils import jsonnet_file, jsonnet_prune, render_jinja2_dir, PrettyDumper
+from kapitan.secrets import secret_gpg_raw_read, secret_token_from_tag, secret_token_attributes
+from kapitan.secrets import SECRET_TOKEN_TAG_PATTERN
 
 logger = logging.getLogger(__name__)
 
@@ -62,15 +65,19 @@ def compile_target_file(target_file, search_path, output_path, **kwargs):
                 ctx = ext_vars.copy()
                 ctx["inventory"] = inventory(search_path, target_name)
                 ctx["inventory_global"] = inventory(search_path, None)
-                compile_jinja2(compile_path_sp, ctx, _output_path)
+                compile_jinja2(compile_path_sp, ctx, _output_path, **kwargs)
             else:
                 raise IOError("Path not found in search_path: %s" % obj["path"])
 
 
-def compile_jinja2(path, context, output_path):
+def compile_jinja2(path, context, output_path, **kwargs):
     """
     Write items in path as jinja2 rendered files to output_path.
+    kwargs:
+        secrets_path: default None, set to access secrets backend
     """
+    secrets_path = kwargs.get('secrets_path', None)
+
     for item_key, item_value in render_jinja2_dir(path, context).iteritems():
         full_item_path = os.path.join(output_path, item_key)
         try:
@@ -79,7 +86,7 @@ def compile_jinja2(path, context, output_path):
             # If directory exists, pass
             if ex.errno == errno.EEXIST:
                 pass
-        with open(full_item_path, 'w') as fp:
+        with CompiledFile(full_item_path, mode="w", secrets_path=secrets_path) as fp:
             fp.write(item_value["content"])
             mode = item_value["mode"]
             os.chmod(full_item_path, mode)
@@ -94,6 +101,7 @@ def compile_jsonnet(file_path, output_path, search_path, ext_vars, **kwargs):
     kwargs:
         output: default 'yaml', accepts 'json'
         prune: default True, accepts False
+        secrets_path: default None, set to access secrets backend
     """
     _search_imports = lambda cwd, imp: search_imports(cwd, imp, search_path)
     json_output = jsonnet_file(file_path, import_callback=_search_imports,
@@ -102,6 +110,7 @@ def compile_jsonnet(file_path, output_path, search_path, ext_vars, **kwargs):
 
     output = kwargs.get('output', 'yaml')
     prune = kwargs.get('prune', True)
+    secrets_path = kwargs.get('secrets_path', None)
 
     if prune:
         json_output = jsonnet_prune(json_output)
@@ -110,12 +119,12 @@ def compile_jsonnet(file_path, output_path, search_path, ext_vars, **kwargs):
         # write each item to disk
         if output == 'json':
             file_path = os.path.join(output_path, '%s.%s' % (item_key, output))
-            with open(file_path, 'w') as fp:
+            with CompiledFile(file_path, mode="w", secrets_path=secrets_path) as fp:
                 json.dump(item_value, fp, indent=4, sort_keys=True)
                 logger.info("Wrote %s", file_path)
         elif output == 'yaml':
             file_path = os.path.join(output_path, '%s.%s' % (item_key, "yml"))
-            with open(file_path, 'w') as fp:
+            with CompiledFile(file_path, mode="w", secrets_path=secrets_path) as fp:
                 yaml.dump(item_value, stream=fp, Dumper=PrettyDumper, default_flow_style=False)
                 logger.info("Wrote %s", file_path)
         else:
@@ -183,3 +192,47 @@ def load_target(target_file):
             logger.debug("Target file %s is valid", target_file)
 
             return target_obj
+
+class CompilingFile(object):
+    def __init__(self, context, fp, **kwargs):
+        self.fp = fp
+        self.kwargs = kwargs
+
+    def hash_token_tag(self, token_tag):
+        """
+        suffixes a secret's hash to its tag:
+        e.g:
+        ?{gpg:app1/secret/1} gets replaced with
+        ?{gpg:app1/secret/1:7a5a9a67efbccff7a7b4764067833e1105f1e5f6779b4bf601f9c7b31b3b18c4}
+        """
+        secrets_path = self.kwargs.get("secrets_path", None)
+        token = secret_token_from_tag(token_tag)
+        secret_raw_obj = secret_gpg_raw_read(secrets_path, token)
+        backend, token_path = secret_token_attributes(token)
+        sha256 = hashlib.sha256("%s%s" % (token_path, secret_raw_obj["data"])).hexdigest()
+        return "?{%s:%s:%s}" % (backend, token_path, sha256)
+
+    def sub_token_compiled(self, data):
+        "find and replace tokens with hashed tokens in data"
+        def _hash_token_tag(match_obj):
+            token_tag, token = match_obj.groups()
+            return self.hash_token_tag(token_tag)
+
+        return re.sub(SECRET_TOKEN_TAG_PATTERN, _hash_token_tag, data)
+
+    def write(self, data):
+        self.fp.write(self.sub_token_compiled(data))
+
+class CompiledFile(object):
+    def __init__(self, name, **kwargs):
+        self.name = name
+        self.kwargs = kwargs
+        self.fp = None
+
+    def __enter__(self):
+        mode = self.kwargs.get("mode", "r")
+        self.fp = open(self.name, mode)
+        return CompilingFile(self, self.fp, **self.kwargs)
+
+    def __exit__(self, *args):
+        self.fp.close()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -30,6 +30,7 @@ KEY = GPG_OBJ.gen_key(GPG_OBJ.gen_key_input(key_type="RSA",
                                             key_length=2048,
                                             passphrase="testphrase"))
 class SecretsTest(unittest.TestCase):
+    "Test secrets"
     def test_secret_token_attributes(self):
         "grab attributes and compare to values"
         token_tag = '?{gpg:secret/sauce}'
@@ -49,9 +50,9 @@ class SecretsTest(unittest.TestCase):
         file_with_secret_tags = tempfile.mktemp()
         file_revealed = tempfile.mktemp()
         with open(file_with_secret_tags, 'w') as fp:
-            fp.write('I am a file with a ?{gpg:secret/sauce}')
+            fp.write('I am a file with a ?{gpg:secret/sauce:deadbeef}')
         with open(file_revealed, 'w') as fp:
             secret_gpg_reveal(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
-                              output=fp, passphrase="testphrase")
+                              verify=False, output=fp, passphrase="testphrase")
         with open(file_revealed) as fp:
             self.assertEqual("I am a file with a super secret value", fp.read())


### PR DESCRIPTION
### About

We're introducing a new default behaviour for any compiled items using kapitan secrets: compiled secret tags. 

Compiled secret tags are a way of verifying that compiled items containing secret tags match the stored secrets. This is done by appending a checksum to the secret tag when compiling.
Checksumming is achieved by doing a sha256 of the token path plus the sha256 of the base64 of the encrypted secret (note, not the secret itself). The checksum is then trimmed to 8 chars.

The use case here is auditing the lifecycle of the stored secrets (via git) whilst allowing developers, CI systems, etc... (who won't have access to decryption keys) to compile and validate the stored secrets without being able to reveal them.

### Example

Create a secret:
```
$ echo -n "secret_thing_1" | kapitan secrets --write test/secret1 --recipients somebody@example.com -f -
Wrote secret test/secret1 for fingerprints DEADBEEF at ./secrets/test/secret1
```

Using the following target:
```
$ cat test_target.yml
version: 1
vars:
  target: test
  namespace: test
compile:
  - name: manifests
    type: jsonnet
    path: test_code.jsonnet
```
And example code:
```
$ cat test_code.jsonnet
{
    this: { thing: "?{gpg:test/secret1}" },
}
```
Compiling the target:
```
$ kapitan compile -f test_target.yml
Wrote compiled/test/manifests/this.yml
```
Notice the compiled secret tag:
```
$ cat compiled/test/manifests/this.yml
thing: ?{gpg:test/secret1:55fc1096}
```

Revealing (and verifying the checksum of both stored secret and compiled secret tag):
```
$ kapitan secrets --reveal -f compiled/test/manifests/this.yml
thing: secret_thing_1
```

Rewriting the secret:
```
$ echo -n "secret_thing_2" | kapitan secrets --write test/secret1 --recipients somebody@example.com -f -
Wrote secret test/secret1 for fingerprints DEADBEEF at ./secrets/test/secret1
```

And attempting to reveal the original compiled item will fail (as the checksums will not match)
```
$ kapitan secrets --reveal -f compiled/test/manifests/this.yml
...
ValueError: Currently stored secret hash: d7863ac5 does not match compiled secret: gpg:test/secret:55fc1096
```

Compiled secret tags also work for jinja2 compile items.

This MR also includes two new flags:
* for compile: --reveal will reveal secrets on compilation
* for secrets: --no-verify will skip compiled secret tag checksum verification when revealing


