### PR TITLE
Cache inventory (reclass) across multiple threads

### DIFF
--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3.6
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"cached module"
+
+inv = {}

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -48,15 +48,15 @@ def compile_targets(inventory_path, search_path, output_path, parallel, targets,
     multiprocessing pool with parallel number of processes.
     kwargs are passed to compile_target()
     """
-    target_path = "targets"
     # temp_path will hold compiled items
     temp_path = tempfile.mkdtemp(suffix='.kapitan')
+
+    target_objs = load_target_inventory(inventory_path, targets)
+
     pool = multiprocessing.Pool(parallel)
     # append "compiled" to output_path so we can safely overwrite it
     compile_path = os.path.join(output_path, "compiled")
     worker = partial(compile_target, search_path=search_path, compile_path=temp_path, **kwargs)
-
-    target_objs = load_target_inventory(inventory_path, targets)
 
     try:
         if target_objs == []:


### PR DESCRIPTION
Fixes #25 

- Save `inventory_reclass` output as a cached variable in `cached` module, initialized only once. No need to complicate ourselves with `multiprocessing.Manager` as inventory is read-only in threads and doesn't change.
- Saves ~8-10s on `kapitan compile`