### PR TITLE
Refactor inventory to show how inventory/components link to components

### DIFF
--- a/examples/kubernetes/compiled/minikube-es-2/README.md
+++ b/examples/kubernetes/compiled/minikube-es-2/README.md
@@ -1,0 +1,61 @@
+# Elasticsearch Minikube
+
+This is a specific version of Elasticsearch to run on a minikube instalation.
+
+## Prerequisites
+
+Elasticsearch is a resource hungry application, for this setup we require
+that minikube is running with the above options:
+
+```
+$ minikube start --insecure-registry https://quay.io --memory=4096 --cpus=2
+```
+
+_If_ you have created the minikube VM previously, you will most likely need to 
+delete the vm and recreate it with more memory/cpu. (i.e. 
+```$ minikube delete```)
+
+## Setting up
+
+Assuming you're already running Minikube, setup for this target:
+
+```
+$ scripts/setup.sh
+```
+
+This will create a context in your minikube cluster called minikube-es-2.
+
+
+Apply the compiled manifests:
+
+```
+$ scripts/kubectl.sh apply -f manifests/
+```
+
+If the commands above did not error, you should be good to go. 
+
+Let's confirm everything is up:
+
+```
+$ scripts/kubectl.sh get pods -w
+```
+
+## Connecting to Elasticsearch
+
+List the elasticsearch service endpoints running in the cluster:
+
+```
+$ minikube service -n minikube-es-2  elasticsearch --url
+```
+
+and curl the health endpoint, i.e.: 
+```$ curl http://192.168.99.100:32130/_cluster/health?pretty```
+
+
+## Deleting Elasticsearch
+
+Deleting is easy (warning, this will remove _everything_):
+
+```
+$ scripts/kubectl.sh delete -f manifests/
+```

--- a/examples/kubernetes/compiled/minikube-es-2/manifests/es-client.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/manifests/es-client.yml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: cluster-client
+    role: client
+  name: cluster-client
+  namespace: minikube-es-2
+spec:
+  replicas: 2
+  serviceName: cluster-client
+  template:
+    metadata:
+      labels:
+        name: cluster-client
+        role: client
+    spec:
+      containers:
+        - env:
+            - name: CLUSTER_NAME
+              value: cluster
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: HTTP_ENABLE
+              value: 'true'
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_DATA
+              value: 'false'
+            - name: NODE_INGEST
+              value: 'false'
+            - name: NODE_MASTER
+              value: 'false'
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NUMBER_OF_MASTERS
+              value: '1'
+          image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+          imagePullPolicy: Always
+          name: client
+          ports:
+            - containerPort: 9200
+              name: client
+              protocol: TCP
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+            privileged: false
+      initContainers:
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          name: sysctl
+          securityContext:
+            privileged: true

--- a/examples/kubernetes/compiled/minikube-es-2/manifests/es-data.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/manifests/es-data.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: cluster-data
+    role: data
+  name: cluster-data
+  namespace: minikube-es-2
+spec:
+  replicas: 2
+  serviceName: cluster-data
+  template:
+    metadata:
+      labels:
+        name: cluster-data
+        role: data
+    spec:
+      containers:
+        - env:
+            - name: CLUSTER_NAME
+              value: cluster
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: HTTP_ENABLE
+              value: 'false'
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_DATA
+              value: 'true'
+            - name: NODE_INGEST
+              value: 'false'
+            - name: NODE_MASTER
+              value: 'false'
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NUMBER_OF_MASTERS
+              value: '1'
+          image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+          imagePullPolicy: Always
+          name: data
+          ports:
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+            privileged: false
+      initContainers:
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          name: sysctl
+          securityContext:
+            privileged: true

--- a/examples/kubernetes/compiled/minikube-es-2/manifests/es-discovery-svc.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/manifests/es-discovery-svc.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: elasticsearch-discovery
+  name: elasticsearch-discovery
+  namespace: minikube-es-2
+spec:
+  ports:
+    - name: transport
+      port: 9300
+      targetPort: transport
+  selector:
+    name: cluster-master
+    role: master
+  type: ClusterIP

--- a/examples/kubernetes/compiled/minikube-es-2/manifests/es-elasticsearch-svc.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/manifests/es-elasticsearch-svc.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: elasticsearch
+  name: elasticsearch
+  namespace: minikube-es-2
+spec:
+  ports:
+    - name: client
+      port: 9200
+      targetPort: client
+    - name: transport
+      port: 9300
+      targetPort: transport
+  selector:
+    name: cluster-client
+    role: client
+  type: NodePort

