### PR TITLE
Customizable indentation of yaml/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ optional arguments:
                         targets to compile, default is all
   --parallelism INT, -p INT
                         Number of concurrent compile processes, default is 4
+  --indent INT, -i INT  Indentation spaces for YAML/JSON, default is 2
   --secrets-path SECRETS_PATH
                         set secrets path, default is "./secrets"
   --reveal              reveal secrets (warning: this will write sensitive

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -76,6 +76,9 @@ def main():
     compile_parser.add_argument('--parallelism', '-p', type=int,
                                 default=4, metavar='INT',
                                 help='Number of concurrent compile processes, default is 4')
+    compile_parser.add_argument('--indent', '-i', type=int,
+                                default=2, metavar='INT',
+                                help='Indentation spaces for YAML/JSON, default is 2')
     compile_parser.add_argument('--secrets-path', help='set secrets path, default is "./secrets"',
                                 default='./secrets',)
     compile_parser.add_argument('--reveal',
@@ -179,7 +182,7 @@ def main():
         compile_targets(args.inventory_path, search_path, args.output_path,
                         args.parallelism, args.targets,
                         prune=(not args.no_prune), secrets_path=args.secrets_path,
-                        secrets_reveal=args.reveal, gpg_obj=gpg_obj)
+                        secrets_reveal=args.reveal, gpg_obj=gpg_obj, indent=args.indent)
 
         if not args.ignore_version_check:
             save_version()


### PR DESCRIPTION
- Added `kapitan compile --indent x` or `kapitan compile -i x` to customize indentation of yaml and json
- Changed default indent to 2 so all outputs are consistent (json was previously on 4 and yaml on 2)

Fixes #109