### PR TITLE
CI/CD usage with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
 FROM python:3.6-alpine
 
-RUN apk --update add git g++ make libstdc++ gnupg musl-dev \
-    && rm -rf /var/cache/apk/* \
-    && mkdir /kapitan
+RUN apk add --update --no-cache git g++ make libstdc++ gnupg musl-dev && \
+    mkdir /kapitan
 
 WORKDIR /kapitan
 COPY kapitan/ kapitan/
 COPY requirements.txt ./
 
-RUN pip install --upgrade --no-cache-dir pip \
-    && pip install --no-cache-dir -r requirements.txt
+RUN pip install --upgrade --no-cache-dir pip && \
+    pip install --no-cache-dir -r requirements.txt
 
 ENV PYTHONPATH="/kapitan/"
 ENV SEARCHPATH="/src"

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ docker run -t --rm -v $(pwd):/src deepmind/kapitan -h
 
 On Linux you can add `-u $(id -u)` on `docker run` in order for kapitan to not change file permissions.
 
+For CI/CD usage, check out [ci/](https://github.com/deepmind/kapitan/tree/master/ci)
+
 #### Pip
 Kapitan needs Python 3.6+ (it still works with Python 2.7 but support has been removed in v0.12.0).
 

--- a/README.md
+++ b/README.md
@@ -49,15 +49,21 @@ For CI/CD usage, check out [ci/](https://github.com/deepmind/kapitan/tree/master
 #### Pip
 Kapitan needs Python 3.6+ (it still works with Python 2.7 but support has been removed in v0.12.0).
 
-Install Python 3:
-<br>Linux: `sudo apt-get update && sudo apt-get install -y python3.6-dev`
+**Install Python 3:**
+<br>Linux: `sudo apt-get update && sudo apt-get install -y python3.6-dev python3-pip`
 <br>Mac: `brew install python3`
 
-Install Kapitan:
+**Install Kapitan:**
+
+User (`$HOME/.local/lib/python3.6/bin` on Linux or `$HOME/Library/Python/3.6/bin` on macOS):
 ```
-$ pip3 install git+https://github.com/deepmind/kapitan.git --process-dependency-links
+pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git  --process-dependency-links
 ```
 
+System-wide:
+```
+sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links
+```
 
 # Example
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,7 +3,7 @@ FROM google/cloud-sdk:alpine
 RUN apk add --update --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --upgrade --no-cache-dir pip setuptools yq && \
+    pip3 install --upgrade --no-cache-dir pip setuptools && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     rm -r /root/.cache

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,13 @@
+FROM google/cloud-sdk:alpine
+
+RUN apk add --update --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade --no-cache-dir pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+    rm -r /root/.cache
+
+RUN pip3 install --no-cache-dir git+https://github.com/deepmind/kapitan.git --process-dependency-links
+
+RUN gcloud components install kubectl

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,7 +3,7 @@ FROM google/cloud-sdk:alpine
 RUN apk add --update --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
-    pip3 install --upgrade --no-cache-dir pip setuptools && \
+    pip3 install --upgrade --no-cache-dir pip setuptools yq && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     rm -r /root/.cache

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,0 +1,36 @@
+## Kapitan: CI/CD usage
+
+The [Docker image](https://hub.docker.com/r/deepmind/kapitan/tags/) (`deepmind/kapitan:ci`) ([Dockerfile](https://github.com/deepmind/kapitan/tree/master/ci/Dockerfile)) comes pre-packages with `gcloud`, `gsutil`, `bq`, `kubectl` and `kapitan`.
+
+### Example workflow - Deploy to GKE
+
+The following commands are run using the `deepmind/kapitan:ci` Docker image.
+
+1. Compile:
+
+   ```
+   kapitan compile
+
+   Compiled app (2.23s)
+   ```
+
+1. Setup gcloud and GKE credentials:
+
+   ```
+   echo "$GCP_SA_KEY_FROM_CI_SECRETS" > service_account_key.json
+   gcloud auth activate-service-account --key-file service_account_key.json
+   gcloud container clusters get-credentials CLUSTER --zone ZONE --project GCP_PROJECT_ID
+   ```
+
+1. Setup kubectl:
+
+   ```
+   kubectl config set-context CLUSTER_CONTEXT --cluster CLUSTER --user USER --namespace NAMESPACE
+   kubectl config use-context CLUSTER_CONTEXT
+   ```
+
+1. Deploy:
+
+   ```
+   kubectl apply -f compiled/app/manifests/
+   ```


### PR DESCRIPTION
- New Docker image `deepmind/kapitan:ci` to be used in CI/CD pipelines. Comes with `gcloud`, `kubectl` and `kapitan`.
- Docs