--- a/examples/kubernetes/compiled/minikube-es-2/manifests/es-master.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/manifests/es-master.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: cluster-master
+    role: master
+  name: cluster-master
+  namespace: minikube-es-2
+spec:
+  replicas: 2
+  serviceName: cluster-master
+  template:
+    metadata:
+      labels:
+        name: cluster-master
+        role: master
+    spec:
+      containers:
+        - env:
+            - name: CLUSTER_NAME
+              value: cluster
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: HTTP_ENABLE
+              value: 'false'
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_DATA
+              value: 'false'
+            - name: NODE_INGEST
+              value: 'false'
+            - name: NODE_MASTER
+              value: 'true'
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NUMBER_OF_MASTERS
+              value: '1'
+          image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+          imagePullPolicy: Always
+          name: master
+          ports:
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+            privileged: false
+      initContainers:
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          name: sysctl
+          securityContext:
+            privileged: true

--- a/examples/kubernetes/compiled/minikube-es-2/pre-deploy/00_namespace.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/pre-deploy/00_namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: minikube-es-2
+  name: minikube-es-2
+  namespace: minikube-es-2

--- a/examples/kubernetes/compiled/minikube-es-2/pre-deploy/10_serviceaccount.yml
+++ b/examples/kubernetes/compiled/minikube-es-2/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: default
+  name: default
+  namespace: minikube-es-2

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/apply.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/apply.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+
+for SECTION in pre-deploy manifests
+do
+  echo "## run kubectl apply for ${SECTION}"
+  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+done

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/delete.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/delete.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+
+${DIR}/kubectl.sh delete -f ${DIR}/../manifests

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/kubectl.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/kubectl.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KUBECTL="kubectl --context minikube-es-2 --insecure-skip-tls-verify=False "
+
+${KUBECTL} $@

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/minikube/install_minikube.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/minikube/install_minikube.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+case "$(uname -s)" in
+    Linux*)     MINIKUBE_BINARY=minikube-linux-amd64;;
+    Darwin*)    MINIKUBE_BINARY=minikube-darwin-amd64;;
+    *)          exit 1
+esac
+
+MINIKUBE_VERSION=${MINIKUBE_VERSION:-v0.25.0}
+URL=https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/${MINIKUBE_BINARY}
+
+
+echo Downloading minikube release ${MINIKUBE_VERSION} to /usr/local/bin/minikube
+pause
+sudo curl --progress-bar -o /usr/local/bin/minikube ${URL}
+sudo chmod +x /usr/local/bin/minikube

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/minikube/start_minikube.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/minikube/start_minikube.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+eval $(minikube docker-env)
+minikube start --insecure-registry https://quay.io --memory=4096 --cpus=4
+minikube ssh "sudo ip link set docker0 promisc on"

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/setup_cluster.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/setup_cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+

--- a/examples/kubernetes/compiled/minikube-es-2/scripts/setup_context.sh
+++ b/examples/kubernetes/compiled/minikube-es-2/scripts/setup_context.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kubectl config set-context minikube-es-2 --cluster minikube --user minikube --namespace minikube-es-2
+kubectl config use-context minikube-es-2

--- a/examples/kubernetes/compiled/minikube-es/README.md
+++ b/examples/kubernetes/compiled/minikube-es/README.md
@@ -1,0 +1,61 @@
+# Elasticsearch Minikube
+
+This is a specific version of Elasticsearch to run on a minikube instalation.
+
+## Prerequisites
+
+Elasticsearch is a resource hungry application, for this setup we require
+that minikube is running with the above options:
+
+```
+$ minikube start --insecure-registry https://quay.io --memory=4096 --cpus=2
+```
+
+_If_ you have created the minikube VM previously, you will most likely need to 
+delete the vm and recreate it with more memory/cpu. (i.e. 
+```$ minikube delete```)
+
+## Setting up
+
+Assuming you're already running Minikube, setup for this target:
+
+```
+$ scripts/setup.sh
+```
+
+This will create a context in your minikube cluster called minikube-es.
+
+
+Apply the compiled manifests:
+
+```
+$ scripts/kubectl.sh apply -f manifests/
+```
+
+If the commands above did not error, you should be good to go. 
+
+Let's confirm everything is up:
+
+```
+$ scripts/kubectl.sh get pods -w
+```
+
+## Connecting to Elasticsearch
+
+List the elasticsearch service endpoints running in the cluster:
+
+```
+$ minikube service -n minikube-es  elasticsearch --url
+```
+
+and curl the health endpoint, i.e.: 
+```$ curl http://192.168.99.100:32130/_cluster/health?pretty```
+
+
+## Deleting Elasticsearch
+
+Deleting is easy (warning, this will remove _everything_):
+
+```
+$ scripts/kubectl.sh delete -f manifests/
+```

