### PR TITLE
Enforce kapitan version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 kapitan.egg-info/
 tags
 .python-version
+.kapitan

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -83,6 +83,9 @@ def main():
                                 action='store_true', default=False)
     compile_parser.add_argument('--inventory-path', default='./inventory',
                                 help='set inventory path, default is "./inventory"')
+    compile_parser.add_argument('--ignore-version-check',
+                                help='ignore the last kapitan version used to compile (from .kapitan)',
+                                action='store_true', default=False)
 
     inventory_parser = subparser.add_parser('inventory', help='show inventory')
     inventory_parser.add_argument('--target-name', '-t', default='',
@@ -171,7 +174,7 @@ def main():
         gpg_obj = secret_gpg_backend()
 
         compile_targets(args.inventory_path, search_path, args.output_path,
-                        args.parallelism, args.targets,
+                        args.parallelism, args.targets, args.ignore_version_check,
                         prune=(not args.no_prune), secrets_path=args.secrets_path,
                         secrets_reveal=args.reveal, gpg_obj=gpg_obj)
 

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -26,7 +26,7 @@ import sys
 import traceback
 import yaml
 
-from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar, deep_get
+from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar, deep_get, check_version, save_version
 from kapitan.targets import compile_targets
 from kapitan.resources import search_imports, resource_callbacks, inventory_reclass
 from kapitan.version import PROJECT_NAME, DESCRIPTION, VERSION
@@ -173,10 +173,16 @@ def main():
         search_path = os.path.abspath(args.search_path)
         gpg_obj = secret_gpg_backend()
 
+        if not args.ignore_version_check:
+            check_version()
+
         compile_targets(args.inventory_path, search_path, args.output_path,
-                        args.parallelism, args.targets, args.ignore_version_check,
+                        args.parallelism, args.targets,
                         prune=(not args.no_prune), secrets_path=args.secrets_path,
                         secrets_reveal=args.reveal, gpg_obj=gpg_obj)
+
+        if not args.ignore_version_check:
+            save_version()
 
     elif cmd == 'inventory':
         if args.pattern and args.target_name == '':

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -42,7 +42,7 @@ from kapitan.errors import KapitanError, CompileError
 
 logger = logging.getLogger(__name__)
 
-def compile_targets(inventory_path, search_path, output_path, parallel, targets, **kwargs):
+def compile_targets(inventory_path, search_path, output_path, parallel, targets, ignore_version_check, **kwargs):
     """
     Searches and loads target files, and runs compile_target_file() on a
     multiprocessing pool with parallel number of processes.
@@ -53,7 +53,8 @@ def compile_targets(inventory_path, search_path, output_path, parallel, targets,
 
     target_objs = load_target_inventory(inventory_path, targets)
 
-    enforce_version()
+    if not ignore_version_check:
+        enforce_version()
 
     pool = multiprocessing.Pool(parallel)
     # append "compiled" to output_path so we can safely overwrite it

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -35,7 +35,7 @@ import yaml
 import time
 
 from kapitan.resources import search_imports, resource_callbacks, inventory, inventory_reclass
-from kapitan.utils import jsonnet_file, prune_empty, render_jinja2, PrettyDumper
+from kapitan.utils import jsonnet_file, prune_empty, render_jinja2, PrettyDumper, enforce_version
 from kapitan.secrets import secret_gpg_raw_read, secret_token_from_tag, secret_token_attributes
 from kapitan.secrets import SECRET_TOKEN_TAG_PATTERN, secret_gpg_read
 from kapitan.errors import KapitanError, CompileError
@@ -52,6 +52,8 @@ def compile_targets(inventory_path, search_path, output_path, parallel, targets,
     temp_path = tempfile.mkdtemp(suffix='.kapitan')
 
     target_objs = load_target_inventory(inventory_path, targets)
+
+    enforce_version()
 
     pool = multiprocessing.Pool(parallel)
     # append "compiled" to output_path so we can safely overwrite it

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -35,14 +35,14 @@ import yaml
 import time
 
 from kapitan.resources import search_imports, resource_callbacks, inventory, inventory_reclass
-from kapitan.utils import jsonnet_file, prune_empty, render_jinja2, PrettyDumper, enforce_version
+from kapitan.utils import jsonnet_file, prune_empty, render_jinja2, PrettyDumper
 from kapitan.secrets import secret_gpg_raw_read, secret_token_from_tag, secret_token_attributes
 from kapitan.secrets import SECRET_TOKEN_TAG_PATTERN, secret_gpg_read
 from kapitan.errors import KapitanError, CompileError
 
 logger = logging.getLogger(__name__)
 
-def compile_targets(inventory_path, search_path, output_path, parallel, targets, ignore_version_check, **kwargs):
+def compile_targets(inventory_path, search_path, output_path, parallel, targets, **kwargs):
     """
     Searches and loads target files, and runs compile_target_file() on a
     multiprocessing pool with parallel number of processes.
@@ -52,9 +52,6 @@ def compile_targets(inventory_path, search_path, output_path, parallel, targets,
     temp_path = tempfile.mkdtemp(suffix='.kapitan')
 
     target_objs = load_target_inventory(inventory_path, targets)
-
-    if not ignore_version_check:
-        enforce_version()
 
     pool = multiprocessing.Pool(parallel)
     # append "compiled" to output_path so we can safely overwrite it

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -236,19 +236,16 @@ def get_directory_hash(directory):
     return hash.hexdigest()
 
 
-def enforce_version():
+def check_version():
     '''
-    Enforces that the last version of kapitan used is at least smaller or equal to current version.
+    Checks that the last version of kapitan used is at least smaller or equal to current version.
     If the last version of kapitan used is bigger, it will give instructions on how to upgrade and exit(1).
     '''
     if os.path.exists('.kapitan'):
         with open('.kapitan', 'r') as f:
             dot_kapitan = yaml.safe_load(f)
-            # If 'version is not saved' or 'saved version is smaller or equal than current version'
-            if not dot_kapitan['version'] or StrictVersion(dot_kapitan['version']) <= StrictVersion(VERSION):
-                save_version()
             # If 'saved version is bigger than current version'
-            else:
+            if dot_kapitan['version'] and StrictVersion(dot_kapitan['version']) > StrictVersion(VERSION):
                 print(f'{termcolor.WARNING}Current version: {VERSION}')
                 print(f'Last used version (in .kapitan): {dot_kapitan["version"]}{termcolor.ENDC}\n')
                 print(f'Please upgrade kapitan to at least "{dot_kapitan["version"]}" in order to keep results consistent:\n')
@@ -256,8 +253,6 @@ def enforce_version():
                 print('Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links')
                 print('Pip (system): sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links')
                 sys.exit(1)
-    else:
-        save_version()
 
 
 def save_version():

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -22,16 +22,30 @@ import functools
 from hashlib import sha256
 import logging
 import os
+import sys
 import stat
 import collections
 import jinja2
 import _jsonnet as jsonnet
 import yaml
+from distutils.version import StrictVersion
 
+from kapitan.version import VERSION
 from kapitan.errors import CompileError
 
 
 logger = logging.getLogger(__name__)
+
+
+class termcolor:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
 
 
 def normalise_join_path(dirname, path):
@@ -49,9 +63,11 @@ def jinja2_sha256_hex_filter(string):
     "Returns hex digest for string"
     return sha256(string.encode("UTF-8")).hexdigest()
 
+
 def jinja2_yaml_filter(obj):
     "Returns yaml for object"
     return yaml.safe_dump(obj, default_flow_style=False)
+
 
 def render_jinja2_file(name, context):
     "Render jinja2 file name with context"
@@ -95,9 +111,10 @@ def render_jinja2(path, context):
             # get subpath and filename, strip any leading/trailing /
             name = render_path[len(os.path.commonprefix([root, path])):].strip('/')
             try:
-                rendered[name] = {"content": render_jinja2_file(render_path, context),
-                                  "mode": file_mode(render_path)
-                                 }
+                rendered[name] = {
+                    "content": render_jinja2_file(render_path, context),
+                    "mode": file_mode(render_path)
+                }
             except Exception as e:
                 logger.error("Jinja2 error: failed to render %s: %s", render_path, str(e))
                 raise CompileError(e)
@@ -217,3 +234,36 @@ def get_directory_hash(directory):
         raise
 
     return hash.hexdigest()
+
+
+def enforce_version():
+    '''
+    Enforces that the last version of kapitan used is at least smaller or equal to current version.
+    If the last version of kapitan used is bigger, it will give instructions on how to upgrade and exit(1).
+    '''
+    if os.path.exists('.kapitan'):
+        with open('.kapitan', 'r') as f:
+            dot_kapitan = yaml.safe_load(f)
+            # If 'version is not saved' or 'saved version is smaller or equal than current version'
+            if not dot_kapitan['version'] or StrictVersion(dot_kapitan['version']) <= StrictVersion(VERSION):
+                save_version()
+            # If 'saved version is bigger than current version'
+            else:
+                print(f'{termcolor.WARNING}Current version: {VERSION}')
+                print(f'Last used version (in .kapitan): {dot_kapitan["version"]}{termcolor.ENDC}\n')
+                print(f'Please upgrade kapitan to at least "{dot_kapitan["version"]}" in order to keep results consistent:\n')
+                print('Docker: docker pull deepmind/kapitan')
+                print('Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links')
+                print('Pip (system): sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links')
+                sys.exit(1)
+    else:
+        save_version()
+
+
+def save_version():
+    '''
+    Saves the current kapitan version to a local .kapitan file
+    '''
+    with open('.kapitan', 'w') as f:
+        dot_kapitan = {'version': VERSION}
+        yaml.safe_dump(dot_kapitan, stream=f, default_flow_style=False)

--- a/kapitan/version.py
+++ b/kapitan/version.py
@@ -17,7 +17,7 @@
 "Project description variables"
 
 PROJECT_NAME = 'kapitan'
-VERSION = '0.14.0'
+VERSION = '0.15.0'
 DESCRIPTION = ('Generic templated configuration management for Kubernetes,'
                'Terraform and other things')
 AUTHOR = 'Ricardo Amaro'


### PR DESCRIPTION
Addresses #57 

- `kapitan compile` now writes the version to `.kapitan` and future executions will check if the last used kapitan version is <= than current kapitan version. If the last version is bigger than current version, it will output something like:
```
Current version: 0.15.0
Last used version (in .kapitan): 0.15.1

Please upgrade kapitan to at least "0.15.1" in order to keep results consistent:

Docker: docker pull deepmind/kapitan
Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links
Pip (system): sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links
```
- `kapitan compile --ignore-version-check` option for cases when you don't want the check such as CI.
- Version increment `0.14.0` -> `0.15.0` as we might want to create a new release for this.