### PR TITLE
Command flags support in .kapitan

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ optional arguments:
   --inventory-path INVENTORY_PATH
                         set inventory path, default is "./inventory"
   --ignore-version-check
-                        ignore the last kapitan version used to compile (from .kapitan)
+                        ignore the version from .kapitan
 ```
 
 # Modes of operation

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Targets can also be defined inside the `inventory`.
 ├── lib
 │   ├── kapitan.libjsonnet
 │   └── kube.libjsonnet
+└── .kapitan
 ```
 
 # Usage
@@ -307,6 +308,28 @@ optional arguments:
                         set inventory path, default is "./inventory"
   --ignore-version-check
                         ignore the version from .kapitan
+```
+
+These parameters can also be defined in a local `.kapitan` file, for example:
+```
+$ cat .kapitan
+
+compile:
+  indent: 4
+  parallelism: 8
+```
+
+This is equivalent to running:
+```
+kapitan compile --indent 4 --parallelism 8
+```
+
+To enforce the kapitan version used for compilation (for consistency and safety), you can add `version` to `.kapitan`:
+```
+$ cat .kapitan
+
+...
+version: 0.17.0
 ```
 
 # Modes of operation

--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -18,3 +18,4 @@
 
 inv = {}
 gpg_backend = None
+dot_kapitan = {}

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -26,7 +26,7 @@ import sys
 import traceback
 import yaml
 
-from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar, deep_get, check_version, save_version
+from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar, deep_get, from_dot_kapitan, check_version, save_version
 from kapitan.targets import compile_targets
 from kapitan.resources import search_imports, resource_callbacks, inventory_reclass
 from kapitan.version import PROJECT_NAME, DESCRIPTION, VERSION
@@ -49,100 +49,134 @@ def main():
     eval_parser = subparser.add_parser('eval', help='evaluate jsonnet file')
     eval_parser.add_argument('jsonnet_file', type=str)
     eval_parser.add_argument('--output', type=str,
-                             choices=('yaml', 'json'), default='yaml',
+                             choices=('yaml', 'json'),
+                             default=from_dot_kapitan('eval', 'output', 'yaml'),
                              help='set output format, default is "yaml"')
-    eval_parser.add_argument('--vars', type=str, default=[], nargs='*',
+    eval_parser.add_argument('--vars', type=str,
+                             default=from_dot_kapitan('eval', 'vars', []),
+                             nargs='*',
                              metavar='VAR',
                              help='set variables')
-    eval_parser.add_argument('--search-path', '-J', type=str, default='.',
+    eval_parser.add_argument('--search-path', '-J', type=str,
+                             default=from_dot_kapitan('eval', 'search-path', '.'),
                              metavar='JPATH',
                              help='set search path, default is "."')
 
     compile_parser = subparser.add_parser('compile', help='compile targets')
-    compile_parser.add_argument('--search-path', '-J', type=str, default='.',
+    compile_parser.add_argument('--search-path', '-J', type=str,
+                                default=from_dot_kapitan('compile', 'search-path', '.'),
                                 metavar='JPATH',
                                 help='set search path, default is "."')
     compile_parser.add_argument('--verbose', '-v', help='set verbose mode',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('compile', 'verbose', False))
     compile_parser.add_argument('--prune', help='prune jsonnet output',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('compile', 'prune', False))
     compile_parser.add_argument('--quiet', help='set quiet mode, only critical output',
-                                action='store_true', default=False)
-    compile_parser.add_argument('--output-path', type=str, default='.',
+                                action='store_true',
+                                default=from_dot_kapitan('compile', 'quiet', False))
+    compile_parser.add_argument('--output-path', type=str,
+                                default=from_dot_kapitan('compile', 'output-path', '.'),
                                 metavar='PATH',
                                 help='set output path, default is "."')
     compile_parser.add_argument('--targets', '-t', help='targets to compile, default is all',
-                                type=str, nargs='+', default=[], metavar='TARGET')
+                                type=str, nargs='+',
+                                default=from_dot_kapitan('compile', 'targets', []),
+                                metavar='TARGET')
     compile_parser.add_argument('--parallelism', '-p', type=int,
-                                default=4, metavar='INT',
+                                default=from_dot_kapitan('compile', 'parallelism', 4),
+                                metavar='INT',
                                 help='Number of concurrent compile processes, default is 4')
     compile_parser.add_argument('--indent', '-i', type=int,
-                                default=2, metavar='INT',
+                                default=from_dot_kapitan('compile', 'indent', 2),
+                                metavar='INT',
                                 help='Indentation spaces for YAML/JSON, default is 2')
     compile_parser.add_argument('--secrets-path', help='set secrets path, default is "./secrets"',
-                                default='./secrets',)
+                                default=from_dot_kapitan('compile', 'secrets-path', './secrets'))
     compile_parser.add_argument('--reveal',
                                 help='reveal secrets (warning: this will write sensitive data)',
-                                action='store_true', default=False)
-    compile_parser.add_argument('--inventory-path', default='./inventory',
+                                action='store_true',
+                                default=from_dot_kapitan('compile', 'reveal', False))
+    compile_parser.add_argument('--inventory-path',
+                                default=from_dot_kapitan('compile', 'inventory-path', './inventory'),
                                 help='set inventory path, default is "./inventory"')
     compile_parser.add_argument('--ignore-version-check',
                                 help='ignore the last kapitan version used to compile (from .kapitan)',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('compile', 'ignore-version-check', False))
 
     inventory_parser = subparser.add_parser('inventory', help='show inventory')
-    inventory_parser.add_argument('--target-name', '-t', default='',
+    inventory_parser.add_argument('--target-name', '-t',
+                                  default=from_dot_kapitan('inventory', 'target-name', ''),
                                   help='set target name, default is all targets')
-    inventory_parser.add_argument('--inventory-path', default='./inventory',
+    inventory_parser.add_argument('--inventory-path',
+                                  default=from_dot_kapitan('inventory', 'inventory-path', './inventory'),
                                   help='set inventory path, default is "./inventory"')
     inventory_parser.add_argument('--flat', '-F', help='flatten nested inventory variables',
-                                  action='store_true', default=False)
-    inventory_parser.add_argument('--pattern', '-p', default='',
+                                  action='store_true',
+                                  default=from_dot_kapitan('inventory', 'flat', False))
+    inventory_parser.add_argument('--pattern', '-p',
+                                  default=from_dot_kapitan('inventory', 'pattern', ''),
                                   help='filter pattern (e.g. parameters.mysql.storage_class, or storage_class,' +
                                   ' or storage_*), default is ""')
     inventory_parser.add_argument('--verbose', '-v', help='set verbose mode',
-                                  action='store_true', default=False)
+                                  action='store_true',
+                                  default=from_dot_kapitan('inventory', 'verbose', False))
 
     searchvar_parser = subparser.add_parser('searchvar',
                                             help='show all inventory files where var is declared')
     searchvar_parser.add_argument('searchvar', type=str, metavar='VARNAME',
                                   help='e.g. parameters.mysql.storage_class, or storage_class, or storage_*')
-    searchvar_parser.add_argument('--inventory-path', default='./inventory',
+    searchvar_parser.add_argument('--inventory-path',
+                                  default=from_dot_kapitan('searchvar', 'inventory-path', './inventory'),
                                   help='set inventory path, default is "./inventory"')
     searchvar_parser.add_argument('--verbose', '-v', help='set verbose mode',
-                                  action='store_true', default=False)
-    searchvar_parser.add_argument('--pretty_print', '-p', help='Pretty print content of var',
-                                  action='store_true', default=False)
+                                  action='store_true',
+                                  default=from_dot_kapitan('searchvar', 'verbose', False))
+    searchvar_parser.add_argument('--pretty-print', '-p', help='Pretty print content of var',
+                                  action='store_true',
+                                  default=from_dot_kapitan('searchvar', 'pretty-print', False))
 
     secrets_parser = subparser.add_parser('secrets', help='manage secrets')
     secrets_parser.add_argument('--write', '-w', help='write secret token',
                                 metavar='TOKENNAME',)
     secrets_parser.add_argument('--update', help='update recipients for secret token',
                                 metavar='TOKENNAME',)
-    secrets_parser.add_argument('--update-targets', action='store_true', default=False,
+    secrets_parser.add_argument('--update-targets', action='store_true',
+                                default=from_dot_kapitan('secrets', 'update-targets', False),
                                 help='update target secrets')
-    secrets_parser.add_argument('--validate-targets', action='store_true', default=False,
+    secrets_parser.add_argument('--validate-targets', action='store_true',
+                                default=from_dot_kapitan('secrets', 'validate-targets', False),
                                 help='validate target secrets')
     secrets_parser.add_argument('--base64', '-b64', help='base64 encode file content',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('secrets', 'base64', False))
     secrets_parser.add_argument('--reveal', '-r', help='reveal secrets',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('secrets', 'reveal', False))
     secrets_parser.add_argument('--file', '-f', help='read file or directory, set "-" for stdin',
                                 metavar='FILENAME')
     secrets_parser.add_argument('--target-name', '-t', help='grab recipients from target name')
-    secrets_parser.add_argument('--inventory-path', default='./inventory',
+    secrets_parser.add_argument('--inventory-path',
+                                default=from_dot_kapitan('secrets', 'inventory-path', './inventory'),
                                 help='set inventory path, default is "./inventory"')
     secrets_parser.add_argument('--recipients', '-R', help='set recipients',
-                                type=str, nargs='+', default=[], metavar='RECIPIENT')
+                                type=str, nargs='+',
+                                default=from_dot_kapitan('secrets', 'recipients', []),
+                                metavar='RECIPIENT')
     secrets_parser.add_argument('--secrets-path', help='set secrets path, default is "./secrets"',
-                                default='./secrets',)
+                                default=from_dot_kapitan('secrets', 'secrets-path', './secrets'))
     secrets_parser.add_argument('--backend', help='set secrets backend, default is "gpg"',
-                                type=str, choices=('gpg',), default='gpg')
+                                type=str, choices=('gpg',),
+                                default=from_dot_kapitan('secrets', 'backend', 'gpg'))
     secrets_parser.add_argument('--verbose', '-v',
                                 help='set verbose mode (warning: this will show sensitive data)',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('secrets', 'verbose', False))
     secrets_parser.add_argument('--no-verify', help='do not verify secret hashes on reveal',
-                                action='store_true', default=False)
+                                action='store_true',
+                                default=from_dot_kapitan('secrets', 'no-verify', False))
 
     args = parser.parse_args()
 

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -26,7 +26,7 @@ import sys
 import traceback
 import yaml
 
-from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar, deep_get, from_dot_kapitan, check_version, save_version
+from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar, deep_get, from_dot_kapitan, check_version
 from kapitan.targets import compile_targets
 from kapitan.resources import search_imports, resource_callbacks, inventory_reclass
 from kapitan.version import PROJECT_NAME, DESCRIPTION, VERSION
@@ -102,7 +102,7 @@ def main():
                                 default=from_dot_kapitan('compile', 'inventory-path', './inventory'),
                                 help='set inventory path, default is "./inventory"')
     compile_parser.add_argument('--ignore-version-check',
-                                help='ignore the last kapitan version used to compile (from .kapitan)',
+                                help='ignore the version from .kapitan',
                                 action='store_true',
                                 default=from_dot_kapitan('compile', 'ignore-version-check', False))
 
@@ -222,9 +222,6 @@ def main():
                         args.parallelism, args.targets,
                         prune=(args.prune), secrets_path=args.secrets_path,
                         secrets_reveal=args.reveal, indent=args.indent)
-
-        if not args.ignore_version_check:
-            save_version()
 
     elif cmd == 'inventory':
         if args.verbose:

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 
 def main():
-    "main function for command line usage"
+    """main function for command line usage"""
     parser = argparse.ArgumentParser(prog=PROJECT_NAME,
                                      description=DESCRIPTION)
     parser.add_argument('--version', action='version', version=VERSION)

--- a/kapitan/errors.py
+++ b/kapitan/errors.py
@@ -16,20 +16,20 @@
 
 
 class KapitanError(Exception):
-    "generic kapitan error"
+    """generic kapitan error"""
     pass
 
 
 class CompileError(KapitanError):
-    "compile error"
+    """compile error"""
     pass
 
 
 class InventoryError(KapitanError):
-    "inventory error"
+    """inventory error"""
     pass
 
 
 class SecretError(KapitanError):
-    "secrets error"
+    """secrets error"""
     pass

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -59,7 +59,7 @@ def resource_callbacks(search_path):
 
 
 def yaml_dump(obj):
-    "Dumps jsonnet obj as yaml"
+    """Dumps jsonnet obj as yaml"""
     _obj = json.loads(obj)
     return yaml.safe_dump(_obj, default_flow_style=False)
 
@@ -86,7 +86,7 @@ def jinja2_render_file(search_path, name, ctx):
 
 
 def read_file(search_path, name):
-    "return content of file in name"
+    """return content of file in name"""
     full_path = os.path.join(search_path, name)
     logger.debug("read_file trying file %s", full_path)
     if os.path.exists(full_path):

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -106,7 +106,7 @@ def compile_targets(inventory_path, search_path, output_path, parallel, targets,
 
 
 def load_target_inventory(inventory_path, targets):
-    "retuns a list of target objects from the inventory"
+    """retuns a list of target objects from the inventory"""
     target_objs = []
     inv = inventory_reclass(inventory_path)
 
@@ -129,9 +129,7 @@ def load_target_inventory(inventory_path, targets):
 
 
 def compile_target(target_obj, search_path, compile_path, **kwargs):
-    """
-    Compiles target_obj and writes to compile_path
-    """
+    """Compiles target_obj and writes to compile_path"""
     start = time.time()
 
     ext_vars = target_obj["vars"]
@@ -319,7 +317,7 @@ class CompilingFile(object):
         self.kwargs = kwargs
 
     def write(self, data):
-        "write data into file"
+        """write data into file"""
         secrets_reveal = self.kwargs.get('secrets_reveal', False)
         if secrets_reveal:
             self.fp.write(self.sub_token_reveal_data(data))
@@ -327,7 +325,7 @@ class CompilingFile(object):
             self.fp.write(self.sub_token_compiled_data(data))
 
     def write_yaml(self, obj):
-        "recursively hash or reveal secrets and convert obj to yaml and write to file"
+        """recursively hash or reveal secrets and convert obj to yaml and write to file"""
         indent = self.kwargs.get('indent', 2)
         secrets_reveal = self.kwargs.get('secrets_reveal', False)
         if secrets_reveal:
@@ -337,7 +335,7 @@ class CompilingFile(object):
         yaml.dump(obj, stream=self.fp, indent=indent, Dumper=PrettyDumper, default_flow_style=False)
 
     def write_json(self, obj):
-        "recursively hash or reveal secrets and convert obj to json and write to file"
+        """recursively hash or reveal secrets and convert obj to json and write to file"""
         indent = self.kwargs.get('indent', 2)
         secrets_reveal = self.kwargs.get('secrets_reveal', False)
         if secrets_reveal:
@@ -347,7 +345,7 @@ class CompilingFile(object):
         json.dump(obj, self.fp, indent=indent, escape_forward_slashes=False)
 
     def sub_token_compiled_obj(self, obj):
-        "recursively find and replace tokens with hashed tokens in obj"
+        """recursively find and replace tokens with hashed tokens in obj"""
         if isinstance(obj, dict):
             for k, v in obj.items():
                 obj[k] = self.sub_token_compiled_obj(v)
@@ -359,7 +357,7 @@ class CompilingFile(object):
         return obj
 
     def sub_token_reveal_obj(self, obj):
-        "recursively find and reveal token tags in data"
+        """recursively find and reveal token tags in data"""
         if isinstance(obj, dict):
             for k, v in obj.items():
                 obj[k] = self.sub_token_reveal_obj(v)
@@ -389,7 +387,7 @@ class CompilingFile(object):
         return "?{%s:%s:%s}" % (backend, token_path, sha256)
 
     def reveal_token_tag(self, token_tag):
-        "reveal token_tag"
+        """reveal token_tag"""
         secrets_path = self.kwargs.get("secrets_path", None)
         if secrets_path is None:
             raise ValueError("secrets_path not set")
@@ -398,7 +396,7 @@ class CompilingFile(object):
         return secret_gpg_read(secrets_path, token)
 
     def sub_token_compiled_data(self, data):
-        "find and replace tokens with hashed tokens in data"
+        """find and replace tokens with hashed tokens in data"""
         def _hash_token_tag(match_obj):
             token_tag, token, func = match_obj.groups()
             _, token_path = secret_token_attributes(token)
@@ -417,7 +415,7 @@ class CompilingFile(object):
         return re.sub(SECRET_TOKEN_TAG_PATTERN, _hash_token_tag, data)
 
     def sub_token_reveal_data(self, data):
-        "find and reveal token tags in data"
+        """find and reveal token tags in data"""
         def _reveal_token_tag(match_obj):
             token_tag, _ = match_obj.groups()
             return self.reveal_token_tag(token_tag)
@@ -425,9 +423,9 @@ class CompilingFile(object):
         return re.sub(SECRET_TOKEN_TAG_PATTERN, _reveal_token_tag, data)
 
     def target_secret_func_write(self, token_path, func):
-        "write a target secret for token with data from func"
+        """write a target secret for token with data from func"""
         target_name = self.kwargs.get('target_name', None)
-        secrets_path = self.kwargs.get("secrets_path", None)
+        secrets_path = self.kwargs.get('secrets_path', None)
         target_inv = cached.inv['nodes'].get(target_name, None)
         if target_name is None:
             raise ValueError('target_name not set')

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -356,11 +356,11 @@ def check_version():
         if kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) > StrictVersion(VERSION):
             print("{}Current version: {}".format(termcolor.WARNING, VERSION))
             print("Version in .kapitan: {}{}\n".format(kapitan_config["version"], termcolor.ENDC))
-            print("Please upgrade kapitan to '{}' in order to keep results consistent:\n".format(kapitan_config["version"]))
+            print("Upgrade kapitan to '{}' in order to keep results consistent:\n".format(kapitan_config["version"]))
             print("Docker: docker pull deepmind/kapitan:{}".format(kapitan_config["version"]))
             print("Pip (user): pip3 install --user --upgrade kapitan=={}\n".format(kapitan_config["version"]))
             print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
-            print("If you know what you\"re doing, you can skip this check by adding \"--ignore-version-check\".")
+            print("If you know what you're doing, you can skip this check by adding '--ignore-version-check'.")
             sys.exit(1)
         elif kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) < StrictVersion(VERSION):
             print("{}Current version: {}".format(termcolor.WARNING, VERSION))
@@ -370,7 +370,7 @@ def check_version():
             print("Docker: docker pull deepmind/kapitan:{}".format(kapitan_config["version"]))
             print("Pip (user): pip3 install --user --upgrade kapitan=={}\n".format(kapitan_config["version"]))
             print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
-            print("If you know what you\"re doing, you can skip this check by adding \"--ignore-version-check\".")
+            print("If you know what you're doing, you can skip this check by adding '--ignore-version-check'.")
             sys.exit(1)
     except KeyError:
         pass

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -347,12 +347,12 @@ def from_dot_kapitan(command, flag, default):
 def check_version():
     """
     Checks the version in .kapitan is the same as the current version.
-    If the last version of kapitan used is bigger, it will prompt to upgrade.
-    If the last version of kapitan used is smaller, it will prompt to update .kapitan or downgrade.
+    If the version in .kapitan is bigger, it will prompt to upgrade.
+    If the version in .kapitan is smaller, it will prompt to update .kapitan or downgrade.
     """
     kapitan_config = dot_kapitan_config()
     try:
-        # If "saved version is bigger than current version"
+        # If .kapitan version is bigger than current version
         if kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) > StrictVersion(VERSION):
             print("{}Current version: {}".format(termcolor.WARNING, VERSION))
             print("Version in .kapitan: {}{}\n".format(kapitan_config["version"], termcolor.ENDC))
@@ -362,6 +362,7 @@ def check_version():
             print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
             print("If you know what you're doing, you can skip this check by adding '--ignore-version-check'.")
             sys.exit(1)
+        # If .kapitan version is smaller than current version
         elif kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) < StrictVersion(VERSION):
             print("{}Current version: {}".format(termcolor.WARNING, VERSION))
             print("Version in .kapitan: {}{}\n".format(kapitan_config["version"], termcolor.ENDC))

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -43,7 +43,7 @@ except ImportError:
 
 
 def hashable_lru_cache(func):
-    "Usable instead of lru_cache for functions using unhashable objects"
+    """Usable instead of lru_cache for functions using unhashable objects"""
 
     cache = lru_cache(maxsize=256)
 
@@ -84,30 +84,30 @@ class termcolor:
 
 
 def normalise_join_path(dirname, path):
-    "Join dirname with path and return in normalised form"
+    """Join dirname with path and return in normalised form"""
     logger.debug(os.path.normpath(os.path.join(dirname, path)))
     return os.path.normpath(os.path.join(dirname, path))
 
 
 @lru_cache(maxsize=256)
 def render_jinja2_template(content, context):
-    "Render jinja2 content with context"
+    """Render jinja2 content with context"""
     return jinja2.Template(content, undefined=jinja2.StrictUndefined).render(context)
 
 
 @lru_cache(maxsize=256)
 def sha256_string(string):
-    "Returns sha256 hex digest for string"
+    """Returns sha256 hex digest for string"""
     return sha256(string.encode("UTF-8")).hexdigest()
 
 
 def jinja2_yaml_filter(obj):
-    "Returns yaml for object"
+    """Returns yaml for object"""
     return yaml.safe_dump(obj, default_flow_style=False)
 
 
 def render_jinja2_file(name, context):
-    "Render jinja2 file name with context"
+    """Render jinja2 file name with context"""
     path, filename = os.path.split(name)
     env = jinja2.Environment(
         undefined=jinja2.StrictUndefined,
@@ -160,7 +160,7 @@ def render_jinja2(path, context):
 
 
 def file_mode(name):
-    "Returns mode for file name"
+    """Returns mode for file name"""
     st = os.stat(name)
     return stat.S_IMODE(st.st_mode)
 
@@ -178,10 +178,10 @@ def jsonnet_file(file_path, **kwargs):
 
 
 def prune_empty(d):
-    '''
+    """
     Remove empty lists and empty dictionaries from d
     (similar to jsonnet std.prune but faster)
-    '''
+    """
     if not isinstance(d, (dict, list)):
         return d
 
@@ -195,20 +195,17 @@ def prune_empty(d):
 
 
 class PrettyDumper(yaml.SafeDumper):
-    '''
+    """
     Increases indent of nested lists.
     By default, they are indendented at the same level as the key on the previous line
     More info on https://stackoverflow.com/questions/25108581/python-yaml-dump-bad-indentation
-    '''
-
+    """
     def increase_indent(self, flow=False, indentless=False):
         return super(PrettyDumper, self).increase_indent(flow, False)
 
 
 def flatten_dict(d, parent_key='', sep='.'):
-    '''
-    Flatten nested elements in a dictionary
-    '''
+    """Flatten nested elements in a dictionary"""
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
@@ -221,9 +218,7 @@ def flatten_dict(d, parent_key='', sep='.'):
 
 @hashable_lru_cache
 def deep_get(dictionary, keys, previousKey=None):
-    '''
-    Search recursively for 'keys' in 'dictionary' and return value, otherwise return None
-    '''
+    """Search recursively for 'keys' in 'dictionary' and return value, otherwise return None"""
     value = None
     if len(keys) > 0:
         value = dictionary.get(keys[0], None) if isinstance(dictionary, dict) else None
@@ -270,10 +265,7 @@ def deep_get(dictionary, keys, previousKey=None):
 
 
 def searchvar(flat_var, inventory_path, pretty_print):
-    '''
-    show all inventory files where a given reclass variable is declared
-    '''
-
+    """Show all inventory files where a given reclass variable is declared"""
     output = []
     maxlenght = 0
     keys = flat_var.split(".")
@@ -300,9 +292,7 @@ def searchvar(flat_var, inventory_path, pretty_print):
 
 
 def get_directory_hash(directory):
-    '''
-    Compute a sha256 hash for the file contents of a directory
-    '''
+    """Compute a sha256 hash for the file contents of a directory"""
     if not os.path.exists(directory):
         logger.error("utils.get_directory_hash failed, %s dir doesn't exist", directory)
         return -1

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -338,7 +338,7 @@ def from_dot_kapitan(command, flag, default):
             flag_value = kapitan_config[command][flag]
             if flag_value:
                 return flag_value
-    except:
+    except KeyError:
         pass
 
     return default
@@ -346,28 +346,31 @@ def from_dot_kapitan(command, flag, default):
 
 def check_version():
     """
-    Checks that the last version of kapitan used is at least smaller or equal to current version.
-    If the last version of kapitan used is bigger, it will give instructions on how to upgrade and exit(1).
+    Checks the version in .kapitan is the same as the current version.
+    If the last version of kapitan used is bigger, it will prompt to upgrade.
+    If the last version of kapitan used is smaller, it will prompt to update .kapitan or downgrade.
     """
     kapitan_config = dot_kapitan_config()
-    # If "saved version is bigger than current version"
-    if kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) > StrictVersion(VERSION):
-        print("{}Current version: {}".format(termcolor.WARNING, VERSION))
-        print("Last used version (in .kapitan): {}{}\n".format(kapitan_config["version"], termcolor.ENDC))
-        print("Please upgrade kapitan to at least '{}' in order to keep results consistent:\n".format(kapitan_config["version"]))
-        print("Docker: docker pull deepmind/kapitan")
-        print("Pip (user): pip3 install --user --upgrade kapitan\n")
-        print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
-        print("If you know what you\"re doing, you can skip this check by adding \"--ignore-version-check\".")
-        sys.exit(1)
-
-
-def save_version():
-    """Saves the current kapitan version to a local .kapitan file"""
-    with open(".kapitan", "w") as f:
-        kapitan_config = dot_kapitan_config()
-        if not kapitan_config:
-            kapitan_config = {}
-
-        kapitan_config["version"] = VERSION
-        yaml.safe_dump(kapitan_config, stream=f, default_flow_style=False)
+    try:
+        # If "saved version is bigger than current version"
+        if kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) > StrictVersion(VERSION):
+            print("{}Current version: {}".format(termcolor.WARNING, VERSION))
+            print("Version in .kapitan: {}{}\n".format(kapitan_config["version"], termcolor.ENDC))
+            print("Please upgrade kapitan to '{}' in order to keep results consistent:\n".format(kapitan_config["version"]))
+            print("Docker: docker pull deepmind/kapitan:{}".format(kapitan_config["version"]))
+            print("Pip (user): pip3 install --user --upgrade kapitan=={}\n".format(kapitan_config["version"]))
+            print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
+            print("If you know what you\"re doing, you can skip this check by adding \"--ignore-version-check\".")
+            sys.exit(1)
+        elif kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) < StrictVersion(VERSION):
+            print("{}Current version: {}".format(termcolor.WARNING, VERSION))
+            print("Version in .kapitan: {}{}\n".format(kapitan_config["version"], termcolor.ENDC))
+            print("Option 1: You can update the version in .kapitan to '{}' and recompile\n".format(VERSION))
+            print("Option 2: Downgrade kapitan to '{}' in order to keep results consistent:\n".format(kapitan_config["version"]))
+            print("Docker: docker pull deepmind/kapitan:{}".format(kapitan_config["version"]))
+            print("Pip (user): pip3 install --user --upgrade kapitan=={}\n".format(kapitan_config["version"]))
+            print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
+            print("If you know what you\"re doing, you can skip this check by adding \"--ignore-version-check\".")
+            sys.exit(1)
+    except KeyError:
+        pass

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -351,7 +351,7 @@ def check_version():
     """
     kapitan_config = dot_kapitan_config()
     # If "saved version is bigger than current version"
-    if kapitan_config["version"] and StrictVersion(kapitan_config["version"]) > StrictVersion(VERSION):
+    if kapitan_config and kapitan_config["version"] and StrictVersion(kapitan_config["version"]) > StrictVersion(VERSION):
         print("{}Current version: {}".format(termcolor.WARNING, VERSION))
         print("Last used version (in .kapitan): {}{}\n".format(kapitan_config["version"], termcolor.ENDC))
         print("Please upgrade kapitan to at least '{}' in order to keep results consistent:\n".format(kapitan_config["version"]))
@@ -366,5 +366,8 @@ def save_version():
     """Saves the current kapitan version to a local .kapitan file"""
     with open(".kapitan", "w") as f:
         kapitan_config = dot_kapitan_config()
+        if not kapitan_config:
+            kapitan_config = {}
+
         kapitan_config["version"] = VERSION
         yaml.safe_dump(kapitan_config, stream=f, default_flow_style=False)


### PR DESCRIPTION
Resolves #111 

- Doc strings consistent with PEP 257
- Allows configuration of command flags in `.kapitan`, such as:
```
version: 0.17.0
compile:
  indent: 4
```
will translate to `kapitan compile --indent 4`
- Enforcing kapitan version from `.kapitan`
- `.kapitan` usage doc