### PR TITLE
Updated reclass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,8 @@ before_install:
 
 # command to install dependencies
 install:
-  - pip install -r requirements.txt
+  # TODO: Remove 'sudo' once https://github.com/salt-formulas/reclass/pull/28 is merged
+  - sudo pip install -r requirements.txt
 
 # command to run tests
 script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ WORKDIR /kapitan
 COPY kapitan/ kapitan/
 COPY requirements.txt ./
 
+# TODO: Remove '--prefix=/usr/local' once https://github.com/salt-formulas/reclass/pull/28 is merged
 RUN pip install --upgrade --no-cache-dir pip && \
-    pip install --no-cache-dir -r requirements.txt
+    pip install --prefix=/usr/local --no-cache-dir -r requirements.txt
 
 ENV PYTHONPATH="/kapitan/"
 ENV SEARCHPATH="/src"

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ User (`$HOME/.local/lib/python3.6/bin` on Linux or `$HOME/Library/Python/3.6/bin
 pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git  --process-dependency-links
 ```
 
-System-wide:
+System-wide (not recommended):
 ```
-sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links
+sudo pip3 install --upgrade --prefix=/usr/local git+https://github.com/deepmind/kapitan.git --process-dependency-links
 ```
 
 # Example
@@ -278,6 +278,8 @@ optional arguments:
                         data)
   --inventory-path INVENTORY_PATH
                         set inventory path, default is "./inventory"
+  --ignore-version-check
+                        ignore the last kapitan version used to compile (from .kapitan)
 ```
 
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev util-li
     if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     rm -rf /root/.cache
 
-RUN pip3 install --upgrade --no-cache-dir git+https://github.com/deepmind/kapitan.git --process-dependency-links
+# TODO: Remove '--prefix=/usr/local' once https://github.com/salt-formulas/reclass/pull/28 is merged
+RUN pip3 install --upgrade --prefix=/usr/local --no-cache-dir git+https://github.com/deepmind/kapitan.git --process-dependency-links
 
 RUN gcloud components install kubectl

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -247,7 +247,7 @@ def main():
                                           verify=(not args.no_verify))
         elif args.update:
             # update recipients for secret tag
-            recipients = [dict([("name", name),]) for name in args.recipients]
+            recipients = [dict([("name", name), ]) for name in args.recipients]
             if args.target_name:
                 inv = inventory_reclass(args.inventory_path)
                 recipients = inv['nodes'][args.target_name]['parameters']['kapitan']['secrets']['recipients']
@@ -271,7 +271,7 @@ def main():
                                 logger.info("%s recipient mismatch", token_path)
                                 ret_code = 1
                             else:
-                                new_recipients = [dict([("fingerprint", f),]) for f in target_fingerprints]
+                                new_recipients = [dict([("fingerprint", f), ]) for f in target_fingerprints]
                                 secret_gpg_update_recipients(gpg_obj, secrets_path, token_path, new_recipients)
                 except KeyError:
                     logger.debug("secret_gpg_update_target: target: %s has no inventory recipients, skipping",

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -182,9 +182,9 @@ def inventory_reclass(inventory_path):
 
         try:
             storage = reclass.get_storage(reclass_config['storage_type'], reclass_config['nodes_uri'],
-                                          reclass_config['classes_uri'], default_environment='base')
+                                          reclass_config['classes_uri'])
             class_mappings = reclass_config.get('class_mappings')  # this defaults to None (disabled)
-            _reclass = reclass.core.Core(storage, class_mappings)
+            _reclass = reclass.core.Core(storage, class_mappings, reclass.settings.Settings())
 
             cached.inv = _reclass.inventory()
             return cached.inv

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -196,7 +196,7 @@ def searchvar(flat_var, inventory_path):
     keys = flat_var.split(".")
     for root, _, files in os.walk(inventory_path):
         for file in files:
-            if file.endswith(".yml"):
+            if file.endswith(".yml") or file.endswith(".yaml"):
                 filename = os.path.join(root, file)
                 with open(filename, 'r') as fd:
                     data = yaml.safe_load(fd)

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -250,8 +250,8 @@ def check_version():
                 print(f'Last used version (in .kapitan): {dot_kapitan["version"]}{termcolor.ENDC}\n')
                 print(f'Please upgrade kapitan to at least "{dot_kapitan["version"]}" in order to keep results consistent:\n')
                 print('Docker: docker pull deepmind/kapitan')
-                print('Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links')
-                print('Pip (system): sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links')
+                print('Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links\n')
+                print('Check https://github.com/deepmind/kapitan#quickstart for more info.')
                 sys.exit(1)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 jsonnet==0.10.0
 PyYAML==3.12
 Jinja2>=2.10
-# Latest commit from salt-formulas/reclass - python3 branch
-# TODO: Change commit hash to release tag, once python3 branch is merged in
-git+https://github.com/salt-formulas/reclass.git@31770c6#egg=reclass
+# Latest commit from salt-formulas/reclass - develop branch (python3 support)
+# TODO: Change commit hash to release tag once develop is merged into master and release is cut
+git+https://github.com/salt-formulas/reclass.git@412740a#egg=reclass
 jsonschema>=2.6.0
 python-gnupg==0.4.2
 six>=1.11.0


### PR DESCRIPTION
salt-formulas/reclass#25 was merged yesterday so moved reclass commit reference to latest develop.

Reclass are overwriting the default pip install prefix so I had to add `--prefix=/usr/local` to the Docker images and Travis. Once https://github.com/salt-formulas/reclass/pull/28 is merged, we can remove the `--prefix`.