### PR TITLE
target secret functions support

### DIFF
--- a/kapitan/errors.py
+++ b/kapitan/errors.py
@@ -28,3 +28,8 @@ class CompileError(KapitanError):
 class InventoryError(KapitanError):
     "inventory error"
     pass
+
+
+class SecretError(KapitanError):
+    "secrets error"
+    pass

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -38,8 +38,8 @@ class SecretsTest(unittest.TestCase):
     def test_secret_token_attributes(self):
         "grab attributes and compare to values"
         token_tag = '?{gpg:secret/sauce}'
-        _token_tag, token = re.match(SECRET_TOKEN_TAG_PATTERN,
-                                     token_tag).groups()
+        _token_tag, token, func = re.match(SECRET_TOKEN_TAG_PATTERN,
+                                           token_tag).groups()
         self.assertEqual(_token_tag, token_tag)
         backend, token_path = secret_token_attributes(token)
         self.assertEqual((backend, token_path), ('gpg', 'secret/sauce'))


### PR DESCRIPTION
This introduces support for creating a target secret on compile time, if the secret does not already exist.

Target secrets have been introduced a few commits ago and have proven to work well. However when using reclass inventory interpolation for target secret tags, you will be forced to create all of the interpolated target secrets manually as compilation will fail.

To solve this problem, this PR proposes the following new (optional) form of secret tags:

`?{gpg:path/to/new_secret|randomstr:32}`

Or interpolating `${target_name}`:

`?{gpg:targets/${target_name}/new_secret|randomstr:16}`

If `path/to/new_secret` does not exist under `secrets_path` it evaluates `randomstr:32`, a function supported in this PR, which returns a 32 (as parameterised) byte-log random string generated by https://docs.python.org/3/library/secrets.html#secrets.token_urlsafe and creates the secret with its content.
`randomstr` can also be evaluated without a parameter and a base64 encoded version of it is also available as `randomstrb64` (which mimics the --base64 flag in `kapitan secrets` command line).

Note that this only supports target secrets and requires the recipients to be set in the inventory for the target being compiled. Once the target secret is created from a function, it will not be recreated.