### PR TITLE
compile arguments force-recompile and targets are mutually exclusive

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -80,10 +80,15 @@ def main():
                                 default=from_dot_kapitan('compile', 'output-path', '.'),
                                 metavar='PATH',
                                 help='set output path, default is "."')
-    compile_parser.add_argument('--targets', '-t', help='targets to compile, default is all',
+    compile_parser_subgroup = compile_parser.add_mutually_exclusive_group()
+    compile_parser_subgroup.add_argument('--targets', '-t', help='targets to compile, default is all',
                                 type=str, nargs='+',
                                 default=from_dot_kapitan('compile', 'targets', []),
                                 metavar='TARGET')
+    compile_parser_subgroup.add_argument('--force-recompile', '-f',
+                                help='force recompilation of all targets, ignores .kapitan_cache',
+                                action='store_true',
+                                default=from_dot_kapitan('compile', 'force-recompile', False))
     compile_parser.add_argument('--parallelism', '-p', type=int,
                                 default=from_dot_kapitan('compile', 'parallelism', 4),
                                 metavar='INT',
@@ -105,10 +110,6 @@ def main():
                                 help='ignore the version from .kapitan',
                                 action='store_true',
                                 default=from_dot_kapitan('compile', 'ignore-version-check', False))
-    compile_parser.add_argument('--force-recompile', '-f',
-                                help='force recompilation of all targets, ignores .kapitan_cache',
-                                action='store_true',
-                                default=from_dot_kapitan('compile', 'force-recompile', False))
 
     inventory_parser = subparser.add_parser('inventory', help='show inventory')
     inventory_parser.add_argument('--target-name', '-t',


### PR DESCRIPTION
```
$ ~/git/kapitan/bin/kapitan compile -t my_target -f
usage: kapitan compile [-h] [--search-paths JPATH [JPATH ...]] [--verbose]
                       [--prune] [--quiet] [--output-path PATH]
                       [--targets TARGET [TARGET ...] | --force-recompile]
                       [--parallelism INT] [--indent INT]
                       [--secrets-path SECRETS_PATH] [--reveal]
                       [--inventory-path INVENTORY_PATH]
                       [--ignore-version-check]
kapitan compile: error: argument --force-recompile/-f: not allowed with argument --targets/-t
```