--- a/examples/kubernetes/compiled/minikube-es/manifests/es-client.yml
+++ b/examples/kubernetes/compiled/minikube-es/manifests/es-client.yml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: cluster-client
+    role: client
+  name: cluster-client
+  namespace: minikube-es
+spec:
+  replicas: 2
+  serviceName: cluster-client
+  template:
+    metadata:
+      labels:
+        name: cluster-client
+        role: client
+    spec:
+      containers:
+        - env:
+            - name: CLUSTER_NAME
+              value: cluster
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: HTTP_ENABLE
+              value: 'true'
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_DATA
+              value: 'false'
+            - name: NODE_INGEST
+              value: 'false'
+            - name: NODE_MASTER
+              value: 'false'
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NUMBER_OF_MASTERS
+              value: '1'
+          image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+          imagePullPolicy: Always
+          name: client
+          ports:
+            - containerPort: 9200
+              name: client
+              protocol: TCP
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+            privileged: false
+      initContainers:
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          name: sysctl
+          securityContext:
+            privileged: true

--- a/examples/kubernetes/compiled/minikube-es/manifests/es-data.yml
+++ b/examples/kubernetes/compiled/minikube-es/manifests/es-data.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: cluster-data
+    role: data
+  name: cluster-data
+  namespace: minikube-es
+spec:
+  replicas: 2
+  serviceName: cluster-data
+  template:
+    metadata:
+      labels:
+        name: cluster-data
+        role: data
+    spec:
+      containers:
+        - env:
+            - name: CLUSTER_NAME
+              value: cluster
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: HTTP_ENABLE
+              value: 'false'
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_DATA
+              value: 'true'
+            - name: NODE_INGEST
+              value: 'false'
+            - name: NODE_MASTER
+              value: 'false'
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NUMBER_OF_MASTERS
+              value: '1'
+          image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+          imagePullPolicy: Always
+          name: data
+          ports:
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+            privileged: false
+      initContainers:
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          name: sysctl
+          securityContext:
+            privileged: true

--- a/examples/kubernetes/compiled/minikube-es/manifests/es-discovery-svc.yml
+++ b/examples/kubernetes/compiled/minikube-es/manifests/es-discovery-svc.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: elasticsearch-discovery
+  name: elasticsearch-discovery
+  namespace: minikube-es
+spec:
+  ports:
+    - name: transport
+      port: 9300
+      targetPort: transport
+  selector:
+    name: cluster-master
+    role: master
+  type: ClusterIP

--- a/examples/kubernetes/compiled/minikube-es/manifests/es-elasticsearch-svc.yml
+++ b/examples/kubernetes/compiled/minikube-es/manifests/es-elasticsearch-svc.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: elasticsearch
+  name: elasticsearch
+  namespace: minikube-es
+spec:
+  ports:
+    - name: client
+      port: 9200
+      targetPort: client
+    - name: transport
+      port: 9300
+      targetPort: transport
+  selector:
+    name: cluster-client
+    role: client
+  type: NodePort

--- a/examples/kubernetes/compiled/minikube-es/manifests/es-master.yml
+++ b/examples/kubernetes/compiled/minikube-es/manifests/es-master.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: cluster-master
+    role: master
+  name: cluster-master
+  namespace: minikube-es
+spec:
+  replicas: 2
+  serviceName: cluster-master
+  template:
+    metadata:
+      labels:
+        name: cluster-master
+        role: master
+    spec:
+      containers:
+        - env:
+            - name: CLUSTER_NAME
+              value: cluster
+            - name: ES_JAVA_OPTS
+              value: -Xms512m -Xmx512m
+            - name: HTTP_ENABLE
+              value: 'false'
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_DATA
+              value: 'false'
+            - name: NODE_INGEST
+              value: 'false'
+            - name: NODE_MASTER
+              value: 'true'
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NUMBER_OF_MASTERS
+              value: '1'
+          image: quay.io/pires/docker-elasticsearch-kubernetes:5.5.0
+          imagePullPolicy: Always
+          name: master
+          ports:
+            - containerPort: 9300
+              name: transport
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - IPC_LOCK
+                - SYS_RESOURCE
+            privileged: false
+      initContainers:
+        - command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          image: busybox
+          imagePullPolicy: IfNotPresent
+          name: sysctl
+          securityContext:
+            privileged: true

