### PR TITLE
improved errors, logging and compilation

### DIFF
--- a/kapitan/errors.py
+++ b/kapitan/errors.py
@@ -1,0 +1,27 @@
+# Copyright 2017 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"kaptitan error classes"
+
+class KapitanError(Exception):
+    "generic kapitan error"
+    pass
+
+class CompileError(KapitanError):
+    "compile error"
+    pass
+
+class InventoryError(KapitanError):
+    "inventory error"
+    pass

--- a/kapitan/errors.py
+++ b/kapitan/errors.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"kaptitan error classes"
+"kapitan error classes"
 
 class KapitanError(Exception):
     "generic kapitan error"


### PR DESCRIPTION
This will log/print friendlier error messages avoiding tracebacks for known failure behaviours:
- inventory not found
- inventory render errors
- jsonnet compile errors
- jinja2 render errors (including jsonnet native calls)

Thus improving https://github.com/deepmind/kapitan/issues/11

Compiling will also now write to a tempdir and move it to output_path on success (tempdir is always removed)