### PR TITLE
base64 encode and write secret support

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -97,6 +97,8 @@ def main():
     secrets_parser = subparser.add_parser('secrets', help='manage secrets')
     secrets_parser.add_argument('--write', '-w', help='write secret token',
                                 metavar='TOKENNAME',)
+    secrets_parser.add_argument('--base64', '-b64', help='base64 encode file content',
+                                action='store_true', default=False)
     secrets_parser.add_argument('--reveal', '-r', help='reveal secrets',
                                 action='store_true', default=False)
     secrets_parser.add_argument('--file', '-f', help='read file, set "-" for stdin',
@@ -192,7 +194,7 @@ def main():
             else:
                 with open(args.file) as fp:
                     data = fp.read()
-            secret_gpg_write(gpg_obj, args.secrets_path, args.write, data, recipients)
+            secret_gpg_write(gpg_obj, args.secrets_path, args.write, data, args.base64, recipients)
         elif args.reveal:
             if args.file == '-':
                 secret_gpg_reveal(gpg_obj, args.secrets_path, None, verify=(not args.no_verify))


### PR DESCRIPTION
Add a new --base64 flag that when used with

```
$ kapitan secrets --write --base64 -f file_to_encrypt.txt
```

will base64 its content and then encrypt. It will also add a new 'encoding' key in the secret file to note that the original content was base64'd.

Essentially, this is equivalent of doing:

```
$ cat file_to_encrypt.txt | base64 | kapitan secrets --write my_secret --recipients person@example.com -f -
```

which is especially handy when using Kubernetes Secrets (which content needs to be base64'd)