### PR TITLE
Gnu update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-alpine
 
-RUN apk add --update --no-cache git g++ make libstdc++ gnupg musl-dev && \
+RUN apk add --no-cache git g++ make libstdc++ gnupg musl-dev && \
     mkdir /kapitan
 
 WORKDIR /kapitan

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk:alpine
 
-RUN apk add --update --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev util-linux && \
+RUN apk add --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev util-linux && \
     python3 -m ensurepip && \
     rm -r /usr/lib/python*/ensurepip && \
     pip3 install --upgrade --no-cache-dir pip setuptools && \

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,5 @@ Jinja2>=2.10
 # TODO: Change commit hash to release tag, once python3 branch is merged in
 git+https://github.com/salt-formulas/reclass.git@31770c6#egg=reclass
 jsonschema>=2.6.0
-# Closest commit to official python-gnupg==0.4.1 + fix for https://bitbucket.org/vinay.sajip/python-gnupg/issues/84/on-osx-version-detection-fails-then-raises
-# TODO: Change to python-gnupg==0.4.2 once released
-git+https://github.com/vsajip/python-gnupg.git@73b5d8d#egg=python-gnupg
+python-gnupg==0.4.2
 six>=1.11.0


### PR DESCRIPTION
updated gnupg to 0.4.2 as suggested in requirements.txt 
released on 28.03.2018 
https://github.com/vsajip/python-gnupg

tested the build, screenshot below
![screen shot 2018-04-04 at 15 25 33](https://user-images.githubusercontent.com/18464684/38310383-ae4205a8-381c-11e8-9976-2599f22cf2e8.png)

