### PR TITLE
Minor cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.22.0-rc.0:
 #### Breaking:
 - Added reveal secrets function, updated rsapublic function (#182)
-- Parameters.kapitan.secrets.recipients is deprecated, please use parameters.kapitan.secrets.gpg.recipients (#183)
+- parameters.kapitan.secrets.recipients is deprecated, please use parameters.kapitan.secrets.gpg.recipients (#183)
 
 #### Updates:
 - Added AWS KMS support as a secrets backend(#179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.22.0-rc.0:
+#### Breaking:
+- Added reveal secrets function, updated rsapublic function (#182)
+- Parameters.kapitan.secrets.recipients is deprecated, please use parameters.kapitan.secrets.gpg.recipients (#183)
+
+#### Updates:
+- Added AWS KMS support as a secrets backend(#179)
+- Refactor input\_type code into classes(#180)
+- Fix GPG failing when expiry of gpg key is infinite (#181)
+
 ## 0.21.0
 - Upgraded to jsonnet 0.12.1 (https://github.com/google/jsonnet/releases/tag/v0.12.1)
 

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -27,11 +27,12 @@ import yaml
 
 from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar
 from kapitan.utils import deep_get, from_dot_kapitan, check_version, fatal_error
+from kapitan.utils import search_target_token_paths
 from kapitan.targets import compile_targets
 from kapitan.resources import search_imports, resource_callbacks, inventory_reclass
 from kapitan.version import PROJECT_NAME, DESCRIPTION, VERSION
 
-from kapitan.refs.base import RefController, Revealer, search_target_token_paths
+from kapitan.refs.base import RefController, Revealer
 from kapitan.refs.secrets.gpg import GPGSecret
 from kapitan.refs.secrets.gpg import lookup_fingerprints
 from kapitan.refs.secrets.gkms import GoogleKMSSecret
@@ -196,7 +197,17 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    if hasattr(args, 'verbose') and args.verbose:
+        logging.basicConfig(level=logging.DEBUG,
+                            format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+    elif hasattr(args, 'quiet') and args.quiet:
+        logging.basicConfig(level=logging.CRITICAL, format="%(message)s")
+    else:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+
     if cmd == 'eval':
+        logging.basicConfig(level=logging.WARNING)
+
         file_path = args.jsonnet_file
         search_paths = [os.path.abspath(path) for path in args.search_paths]
         ext_vars = {}
@@ -217,14 +228,6 @@ def main():
             print(json_output)
 
     elif cmd == 'compile':
-        if args.verbose:
-            logging.basicConfig(level=logging.DEBUG,
-                                format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        elif args.quiet:
-            logging.basicConfig(level=logging.CRITICAL, format="%(message)s")
-        else:
-            logging.basicConfig(level=logging.INFO, format="%(message)s")
-
         search_paths = [os.path.abspath(path) for path in args.search_paths]
 
         if not args.ignore_version_check:
@@ -238,12 +241,6 @@ def main():
                         cache=args.cache, cache_paths=args.cache_paths)
 
     elif cmd == 'inventory':
-        if args.verbose:
-            logging.basicConfig(level=logging.DEBUG,
-                                format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        else:
-            logging.basicConfig(level=logging.INFO, format="%(message)s")
-
         if args.pattern and args.target_name == '':
             parser.error("--pattern requires --target_name")
         try:
@@ -264,21 +261,9 @@ def main():
             sys.exit(1)
 
     elif cmd == 'searchvar':
-        if args.verbose:
-            logging.basicConfig(level=logging.DEBUG,
-                                format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        else:
-            logging.basicConfig(level=logging.INFO, format="%(message)s")
-
         searchvar(args.searchvar, args.inventory_path, args.pretty_print)
 
     elif cmd == 'secrets':
-        if args.verbose:
-            logging.basicConfig(level=logging.DEBUG,
-                                format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
-        else:
-            logging.basicConfig(level=logging.INFO, format="%(message)s")
-
         ref_controller = RefController(args.secrets_path)
 
         if args.write is not None:

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import errno
 import logging
 import os
 import yaml

--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import errno
 import logging
 import os
 

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -23,7 +23,6 @@ import re
 import sys
 import os
 import yaml
-from collections import defaultdict
 
 from kapitan.errors import RefFromFuncError, RefBackendError, RefError
 from kapitan.errors import RefHashMismatchError
@@ -132,19 +131,10 @@ class RefBackend(object):
 
         raise KeyError(ref_path)
 
-    def _mkdir_ref(self, full_ref_path):
-        "create dir full_ref_path if not existent"
-        try:
-            os.makedirs(os.path.dirname(full_ref_path))
-        except OSError as ex:
-            # If directory exists, pass
-            if ex.errno == errno.EEXIST:
-                pass
-
     def __setitem__(self, ref_path, ref_obj):
         assert(isinstance(ref_obj, self.ref_type))
         full_ref_path = os.path.join(self.path, ref_path)
-        self._mkdir_ref(full_ref_path)
+        os.makedirs(os.path.dirname(full_ref_path), exist_ok=True)
 
         with open(full_ref_path, 'w') as fp:
             yaml.safe_dump(ref_obj.dump(), stream=fp, default_flow_style=False)
@@ -264,7 +254,7 @@ class Revealer(object):
                 ref = self.ref_controller[tag]
                 return ref.compile()
             # if refs don't exist:
-            except KeyError as e:
+            except KeyError:
                 raise RefError("Could not find ref: {}".format(tag))
 
         return compile_replace_match
@@ -513,5 +503,5 @@ class RefController(object):
 
 class FunctionContext(object):
     def __init__(self, data):
-        "Carry context accross function evaluation"
+        "Carry context across function evaluation"
         self.data = data

--- a/kapitan/refs/secrets/awskms.py
+++ b/kapitan/refs/secrets/awskms.py
@@ -58,10 +58,11 @@ class AWSKMSSecret(Ref):
         """
         try:
             target_name = ref_params.kwargs['target_name']
-            target_inv = cached.inv['nodes'].get(target_name, None)
-            if target_name is None:
+            if not target_name:
                 raise ValueError('target_name not set')
-            if target_inv is None:
+
+            target_inv = cached.inv['nodes'].get(target_name, None)
+            if not target_inv:
                 raise ValueError('target_inv not set')
 
             key = target_inv['parameters']['kapitan']['secrets']['awskms']['key']
@@ -137,8 +138,9 @@ class AWSKMSSecret(Ref):
         """
         Returns dict with keys/values to be serialised.
         """
-        return {"data": self.data, "encoding": self.encoding,
-                "key": self.key, "type": self.type_name}
+        orig = super().dump()
+        orig['key'] = self.key
+        return orig
 
 
 class AWSKMSBackend(RefBackend):

--- a/kapitan/refs/secrets/awskms.py
+++ b/kapitan/refs/secrets/awskms.py
@@ -58,11 +58,11 @@ class AWSKMSSecret(Ref):
         """
         try:
             target_name = ref_params.kwargs['target_name']
-            if not target_name:
+            if target_name is None:
                 raise ValueError('target_name not set')
 
             target_inv = cached.inv['nodes'].get(target_name, None)
-            if not target_inv:
+            if target_inv is None:
                 raise ValueError('target_inv not set')
 
             key = target_inv['parameters']['kapitan']['secrets']['awskms']['key']
@@ -138,9 +138,8 @@ class AWSKMSSecret(Ref):
         """
         Returns dict with keys/values to be serialised.
         """
-        orig = super().dump()
-        orig['key'] = self.key
-        return orig
+        return {"data": self.data, "encoding": self.encoding,
+                "key": self.key, "type": self.type_name}
 
 
 class AWSKMSBackend(RefBackend):

--- a/kapitan/refs/secrets/gkms.py
+++ b/kapitan/refs/secrets/gkms.py
@@ -69,10 +69,11 @@ class GoogleKMSSecret(Ref):
         """
         try:
             target_name = ref_params.kwargs['target_name']
-            target_inv = cached.inv['nodes'].get(target_name, None)
-            if target_name is None:
+            if not target_name:
                 raise ValueError('target_name not set')
-            if target_inv is None:
+
+            target_inv = cached.inv['nodes'].get(target_name, None)
+            if not target_inv:
                 raise ValueError('target_inv not set')
 
             key = target_inv['parameters']['kapitan']['secrets']['gkms']['key']
@@ -155,8 +156,9 @@ class GoogleKMSSecret(Ref):
         """
         Returns dict with keys/values to be serialised.
         """
-        return {"data": self.data, "encoding": self.encoding,
-                "key": self.key, "type": self.type_name}
+        orig = super().dump()
+        orig['key'] = self.key
+        return orig
 
 
 class GoogleKMSBackend(RefBackend):

--- a/kapitan/refs/secrets/gkms.py
+++ b/kapitan/refs/secrets/gkms.py
@@ -69,11 +69,11 @@ class GoogleKMSSecret(Ref):
         """
         try:
             target_name = ref_params.kwargs['target_name']
-            if not target_name:
+            if target_name is None:
                 raise ValueError('target_name not set')
 
             target_inv = cached.inv['nodes'].get(target_name, None)
-            if not target_inv:
+            if target_inv is None:
                 raise ValueError('target_inv not set')
 
             key = target_inv['parameters']['kapitan']['secrets']['gkms']['key']
@@ -156,9 +156,8 @@ class GoogleKMSSecret(Ref):
         """
         Returns dict with keys/values to be serialised.
         """
-        orig = super().dump()
-        orig['key'] = self.key
-        return orig
+        return {"data": self.data, "encoding": self.encoding,
+                "key": self.key, "type": self.type_name}
 
 
 class GoogleKMSBackend(RefBackend):

--- a/kapitan/refs/secrets/gpg.py
+++ b/kapitan/refs/secrets/gpg.py
@@ -79,11 +79,11 @@ class GPGSecret(Ref):
                 return cls(data, _fingerprints, **ref_params.kwargs)
 
             target_name = ref_params.kwargs['target_name']
-            if not target_name:
+            if target_name is None:
                 raise ValueError('target_name not set')
 
             target_inv = cached.inv['nodes'].get(target_name, None)
-            if not target_inv:
+            if target_inv is None:
                 raise ValueError('target_inv not set')
 
             if 'secrets' not in target_inv['parameters']['kapitan']:
@@ -155,9 +155,8 @@ class GPGSecret(Ref):
         """
         Returns dict with keys/values to be serialised.
         """
-        orig = super().dump()
-        orig['recipients'] = self.recipients
-        return orig
+        return {"data": self.data, "encoding": self.encoding,
+                "recipients": self.recipients, "type": self.type_name}
 
 
 class GPGBackend(RefBackend):

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -409,3 +409,27 @@ def check_version():
             sys.exit(1)
     except KeyError:
         pass
+
+def search_target_token_paths(target_secrets_path, targets):
+    """
+    returns dict of target and their secret token paths (e.g ?{[gpg/gkms/awskms]:mysql/root/password}) in target_secrets_path
+    targets is a set of target names used to lookup targets in target_secrets_path
+    """
+    target_files = defaultdict(list)
+    for root, _, files in os.walk(target_secrets_path):
+        for f in files:
+            full_path = os.path.join(root, f)
+            secret_path = full_path[len(target_secrets_path) + 1:]
+            target_name = secret_path.split("/")[0]
+            if target_name in targets:
+                with open(full_path) as fp:
+                    obj = yaml.load(fp, Loader=YamlLoader)
+                    try:
+                        secret_type = obj['type']
+                    except KeyError:
+                        # Backwards compatible with gpg secrets that didn't have type in yaml
+                        secret_type = "gpg"
+                    secret_path = "?{{{}:{}}}".format(secret_type, secret_path)
+                logger.debug('search_target_token_paths: found %s', secret_path)
+                target_files[target_name].append(secret_path)
+    return target_files

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -18,8 +18,6 @@ from __future__ import print_function
 
 "random utils"
 
-from functools import lru_cache, wraps
-from hashlib import sha256
 import logging
 import os
 import sys
@@ -31,8 +29,10 @@ import _jsonnet as jsonnet
 import yaml
 import math
 import base64
-from collections import Counter
+from collections import Counter, defaultdict
 from pkg_resources import parse_version
+from functools import lru_cache, wraps
+from hashlib import sha256
 
 from kapitan.version import VERSION
 from kapitan.errors import CompileError
@@ -409,6 +409,7 @@ def check_version():
             sys.exit(1)
     except KeyError:
         pass
+
 
 def search_target_token_paths(target_secrets_path, targets):
     """


### PR DESCRIPTION
Some more no-op cleanup + a breaking change since there is one more in this release candidate.

Specifically:

 - fix various codestyle errors
 - fix a TODO with missing exception handling
 - simplify os.makedirs everywhere
 - move search_target_token_paths to kapitan.utils since it's only used in cli and is not logically bound to kapitan/refs/base.py
 - Update changelog