### PR TITLE
Add pretty_printer option to searchvar

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -111,6 +111,8 @@ def main():
                                   help='set inventory path, default is "./inventory"')
     searchvar_parser.add_argument('--verbose', '-v', help='set verbose mode',
                                   action='store_true', default=False)
+    searchvar_parser.add_argument('--pretty_print', '-p', help='Pretty print content of var',
+                                  action='store_true', default=False)
 
     secrets_parser = subparser.add_parser('secrets', help='manage secrets')
     secrets_parser.add_argument('--write', '-w', help='write secret token',
@@ -224,7 +226,7 @@ def main():
         else:
             logging.basicConfig(level=logging.INFO, format="%(message)s")
 
-        searchvar(args.searchvar, args.inventory_path)
+        searchvar(args.searchvar, args.inventory_path, args.pretty_print)
 
     elif cmd == 'secrets':
         if args.verbose:

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -269,7 +269,7 @@ def deep_get(dictionary, keys, previousKey=None):
     return value
 
 
-def searchvar(flat_var, inventory_path):
+def searchvar(flat_var, inventory_path, pretty_print):
     '''
     show all inventory files where a given reclass variable is declared
     '''
@@ -288,8 +288,15 @@ def searchvar(flat_var, inventory_path):
                         output.append((filename, value))
                         if len(filename) > maxlenght:
                             maxlenght = len(filename)
-    for i in output:
-        print('{0!s:{l}} {1!s}'.format(*i, l=maxlenght + 2))
+    if pretty_print:
+        for i in output:
+            print(i[0])
+            for line in yaml.dump(i[1], default_flow_style=False).splitlines():
+                print("    ", line)
+            print()
+    else:
+        for i in output:
+            print('{0!s:{l}} {1!s}'.format(*i, l=maxlenght + 2))
 
 
 def get_directory_hash(directory):


### PR DESCRIPTION


BEFORE

```
$ kapitan searchvar parameters.kapitan.compile
./inventory/targets/global.yml                           [{'input_paths': ['docs/global/'], 'input_type': 'jinja2', 'output_path': 'docs'}]
./inventory/targets/auto-deploy.yml                      [{'input_paths': ['scripts/ci/'], 'input_type': 'jinja2', 'output_path': 'scripts'}]
```

AFTER

```
$ kapitan searchvar parameters.kapitan.compile -p
./inventory/targets/global.yml
     - input_paths:
       - docs/global/
       input_type: jinja2
       output_path: docs

./inventory/targets/auto-deploy.yml
     - input_paths:
       - scripts/ci/
       input_type: jinja2
       output_path: scripts
```