--- a/examples/kubernetes/compiled/minikube-es/pre-deploy/00_namespace.yml
+++ b/examples/kubernetes/compiled/minikube-es/pre-deploy/00_namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: minikube-es
+  name: minikube-es
+  namespace: minikube-es

--- a/examples/kubernetes/compiled/minikube-es/pre-deploy/10_serviceaccount.yml
+++ b/examples/kubernetes/compiled/minikube-es/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: default
+  name: default
+  namespace: minikube-es

--- a/examples/kubernetes/compiled/minikube-es/scripts/apply.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/apply.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+
+for SECTION in pre-deploy manifests
+do
+  echo "## run kubectl apply for ${SECTION}"
+  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+done

--- a/examples/kubernetes/compiled/minikube-es/scripts/delete.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/delete.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+
+${DIR}/kubectl.sh delete -f ${DIR}/../manifests

--- a/examples/kubernetes/compiled/minikube-es/scripts/kubectl.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/kubectl.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KUBECTL="kubectl --context minikube-es --insecure-skip-tls-verify=False "
+
+${KUBECTL} $@

--- a/examples/kubernetes/compiled/minikube-es/scripts/minikube/install_minikube.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/minikube/install_minikube.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+case "$(uname -s)" in
+    Linux*)     MINIKUBE_BINARY=minikube-linux-amd64;;
+    Darwin*)    MINIKUBE_BINARY=minikube-darwin-amd64;;
+    *)          exit 1
+esac
+
+MINIKUBE_VERSION=${MINIKUBE_VERSION:-v0.25.0}
+URL=https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/${MINIKUBE_BINARY}
+
+
+echo Downloading minikube release ${MINIKUBE_VERSION} to /usr/local/bin/minikube
+pause
+sudo curl --progress-bar -o /usr/local/bin/minikube ${URL}
+sudo chmod +x /usr/local/bin/minikube

--- a/examples/kubernetes/compiled/minikube-es/scripts/minikube/start_minikube.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/minikube/start_minikube.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+eval $(minikube docker-env)
+minikube start --insecure-registry https://quay.io --memory=4096 --cpus=4
+minikube ssh "sudo ip link set docker0 promisc on"

--- a/examples/kubernetes/compiled/minikube-es/scripts/setup_cluster.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/setup_cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+

--- a/examples/kubernetes/compiled/minikube-es/scripts/setup_context.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/setup_context.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kubectl config set-context minikube-es --cluster minikube --user minikube --namespace minikube-es
+kubectl config use-context minikube-es

--- a/examples/kubernetes/compiled/minikube-mysql/README.md
+++ b/examples/kubernetes/compiled/minikube-mysql/README.md
@@ -1,0 +1,61 @@
+# Elasticsearch Minikube
+
+This is a specific version of Elasticsearch to run on a minikube instalation.
+
+## Prerequisites
+
+Elasticsearch is a resource hungry application, for this setup we require
+that minikube is running with the above options:
+
+```
+$ minikube start --insecure-registry https://quay.io --memory=4096 --cpus=2
+```
+
+_If_ you have created the minikube VM previously, you will most likely need to 
+delete the vm and recreate it with more memory/cpu. (i.e. 
+```$ minikube delete```)
+
+## Setting up
+
+Assuming you're already running Minikube, setup for this target:
+
+```
+$ scripts/setup.sh
+```
+
+This will create a context in your minikube cluster called minikube-mysql.
+
+
+Apply the compiled manifests:
+
+```
+$ scripts/kubectl.sh apply -f manifests/
+```
+
+If the commands above did not error, you should be good to go. 
+
+Let's confirm everything is up:
+
+```
+$ scripts/kubectl.sh get pods -w
+```
+
+## Connecting to Elasticsearch
+
+List the elasticsearch service endpoints running in the cluster:
+
+```
+$ minikube service -n minikube-mysql  elasticsearch --url
+```
+
+and curl the health endpoint, i.e.: 
+```$ curl http://192.168.99.100:32130/_cluster/health?pretty```
+
+
+## Deleting Elasticsearch
+
+Deleting is easy (warning, this will remove _everything_):
+
+```
+$ scripts/kubectl.sh delete -f manifests/
+```

