### PR TITLE
Reclass update and import as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reclass"]
+  path = reclass
+  url = git://github.com/salt-formulas/reclass.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ notifications:
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y gnupg2 git
+  - sudo apt-get install -y gnupg2
 
 # command to install dependencies
 install:

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Kapitan needs Python 3.6.
 
 User (`$HOME/.local/lib/python3.6/bin` on Linux or `$HOME/Library/Python/3.6/bin` on macOS):
 ```
-pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git  --process-dependency-links
+pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git
 ```
 
 System-wide (not recommended):
 ```
-sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links
+sudo pip3 install --upgrade git+https://github.com/deepmind/kapitan.git
 ```
 
 # Example

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache python3-dev git g++ make libstdc++ gnupg musl-dev util-li
     if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     rm -rf /root/.cache
 
-RUN pip3 install --upgrade --no-cache-dir git+https://github.com/deepmind/kapitan.git --process-dependency-links
+RUN pip3 install --upgrade --no-cache-dir git+https://github.com/deepmind/kapitan.git
 
 RUN gcloud components install kubectl
 

--- a/kapitan/__init__.py
+++ b/kapitan/__init__.py
@@ -13,3 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+import os
+import sys
+
+# Adding reclass to PYTHONPATH
+sys.path.insert(0, os.path.dirname(__file__) + "/../reclass")

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -291,7 +291,7 @@ def check_version():
                 print('Last used version (in .kapitan): {}{}\n'.format(dot_kapitan["version"], termcolor.ENDC))
                 print('Please upgrade kapitan to at least "{}" in order to keep results consistent:\n'.format(dot_kapitan["version"]))
                 print('Docker: docker pull deepmind/kapitan')
-                print('Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git --process-dependency-links\n')
+                print('Pip (user): pip3 install --user --upgrade git+https://github.com/deepmind/kapitan.git\n')
                 print('Check https://github.com/deepmind/kapitan#quickstart for more info.\n')
                 print('If you know what you\'re doing, you can skip this check by adding \'--ignore-version-check\'.')
                 sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ python-gnupg==0.4.2
 six>=1.11.0
 cryptography==2.2.2
 requests>=2.18.4
+# Reclass dependencies
+pyparsing

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,6 @@ jsonnet==0.10.0
 PyYAML==3.12
 ujson==1.35
 Jinja2>=2.10
-# Latest commit from salt-formulas/reclass - develop branch (python3 support)
-# TODO: Change commit hash to release tag once develop is merged into master and release is cut
-git+https://github.com/salt-formulas/reclass.git@13a2472f#egg=reclass
 jsonschema>=2.6.0
 python-gnupg==0.4.2
 six>=1.11.0

--- a/setup.py
+++ b/setup.py
@@ -74,9 +74,6 @@ setup(
 
         'License :: OSI Approved :: Apache Software License',
 
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6'
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,6 @@ def install_deps():
     or something like that, so e.g. `-9231` works as well as
     `1.1.0`. This is ignored by the setuptools, but has to be there.
 
-    Warnings:
-        to make pip respect the links, you have to use
-        `--process-dependency-links` switch. So e.g.:
-        `pip install --process-dependency-links {git-url}`
-
     Returns:
          list of packages and dependency links.
     """

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -19,9 +19,9 @@
 import unittest
 import os
 import sys
-import shutil
 from kapitan.cli import main
 from kapitan.utils import get_directory_hash
+
 
 class CompileTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 "inventory tests"
+
 import unittest
 from kapitan.resources import inventory
+
 
 class InventoryTargetTest(unittest.TestCase):
     def test_inventory_target(self):

--- a/tests/test_jinja2.py
+++ b/tests/test_jinja2.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 "jinja2 tests"
+
 import unittest
 import tempfile
 from kapitan.utils import render_jinja2_file
 from kapitan.resources import inventory
+
 
 class Jinja2FiltersTest(unittest.TestCase):
     def test_sha256(self):
@@ -36,6 +38,7 @@ class Jinja2FiltersTest(unittest.TestCase):
             context = {"text":["this", "that"]}
             yaml = '- this\n- that\n'
             self.assertEqual(render_jinja2_file(f.name, context), yaml)
+
 
 class Jinja2ContextVars(unittest.TestCase):
     def test_inventory_context(self):

--- a/tests/test_jsonnet.py
+++ b/tests/test_jsonnet.py
@@ -15,8 +15,10 @@
 # limitations under the License.
 
 "jsonnet tests"
+
 import unittest
 from kapitan.resources import yaml_dump
+
 
 class JsonnetNativeFuncsTest(unittest.TestCase):
     def test_yaml_dump(self):

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 "secrets tests"
+
 import os
 import unittest
 import re
@@ -33,6 +34,8 @@ KEY = GPG_OBJ.gen_key(GPG_OBJ.gen_key_input(key_type="RSA",
 KEY2 = GPG_OBJ.gen_key(GPG_OBJ.gen_key_input(key_type="RSA",
                                             key_length=2048,
                                             passphrase="testphrase"))
+
+
 class SecretsTest(unittest.TestCase):
     "Test secrets"
     def test_secret_token_attributes(self):


### PR DESCRIPTION
- Updated reclass to latest master v1.5.3
- Importing as git submodule with v1.5.3 checked out
- Removed deprecated `--process-dependency-links` pip install flag and references
- Light cleanup

We can push kapitan to pip after merging and minor release