### PR TITLE
Fix secrets cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ The usual flow of creating and using an encrypted secret with kapitan is:
 
   - Manually:
     ```
-    kapitan secrets --write mysql/root/password -t minikube-mysql -f <password file>
+    kapitan secrets --write gpg:mysql/root/password -t minikube-mysql -f <password file>
     OR
-    echo -n '<password>' | kapitan secrets --write mysql/root/password -t minikube-mysql -f -
+    echo -n '<password>' | kapitan secrets --write gpg:mysql/root/password -t minikube-mysql -f -
     ```
     This will encrypt and save your password into `secrets/mysql/root/password`, see `examples/kubernetes`.
 

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -288,7 +288,7 @@ def main():
 def secret_write(args, ref_controller):
     "Write secret to ref_controller based on cli args"
     token_name = args.write
-    file_name = args.file_name
+    file_name = args.file
     data = None
 
     if file_name is None:

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -288,7 +288,7 @@ def main():
 def secret_write(args, ref_controller):
     "Write secret to ref_controller based on cli args"
     token_name = args.write
-    file_name = args.file
+    file_name = args.file_name
     data = None
 
     if file_name is None:

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -295,8 +295,10 @@ def main():
                     data = fp.read()
             # TODO deprecate backend and move to passing ref tags in command line
             if args.backend == "gpg":
-                secret_obj = GPGSecret(data, recipients, args.base64)
-                ref_controller.backends['gpg'][args.write] = secret_obj
+                secret_obj = GPGSecret(data.encode(), recipients, encode_base64=args.base64)
+                tag = '?{{gpg:{}}}'.format(args.write)
+                print('data', secret_obj.data)
+                ref_controller[tag] = secret_obj
         elif args.reveal:
             revealer = Revealer(ref_controller)
             if args.file is None:

--- a/kapitan/refs/secrets/gpg.py
+++ b/kapitan/refs/secrets/gpg.py
@@ -59,6 +59,8 @@ class GPGSecret(Ref):
         fingerprints = lookup_fingerprints(recipients)
         if encrypt:
             self._encrypt(data, fingerprints, encode_base64)
+            if encode_base64:
+                kwargs["encoding"] = "base64"
         else:
             self.data = data
             self.recipients = [{'fingerprint': f} for f in fingerprints]  # TODO move to .load() method

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -45,6 +45,12 @@ except ImportError:
     from yaml import SafeLoader as YamlLoader
 
 
+def fatal_error(message):
+    "Logs error message, sys.exit(1)"
+    logger.error(message)
+    sys.exit(1)
+
+
 def hashable_lru_cache(func):
     """Usable instead of lru_cache for functions using unhashable objects"""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,121 @@
+# Copyright 2018 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"cli tests"
+
+import base64
+import contextlib
+import io
+import os
+import tempfile
+import shutil
+import subprocess
+import sys
+import unittest
+
+from kapitan.cli import main
+
+SECRETS_PATH = tempfile.mkdtemp()
+
+# set GNUPGHOME if only running this test
+# otherwise it will reuse the value from test_gpg.py
+if os.environ.get("GNUPGHOME", None) is None:
+    GNUPGHOME = tempfile.mkdtemp()
+    os.environ["GNUPGHOME"] = GNUPGHOME
+
+
+class CliFuncsTest(unittest.TestCase):
+    def setUp(self):
+        example_key = 'examples/kubernetes/secrets/example@kapitan.dev.key'
+        example_key = os.path.join(os.getcwd(), example_key)
+        example_key_ownertrust = tempfile.mktemp()
+
+        # always trust this key - for testing only!
+        with open(example_key_ownertrust, "w") as fp:
+            fp.write("D9234C61F58BEB3ED8552A57E28DC07A3CBFAE7C:6\n")
+
+        subprocess.run(["gpg", "--import", example_key])
+        subprocess.run(["gpg", "--import-ownertrust", example_key_ownertrust])
+        os.remove(example_key_ownertrust)
+
+    def test_cli_secret_write_reveal_gpg(self):
+        """
+        run $ kapitan secrets --write
+        and $ kapitan secrets --reveal
+        with example@kapitan.dev recipient
+        """
+        test_secret_content = "I am a secret!"
+        test_secret_file = tempfile.mktemp()
+        with open(test_secret_file, "w") as fp:
+            fp.write(test_secret_content)
+
+        sys.argv = ["kapitan", "secrets", "--write", "gpg:test_secret",
+                    "-f", test_secret_file,
+                    "--secrets-path", SECRETS_PATH,
+                    "--recipients", "example@kapitan.dev"]
+        main()
+
+        test_tag_content = "revealing: ?{gpg:test_secret}"
+        test_tag_file = tempfile.mktemp()
+        with open(test_tag_file, "w") as fp:
+            fp.write(test_tag_content)
+        sys.argv = ["kapitan", "secrets", "--reveal",
+                    "-f", test_tag_file,
+                    "--secrets-path", SECRETS_PATH]
+
+        # set stdout as string
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            main()
+        self.assertEqual("revealing: {}".format(test_secret_content),
+                         stdout.getvalue())
+
+        os.remove(test_tag_file)
+
+    def test_cli_secret_base64_write_reveal_gpg(self):
+        """
+        run $ kapitan secrets --write --base64
+        and $ kapitan secrets --reveal
+        with example@kapitan.dev recipient
+        """
+        test_secret_content = "I am another secret!"
+        test_secret_file = tempfile.mktemp()
+        with open(test_secret_file, "w") as fp:
+            fp.write(test_secret_content)
+
+        sys.argv = ["kapitan", "secrets", "--write", "gpg:test_secretb64",
+                    "-f", test_secret_file, "--base64",
+                    "--secrets-path", SECRETS_PATH,
+                    "--recipients", "example@kapitan.dev"]
+        main()
+
+        test_tag_content = "?{gpg:test_secretb64}"
+        test_tag_file = tempfile.mktemp()
+        with open(test_tag_file, "w") as fp:
+            fp.write(test_tag_content)
+        sys.argv = ["kapitan", "secrets", "--reveal",
+                    "-f", test_tag_file,
+                    "--secrets-path", SECRETS_PATH]
+
+        # set stdout as string
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            main()
+        stdout_base64 = base64.b64decode(stdout.getvalue()).decode()
+        self.assertEqual(test_secret_content, stdout_base64)
+
+        os.remove(test_tag_file)
+
+    def tearDown(self):
+        shutil.rmtree(SECRETS_PATH)

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -27,7 +27,12 @@ from kapitan.refs.secrets.gpg import gpg_obj, GPGSecret, GPG_KWARGS, GPG_TARGET_
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
 
-gpg_obj(gnupghome=tempfile.mkdtemp())
+# set GNUPGHOME for test_cli
+GNUPGHOME = tempfile.mkdtemp()
+os.environ["GNUPGHOME"] = GNUPGHOME
+
+gpg_obj(gnupghome=GNUPGHOME)
+
 KEY = cached.gpg_obj.gen_key(cached.gpg_obj.gen_key_input(key_type="RSA",
                                                           key_length=2048,
                                                           passphrase="testphrase"))


### PR DESCRIPTION
Fixes encoding issues when creating gpg secrets using the cli (#150)
Breaking change: removes `--backend` in `secrets` subcommand. New format for secret token in cli is prefix with backend name (now referred as type_name) e.g. `gpg:path/to/secret1`
Refactor of cli code into smaller functions easier to test.