--- a/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_secret.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_secret.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: P3tncGc6bXlzcWwvcm9vdC9wYXNzd29yZH0=
+kind: Secret
+metadata:
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+type: Opaque

--- a/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_service_jsonnet.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_service_jsonnet.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: example-mysql-jsonnet
+  name: example-mysql-jsonnet
+  namespace: minikube-mysql
+spec:
+  clusterIP: None
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector:
+    name: example-mysql
+  type: ClusterIP

--- a/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_service_simple.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_service_simple.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+spec:
+  clusterIP: None
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector:
+    name: example-mysql
+  type: ClusterIP

--- a/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_statefulset.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_statefulset.yml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+spec:
+  replicas: 1
+  serviceName: example-mysql
+  template:
+    metadata:
+      labels:
+        name: example-mysql
+    spec:
+      containers:
+        - env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MYSQL_ROOT_PASSWORD
+                  name: example-mysql
+          image: mysql:latest
+          imagePullPolicy: Always
+          name: mysql
+          ports:
+            - containerPort: 3306
+              name: mysql
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        annotations:
+          volume.beta.kubernetes.io/storage-class: standard
+        labels:
+          name: data
+        name: data
+        namespace: minikube-mysql
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10G

--- a/examples/kubernetes/compiled/minikube-mysql/pre-deploy/00_namespace.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/pre-deploy/00_namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: minikube-mysql
+  name: minikube-mysql
+  namespace: minikube-mysql

--- a/examples/kubernetes/compiled/minikube-mysql/pre-deploy/10_serviceaccount.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: default
+  name: default
+  namespace: minikube-mysql

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/apply.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/apply.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+
+for SECTION in pre-deploy manifests
+do
+  echo "## run kubectl apply for ${SECTION}"
+  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+done

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/delete.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/delete.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+
+${DIR}/kubectl.sh delete -f ${DIR}/../manifests

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/kubectl.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/kubectl.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KUBECTL="kubectl --context minikube-mysql --insecure-skip-tls-verify=False "
+
+${KUBECTL} $@

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/minikube/install_minikube.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/minikube/install_minikube.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+case "$(uname -s)" in
+    Linux*)     MINIKUBE_BINARY=minikube-linux-amd64;;
+    Darwin*)    MINIKUBE_BINARY=minikube-darwin-amd64;;
+    *)          exit 1
+esac
+
+MINIKUBE_VERSION=${MINIKUBE_VERSION:-v0.25.0}
+URL=https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/${MINIKUBE_BINARY}
+
+
+echo Downloading minikube release ${MINIKUBE_VERSION} to /usr/local/bin/minikube
+pause
+sudo curl --progress-bar -o /usr/local/bin/minikube ${URL}
+sudo chmod +x /usr/local/bin/minikube

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/minikube/start_minikube.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/minikube/start_minikube.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+eval $(minikube docker-env)
+minikube start --insecure-registry https://quay.io --memory=4096 --cpus=4
+minikube ssh "sudo ip link set docker0 promisc on"

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/setup_cluster.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/setup_cluster.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/setup_context.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/setup_context.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -eu
+#
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kubectl config set-context minikube-mysql --cluster minikube --user minikube --namespace minikube-mysql
+kubectl config use-context minikube-mysql

--- a/examples/kubernetes/inventory/classes/common.yml
+++ b/examples/kubernetes/inventory/classes/common.yml
@@ -1,0 +1,12 @@
+classes:
+- component.namespace 
+
+parameters:
+  kapitan:
+    vars:
+      target: ${target_name}
+      namespace: ${target_name}
+    secrets:
+      recipients:
+        - name: example@kapitan.dev
+          fingerprint: D9234C61F58BEB3ED8552A57E28DC07A3CBFAE7C

--- a/examples/kubernetes/inventory/classes/component/elasticsearch.yml
+++ b/examples/kubernetes/inventory/classes/component/elasticsearch.yml
@@ -25,3 +25,22 @@ parameters:
         java_opts: ${elasticsearch:java_opts}
         replicas: ${elasticsearch:replicas}
         masters: ${elasticsearch:masters}
+
+  kapitan:
+    vars:
+      target: ${target_name}
+      namespace: ${target_name}
+    compile:
+    - output_path: manifests
+      input_type: jsonnet
+      input_paths:
+        - components/elasticsearch/main.jsonnet
+      output_type: yaml
+    - output_path: scripts
+      input_type: jinja2
+      input_paths:
+        - scripts
+    - output_path: .
+      input_type: jinja2
+      input_paths:
+        - docs/elasticsearch/README.md

