### PR TITLE
Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - "2.7"
+  - "3.6"
 
 branches:
   only:
@@ -12,6 +12,7 @@ notifications:
     - buriola@google.com
     - ramaro@google.com
     - ademaria@google.com
+    - chifor@google.com
   email:
     on_success: change
     on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y gnupg2
+  - sudo apt-get install -y gnupg2 git
 
 # command to install dependencies
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM alpine
+FROM python:3.6-alpine
 
-RUN apk --update add --virtual build-dependencies build-base python-dev py-pip && \ 
-    apk --update add python libstdc++ gnupg && mkdir /kapitan
+RUN apk --update add git g++ make libstdc++ gnupg musl-dev \
+    && rm -rf /var/cache/apk/* \
+    && mkdir /kapitan
+
 WORKDIR /kapitan
 COPY kapitan/ kapitan/
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt && apk del build-dependencies
 
+RUN pip install --upgrade --no-cache-dir pip \
+    && pip install --no-cache-dir -r requirements.txt
 
 ENV PYTHONPATH="/kapitan/"
 ENV SEARCHPATH="/src"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please lo
 
 # Main Features
 
-* Use [reclass](https://github.com/madduck/reclass) to build an inventory of data/variables for all your deployments as a whole, avoiding dangerous duplications, and improving readibility.
+* Use [reclass](https://github.com/salt-formulas/reclass) to build an inventory of data/variables for all your deployments as a whole, avoiding dangerous duplications, and improving readibility.
 * Use [Jsonnet](https://github.com/google/jsonnet) to create json/yaml based configurations (e.g. Kubernetes, Terraform);
 * Use [Jinja2](http://jinja.pocoo.org/docs/2.9/) to create text based templates for scripts and documentation;
 * Manage secrets by defining who can see them, without compromising collaboration with other users.
@@ -37,12 +37,16 @@ How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please lo
 
 # Installation
 
-Kapitan needs Python 2.7+ and can be installed with pip.
+Kapitan needs Python 3.6+ (it still works with Python 2.7 but support has been removed in v0.12.0).
 
-```
-$ pip install git+https://github.com/deepmind/kapitan.git
-```
+Install Python 3:
+<br>Linux: `sudo apt-get install python3.6`
+<br>Mac: `brew install python3`
 
+Install Kapitan via pip:
+```
+$ pip3 install git+https://github.com/deepmind/kapitan.git
+```
 
 
 # Example
@@ -408,7 +412,7 @@ $ kapitan searchvar parameters.elasticsearch.replicas
 
 * [Jsonnet](https://github.com/google/jsonnet)
 * [Jinja2](http://jinja.pocoo.org/docs/2.9/)
-* [reclass](https://github.com/madduck/reclass)
+* [reclass](https://github.com/salt-formulas/reclass)
 
 # FAQ
 
@@ -429,7 +433,7 @@ With Kapitan, we worked to de-compose several problems that most of the other so
 
 1) ***Kubernetes manifests***: We like the jsonnet approach of using json as the working language. Jsonnet allows us to use inheritance and composition, and hide complexity at higher levels.
 2) ***Configuration files***: Most solutions will assume this problem is solved somewhere else. We feel Jinja (or your template engine of choice) have the upper hand here.
-3) ***Hierarchical inventory***: This is the feature that sets us apart from other solutions. We use the inventory (based on [reclass](https://github.com/madduck/reclass)) to define variables and properties that can be reused across different projects/deployments. This allows us to limit repetition, but also to define a nicer interface with developers (or CI tools) which will only need to understand YAML to operate changes.
+3) ***Hierarchical inventory***: This is the feature that sets us apart from other solutions. We use the inventory (based on [reclass](https://github.com/salt-formulas/reclass)) to define variables and properties that can be reused across different projects/deployments. This allows us to limit repetition, but also to define a nicer interface with developers (or CI tools) which will only need to understand YAML to operate changes.
 4) ***Canned scripts***: We treat scripts as text templates, so that we can craft pre-canned scripts for the specific target we are working on. This can be used for instance to define scripts that setup clusters, contexts or allow to run kubectl with all the correct settings. Most other solutions require you to define contexts and call kubectl with the correct settings. We take care of that for you. Less ambiguity, less mistakes.
 5) ***Documentation***: We also use templates to create documentation for the targets we deploy. Documentation lived alongside everything else and it is treated as a first class citizen.
 We feel most other solutions are pushing the limits of their capacity in order to provide for the above problems.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Install Python 3:
 
 Install Kapitan via pip:
 ```
-$ pip3 install git+https://github.com/deepmind/kapitan.git
+$ pip3 install git+https://github.com/deepmind/kapitan.git --process-dependency-links
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please lo
 Kapitan needs Python 3.6+ (it still works with Python 2.7 but support has been removed in v0.12.0).
 
 Install Python 3:
-<br>Linux: `sudo apt-get install python3.6`
+<br>Linux: `sudo apt-get update && sudo apt-get install -y python3.6-dev`
 <br>Mac: `brew install python3`
 
 Install Kapitan via pip:

--- a/bin/kapitan
+++ b/bin/kapitan
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 BINPATH=`dirname $0`
-PYTHONPATH="$BINPATH/../:$PYTHONPATH" python -m kapitan $@
+PYTHONPATH="$BINPATH/../:$PYTHONPATH" python3 -m kapitan $@

--- a/kapitan/__init__.py
+++ b/kapitan/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #

--- a/kapitan/__main__.py
+++ b/kapitan/__main__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import print_function
 
 "command line module"
 
@@ -141,7 +143,7 @@ def main():
             json_obj = json.loads(json_output)
             yaml.safe_dump(json_obj, sys.stdout, default_flow_style=False)
         elif json_output:
-            print json_output
+            print(json_output)
 
     elif cmd == 'compile':
         if args.verbose:

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #
@@ -21,6 +21,7 @@ from functools import partial
 import json
 import logging
 import os
+import io
 import reclass
 import reclass.core
 from reclass.errors import ReclassException, NotFoundError
@@ -83,7 +84,7 @@ def read_file(search_path, name):
     logger.debug("read_file trying file %s", full_path)
     if os.path.exists(full_path):
         logger.debug("read_file found file at %s", full_path)
-        with open(full_path) as f:
+        with io.open(full_path, newline='') as f:
             return f.read()
     raise IOError("Could not find file %s" % name)
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 "random utils"
+
 import functools
 from hashlib import sha256
 import logging
@@ -44,7 +47,7 @@ def render_jinja2_template(content, context):
 
 def jinja2_sha256_hex_filter(string):
     "Returns hex digest for string"
-    return sha256(string).hexdigest()
+    return sha256(string.encode("UTF-8")).hexdigest()
 
 
 def render_jinja2_file(name, context):

--- a/kapitan/version.py
+++ b/kapitan/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #
@@ -17,7 +17,7 @@
 "Project description variables"
 
 PROJECT_NAME = 'kapitan'
-VERSION = '0.11.0'
+VERSION = '0.12.0'
 DESCRIPTION = 'Kapitan is a tool to manage kubernetes configuration using jsonnet templates'
 AUTHOR = 'Ricardo Amaro'
 AUTHOR_EMAIL = 'ramaro@google.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 jsonnet==0.10.0
 PyYAML==3.12
-Jinja2==2.9.4
-jsonschema==2.5.1
-reclass==1.4.1
-python-gnupg==0.4.1
+Jinja2>=2.10
+# Latest commit from salt-formulas/reclass - python3 branch
+# TODO: Change commit hash to release tag, once python3 branch is merged in
+git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass
+jsonschema>=2.6.0
+# Closest commit to official python-gnupg==0.4.1 + fix for https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises
+# TODO: Change to python-gnupg==0.4.2 once released
+git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg
+six>=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ PyYAML==3.12
 Jinja2>=2.10
 # Latest commit from salt-formulas/reclass - python3 branch
 # TODO: Change commit hash to release tag, once python3 branch is merged in
-git+ssh://git@github.com/salt-formulas/reclass.git@31770c6#egg=reclass
+git+https://github.com/salt-formulas/reclass.git@31770c6#egg=reclass
 jsonschema>=2.6.0
 # Closest commit to official python-gnupg==0.4.1 + fix for https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises
 # TODO: Change to python-gnupg==0.4.2 once released
-git+ssh://git@github.com/vsajip/python-gnupg.git@73b5d8d#egg=python-gnupg
+git+https://github.com/vsajip/python-gnupg.git@73b5d8d#egg=python-gnupg
 six>=1.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ PyYAML==3.12
 Jinja2>=2.10
 # Latest commit from salt-formulas/reclass - python3 branch
 # TODO: Change commit hash to release tag, once python3 branch is merged in
-git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass
+git+ssh://git@github.com/salt-formulas/reclass.git@31770c6#egg=reclass
 jsonschema>=2.6.0
 # Closest commit to official python-gnupg==0.4.1 + fix for https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises
 # TODO: Change to python-gnupg==0.4.2 once released
-git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg
+git+ssh://git@github.com/vsajip/python-gnupg.git@73b5d8d#egg=python-gnupg
 six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -56,12 +56,8 @@ setup(
         'jsonnet==0.10.0',
         'PyYAML==3.12',
         'Jinja2>=2.10',
-        # Latest commit from salt-formulas/reclass - python3 branch
-        # TODO: Change commit hash to release tag, once python3 branch is merged in
         'git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass',
         'jsonschema>=2.6.0',
-        # Closest commit to official python-gnupg==0.4.1 + fix for https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises
-        # TODO: Change to python-gnupg==0.4.2 once released
         'git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg',
         'six>=1.11.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,41 @@ Kapitan setup.py for PIP install
 from setuptools import setup, find_packages
 from kapitan.version import PROJECT_NAME, VERSION, DESCRIPTION, URL, AUTHOR, AUTHOR_EMAIL, LICENCE
 
+# From https://github.com/pypa/pip/issues/3610#issuecomment-356687173
+def install_deps():
+    """Reads requirements.txt and preprocess it
+    to be feed into setuptools.
+
+    This is the only possible way (we found)
+    how requirements.txt can be reused in setup.py
+    using dependencies from private github repositories.
+
+    Links must be appendend by `-{StringWithAtLeastOneNumber}`
+    or something like that, so e.g. `-9231` works as well as
+    `1.1.0`. This is ignored by the setuptools, but has to be there.
+
+    Warnings:
+        to make pip respect the links, you have to use
+        `--process-dependency-links` switch. So e.g.:
+        `pip install --process-dependency-links {git-url}`
+
+    Returns:
+         list of packages and dependency links.
+    """
+    default = open('requirements.txt', 'r').readlines()
+    new_pkgs = []
+    links = []
+    for resource in default:
+        if 'git+ssh' in resource:
+            pkg = resource.split('#')[-1]
+            links.append(resource.strip() + '-9876543210')
+            new_pkgs.append(pkg.replace('egg=', '').rstrip())
+        else:
+            new_pkgs.append(resource.strip())
+    return new_pkgs, links
+
+pkgs, new_links = install_deps()
+
 setup(
     name=PROJECT_NAME,
     version=VERSION,
@@ -52,21 +87,8 @@ setup(
     packages=find_packages(),
     package_data={"": ["lib/*"]},
     include_package_data=True,
-    dependency_links=[
-        'git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass-1.4.1',
-        'git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg-0.4.2.dev0'
-    ],
-
-    install_requires=[
-        'jsonnet==0.10.0',
-        'PyYAML==3.12',
-        'Jinja2>=2.10',
-        'reclass==1.4.1',
-        'jsonschema>=2.6.0',
-        'python-gnupg==0.4.2.dev0',
-        'six>=1.11.0'
-    ],
-
+    dependency_links=new_links,
+    install_requires=pkgs,
     entry_points={
         'console_scripts': [
             'kapitan=kapitan.cli:main',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #
@@ -43,6 +43,8 @@ setup(
 
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6'
     ],
 
     keywords='jsonnet kubernetes reclass jinja',
@@ -51,12 +53,17 @@ setup(
     package_data={"": ["lib/*"]},
     include_package_data=True,
     install_requires=[
-        'jsonnet>=0.9.5',
-        'PyYAML>=3.12',
+        'jsonnet==0.10.0',
+        'PyYAML==3.12',
         'Jinja2>=2.10',
-        'reclass>=1.4.1',
+        # Latest commit from salt-formulas/reclass - python3 branch
+        # TODO: Change commit hash to release tag, once python3 branch is merged in
+        'git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass',
         'jsonschema>=2.6.0',
-        'python-gnupg==0.4.1'
+        # Closest commit to official python-gnupg==0.4.1 + fix for https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises
+        # TODO: Change to python-gnupg==0.4.2 once released
+        'git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg',
+        'six>=1.11.0'
     ],
 
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -52,13 +52,18 @@ setup(
     packages=find_packages(),
     package_data={"": ["lib/*"]},
     include_package_data=True,
+    dependency_links=[
+        'git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass-1.4.1',
+        'git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg-0.4.2.dev0'
+    ],
+
     install_requires=[
         'jsonnet==0.10.0',
         'PyYAML==3.12',
         'Jinja2>=2.10',
-        'git+git://github.com/salt-formulas/reclass@31770c6#egg=reclass',
+        'reclass==1.4.1',
         'jsonschema>=2.6.0',
-        'git+git://github.com/vsajip/python-gnupg@73b5d8d#egg=python-gnupg',
+        'python-gnupg==0.4.2.dev0',
         'six>=1.11.0'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def install_deps():
     new_pkgs = []
     links = []
     for resource in default:
-        if 'git+ssh' in resource:
+        if 'git+https' in resource:
             pkg = resource.split('#')[-1]
             links.append(resource.strip() + '-9876543210')
             new_pkgs.append(pkg.replace('egg=', '').rstrip())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #

--- a/tests/test_jinja2.py
+++ b/tests/test_jinja2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #
@@ -23,7 +23,7 @@ from kapitan.resources import inventory
 class Jinja2FiltersTest(unittest.TestCase):
     def test_sha256(self):
         with tempfile.NamedTemporaryFile() as f:
-            f.write("{{text|sha256}}")
+            f.write("{{text|sha256}}".encode("UTF-8"))
             f.seek(0)
             context = {"text":"this and that"}
             digest = 'e863c1ac42619a2b429a08775a6acd89ff4c2c6b8dae12e3461a5fa63b2f92f5'
@@ -32,7 +32,7 @@ class Jinja2FiltersTest(unittest.TestCase):
 class Jinja2ContextVars(unittest.TestCase):
     def test_inventory_context(self):
         with tempfile.NamedTemporaryFile() as f:
-            f.write("{{inventory.parameters.cluster.name}}")
+            f.write("{{inventory.parameters.cluster.name}}".encode("UTF-8"))
             cluster_name = "minikube"
             target_name = "minikube-es"
             inv = inventory("examples/kubernetes", target_name)
@@ -43,7 +43,7 @@ class Jinja2ContextVars(unittest.TestCase):
     def test_inventory_global_context(self):
         with tempfile.NamedTemporaryFile() as f:
             target_name = "minikube-es"
-            f.write("{{inventory_global[\"%s\"].parameters.cluster.name}}" % target_name)
+            f.write("{{inventory_global[\"%s\"].parameters.cluster.name}}".encode("UTF-8") % target_name.encode("UTF-8"))
             cluster_name = "minikube"
             inv_global = inventory("examples/kubernetes", None)
             context = {"inventory_global": inv_global}

--- a/tests/test_jsonnet.py
+++ b/tests/test_jsonnet.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 #
 # Copyright 2017 The Kapitan Authors
 #


### PR DESCRIPTION
This is backwards compatible with Python 2, but compiled output will have different ordering because of `obj.iteritems()` (py2) -> `obj.items()` (py3).

- Support for Python 3 in the codebase:
    - `print` function
    - some functions updated to take encoded objects instead of plain strings (`.encode("UTF-8")`, `.decode("UTF-8")`)
    - `.iteritems()` -> `.items()`
    - `basestring` -> `string_types` from six
- Refactored the Dockerfile to use a python 3 alpine base directly.
- Refactored `setup.py` to take dependencies from `requirements.txt`.
- Updated reclass to be taken from a specific commit on python3 branch of [salt-formulas/reclass](https://github.com/salt-formulas/reclass/tree/31770c696f52d35a6164e03e4eb5010d3c40accc); needed for python 3 support.
- Updated python-gnupg to be taken from a specific commit of [vsajip/python-gnupg](https://github.com/vsajip/python-gnupg/tree/73b5d8d4ea509ed5f7da219837de784063aacd67); needed to fix an [issue with gnupg version checking on Macs](https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises).
- Updated README.md