### PR TITLE
Fixed secrets validate and update

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -275,7 +275,10 @@ def main():
             # update recipients for all secrets in secrets_path
             # use --secrets-path to set scanning path
             inv = inventory_reclass(args.inventory_path)
-            targets = set(inv['nodes'].keys())
+            if args.target_name:
+                targets = set(args.target_name.split(','))
+            else:
+                targets = set(inv['nodes'].keys())
             secrets_path = os.path.abspath(args.secrets_path)
             target_token_paths = search_target_token_paths(secrets_path, targets)
             ret_code = 0

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -123,6 +123,7 @@ def main():
                                 help='update target secrets')
     secrets_parser.add_argument('--validate-targets', action='store_true', default=False,
                                 help='validate target secrets')
+    secrets_parser.add_argument('--targets', '-T', help='targets to validate/update, default is all')
     secrets_parser.add_argument('--base64', '-b64', help='base64 encode file content',
                                 action='store_true', default=False)
     secrets_parser.add_argument('--reveal', '-r', help='reveal secrets',
@@ -275,8 +276,8 @@ def main():
             # update recipients for all secrets in secrets_path
             # use --secrets-path to set scanning path
             inv = inventory_reclass(args.inventory_path)
-            if args.target_name:
-                targets = set(args.target_name.split(','))
+            if args.targets:
+                targets = set(args.targets.split(','))
             else:
                 targets = set(inv['nodes'].keys())
             secrets_path = os.path.abspath(args.secrets_path)

--- a/kapitan/secrets.py
+++ b/kapitan/secrets.py
@@ -371,7 +371,7 @@ def search_target_token_paths(target_secrets_path, targets):
         for f in files:
             full_path = os.path.join(root, f)
             full_path = full_path[len(target_secrets_path)+1:]
-            target_name = full_path.split("/")[0]
+            target_name = full_path.split("/")[1]
             if target_name in targets:
                 logger.debug('search_target_token_paths: found %s', full_path)
                 target_files[target_name].append(full_path)


### PR DESCRIPTION
- `kapitan secrets --validate-targets` and `kapitan secrets --update-targets` is now looking at all secrets (broke after the reclass update).
- Allow to validate and update secrets for specific targets `kapitan secrets --update-targets -T minikube-mysql`