--- a/examples/kubernetes/inventory/classes/component/mysql.yml
+++ b/examples/kubernetes/inventory/classes/component/mysql.yml
@@ -1,4 +1,20 @@
 parameters:
+  kapitan:
+    compile:
+    - output_path: manifests
+      input_type: jsonnet
+      input_paths:
+        - components/mysql/main.jsonnet
+      output_type: yaml
+    - output_path: scripts
+      input_type: jinja2
+      input_paths:
+        - scripts
+    - output_path: .
+      output_type: yaml
+      input_type: jinja2
+      input_paths:
+        - docs/mysql/README.md
   mysql:
     storage: 10G
     storage_class: standard

--- a/examples/kubernetes/inventory/classes/component/namespace.yml
+++ b/examples/kubernetes/inventory/classes/component/namespace.yml
@@ -1,0 +1,10 @@
+parameters:
+  namespace: ${target_name}
+  kapitan:
+    compile:
+    - output_path: pre-deploy
+      input_type: jsonnet
+      output_type: yaml
+      input_paths:
+        - components/namespace/main.jsonnet
+

--- a/examples/kubernetes/inventory/targets/minikube-es-2.yml
+++ b/examples/kubernetes/inventory/targets/minikube-es-2.yml
@@ -1,28 +1,10 @@
 classes:
+  - common
   - cluster.minikube
   - component.elasticsearch
 
 parameters:
   target_name: minikube-es-2
-  kapitan:
-    vars:
-      target: ${target_name}
-      namespace: ${target_name}
-    compile:
-      - output_path: manifests
-        input_type: jsonnet
-        input_paths:
-          - components/elasticsearch/main.jsonnet
-        output_type: yaml
-      - output_path: scripts
-        input_type: jinja2
-        input_paths:
-          - scripts
-      - output_path: .
-        input_type: jinja2
-        input_paths:
-          - docs/elasticsearch/README.md
-  namespace: minikube-es
 
   elasticsearch:
     replicas: 2

--- a/examples/kubernetes/inventory/targets/minikube-es.yml
+++ b/examples/kubernetes/inventory/targets/minikube-es.yml
@@ -1,33 +1,10 @@
 classes:
+  - common
   - cluster.minikube
   - component.elasticsearch
 
 parameters:
   target_name: minikube-es
-  kapitan:
-    vars:
-      target: ${target_name}
-      namespace: ${target_name}
-    compile:
-    - output_path: manifests
-      input_type: jsonnet
-      input_paths:
-        - components/elasticsearch/main.jsonnet
-      output_type: yaml
-    - output_path: scripts
-      input_type: jinja2
-      input_paths:
-        - scripts
-    - output_path: .
-      input_type: jinja2
-      input_paths:
-        - docs/elasticsearch/README.md
-
-    secrets:
-      recipients:
-        - name: example@kapitan.dev
-          fingerprint: D9234C61F58BEB3ED8552A57E28DC07A3CBFAE7C
-  namespace: ${target_name}
 
   elasticsearch:
     replicas: 2

--- a/examples/kubernetes/inventory/targets/minikube-mysql.yml
+++ b/examples/kubernetes/inventory/targets/minikube-mysql.yml
@@ -1,38 +1,10 @@
 classes:
+  - common
   - cluster.minikube
   - component.mysql
 
 parameters:
   target_name: minikube-mysql
-  kapitan:
-    vars:
-      target: ${target_name}
-      namespace: ${target_name}
-    compile:
-    - output_path: pre-deploy
-      input_type: jsonnet
-      output_type: yaml
-      input_paths:
-        - components/namespace/main.jsonnet
-    - output_path: manifests
-      input_type: jsonnet
-      input_paths:
-        - components/mysql/main.jsonnet
-      output_type: yaml
-    - output_path: scripts
-      input_type: jinja2
-      input_paths:
-        - scripts
-    - output_path: .
-      output_type: yaml
-      input_type: jinja2
-      input_paths:
-        - docs/mysql/README.md
-    secrets:
-      recipients:
-        - name: example@kapitan.dev
-          fingerprint: D9234C61F58BEB3ED8552A57E28DC07A3CBFAE7C
-  namespace: ${target_name}
 
   mysql:
     instance_name: example-mysql


### PR DESCRIPTION
Created a slightly deeper inventory to show how we usually define the link between "inventory" components and the jsonnet they are used to create the actual manifests.

Also adding in compiled files so we can give a more complete example of the workflow for Kapitan.