### PR TITLE
Updated compiled dir used to tests

### DIFF
--- a/tests/test_kubernetes_compiled/minikube-es-2/README.md
+++ b/tests/test_kubernetes_compiled/minikube-es-2/README.md
@@ -45,7 +45,7 @@ $ scripts/kubectl.sh get pods -w
 List the elasticsearch service endpoints running in the cluster:
 
 ```
-$ minikube service -n minikube-es  elasticsearch --url
+$ minikube service -n minikube-es-2  elasticsearch --url
 ```
 
 and curl the health endpoint, i.e.: 

--- a/tests/test_kubernetes_compiled/minikube-es-2/pre-deploy/00_namespace.yml
+++ b/tests/test_kubernetes_compiled/minikube-es-2/pre-deploy/00_namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: minikube-es-2
+  name: minikube-es-2
+  namespace: minikube-es-2

--- a/tests/test_kubernetes_compiled/minikube-es-2/pre-deploy/10_serviceaccount.yml
+++ b/tests/test_kubernetes_compiled/minikube-es-2/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: default
+  name: default
+  namespace: minikube-es-2

--- a/tests/test_kubernetes_compiled/minikube-es-2/scripts/setup_context.sh
+++ b/tests/test_kubernetes_compiled/minikube-es-2/scripts/setup_context.sh
@@ -14,5 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-kubectl config set-context minikube-es-2 --cluster minikube --user minikube --namespace minikube-es
+kubectl config set-context minikube-es-2 --cluster minikube --user minikube --namespace minikube-es-2
 kubectl config use-context minikube-es-2

--- a/tests/test_kubernetes_compiled/minikube-es/pre-deploy/00_namespace.yml
+++ b/tests/test_kubernetes_compiled/minikube-es/pre-deploy/00_namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    name: minikube-es
+  name: minikube-es
+  namespace: minikube-es

--- a/tests/test_kubernetes_compiled/minikube-es/pre-deploy/10_serviceaccount.yml
+++ b/tests/test_kubernetes_compiled/minikube-es/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    name: default
+  name: default
+  namespace: minikube-es


### PR DESCRIPTION
The compilation test runs `kapitan compile` on the kubernetes example and compares the result to a pre-compiled directory in the `tests` folder.

Fixes the compilation test.