### PR TITLE
improved revealing, added support for revealing files in directories

### DIFF
--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -21,7 +21,7 @@ import re
 import tempfile
 import gnupg
 from kapitan.secrets import secret_token_attributes, SECRET_TOKEN_TAG_PATTERN
-from kapitan.secrets import secret_gpg_write, secret_gpg_reveal
+from kapitan.secrets import secret_gpg_write, secret_gpg_reveal_raw
 
 GPG_HOME = tempfile.mkdtemp()
 GPG_OBJ = gnupg.GPG(gnupghome=GPG_HOME)
@@ -52,7 +52,7 @@ class SecretsTest(unittest.TestCase):
         with open(file_with_secret_tags, 'w') as fp:
             fp.write('I am a file with a ?{gpg:secret/sauce:deadbeef}')
         with open(file_revealed, 'w') as fp:
-            secret_gpg_reveal(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
+            secret_gpg_reveal_raw(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
                               verify=False, output=fp, passphrase="testphrase")
         with open(file_revealed) as fp:
             self.assertEqual("I am a file with a super secret value", fp.read())
@@ -72,7 +72,7 @@ class SecretsTest(unittest.TestCase):
         with open(file_with_secret_tags, 'w') as fp:
             fp.write('I am a file with a ?{gpg:secret/sauce:deadbeef}')
         with open(file_revealed, 'w') as fp:
-            secret_gpg_reveal(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
+            secret_gpg_reveal_raw(GPG_OBJ, SECRETS_HOME, file_with_secret_tags,
                               verify=False, output=fp, passphrase="testphrase")
         with open(file_revealed) as fp:
             self.assertEqual("I am a file with a c3VwZXIgc2VjcmV0IHZhbHVl", fp.read())


### PR DESCRIPTION
Added support for revealing directories with compiled files. The following:

```
$ kapitan secrets --reveal -f my_files/
```
Will keep output in memory until all files have been successfully revealed and will only then write to stdout.

Also on _secrets_ and _compile_ subcommands,  `--reveal`  will now recursively replace secret tags whenever possible (should they be json/yaml structured) and will fall back to search and replace on other formats.