### PR TITLE
Allow recursive search and globbing in searchvar and inventory commands

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -95,13 +95,13 @@ def main():
     inventory_parser.add_argument('--flat', '-F', help='flatten nested inventory variables',
                                   action='store_true', default=False)
     inventory_parser.add_argument('--pattern', '-p', default='',
-                                  help='filter pattern (e.g. parameters.mysql), default is ""')
+                                  help='filter pattern (e.g. parameters.mysql.storage_class, or storage_class,' +
+                                  ' or storage_*), default is ""')
 
     searchvar_parser = subparser.add_parser('searchvar',
                                             help='show all inventory files where var is declared')
     searchvar_parser.add_argument('searchvar', type=str, metavar='VARNAME',
-                                  help='flattened full variable name. Example: ' +
-                                  'parameters.cluster.type')
+                                  help='e.g. parameters.mysql.storage_class, or storage_class, or storage_*')
     searchvar_parser.add_argument('--inventory-path', default='./inventory',
                                   help='set inventory path, default is "./inventory"')
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -186,7 +186,7 @@ def flatten_dict(d, parent_key='', sep='.'):
 
 def deep_get(dictionary, keys):
     '''
-    Search recursevely for 'keys' in 'dictionary' and return value, otherwise return None
+    Search recursively for 'keys' in 'dictionary' and return value, otherwise return None
     '''
     value = reduce(lambda d, key: d.get(key, None) if isinstance(d, dict) else None, keys, dictionary)
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -191,11 +191,24 @@ def deep_get(dictionary, keys):
     value = reduce(lambda d, key: d.get(key, None) if isinstance(d, dict) else None, keys, dictionary)
 
     if value is None:
-        for _, v in dictionary.items():
+        # Remove first key (if >1 in list), as we haven't found anything yet
+        if len(keys) > 1:
+            del keys[0]
+
+        # Move down the dictionary
+        for v in dictionary.values():
             if isinstance(v, dict):
+                # Recurse with new dict and fewer keys (if we had >1 in list)
                 item = deep_get(v, keys)
                 if item is not None:
                     return item
+                else:
+                    # If we find nothing, check for globbing in last key, loop and match with dict keys
+                    if '*' in keys[-1]:
+                        last_key_lower = keys[-1].replace('*', '').lower()
+                        for v_key in v.keys():
+                            if last_key_lower in v_key.lower():
+                                return v[v_key]
 
     return value
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -186,9 +186,18 @@ def flatten_dict(d, parent_key='', sep='.'):
 
 def deep_get(dictionary, keys):
     '''
-    Return (keys) values from dictionary
+    Search recursevely for 'keys' in 'dictionary' and return value, otherwise return None
     '''
-    return reduce(lambda d, key: d.get(key, None) if isinstance(d, dict) else None, keys, dictionary)
+    value = reduce(lambda d, key: d.get(key, None) if isinstance(d, dict) else None, keys, dictionary)
+
+    if value is None:
+        for _, v in dictionary.items():
+            if isinstance(v, dict):
+                item = deep_get(v, keys)
+                if item is not None:
+                    return item
+
+    return value
 
 
 def searchvar(flat_var, inventory_path):


### PR DESCRIPTION
Right now we have to specify the whole path when we search for variables using `searchvar` like:
```
kapitan searchvar parameters.mysql.storage_class
```

We want to be able to just specify:
```
kapitan searchvar storage_class
```

Or even:
```
kapitan searchvar storage_*
```

This also applies to `kapitan inventory -t <target> -p <filter>`:
```
kapitan inventory -t minikube-mysql -p storage_*
```