### PR TITLE
remove not needed command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine
 
-RUN apk add --update --no-cache git g++ make libstdc++ gnupg musl-dev && \
+RUN apk add --no-cache git g++ make libstdc++ gnupg musl-dev && \
     mkdir /kapitan
 
 WORKDIR /kapitan

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk:alpine
 
-RUN apk add --update --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev util-linux && \
+RUN apk add --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev util-linux && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade --no-cache-dir pip setuptools && \


### PR DESCRIPTION
updating the package cache is IMHO not needed since the 

> --no-cache

 option will pull directly from the online repos anyway. 
(with the small benefit of around 1MB for the package cache)

if you do this to avoid caching of the layers while building i suggest to build with the --no-cache option from docker:
`docker build --no-cache `

All the best