### PR TITLE
Add support for writing ref type secrets in command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,8 @@ shuffle - randomly shuffle elements of a list {{ [1, 2, 3, 4, 5] | shuffle }}
 
 Manages your secrets with GPG, Google Cloud KMS (beta) or AWS KMS (beta), with plans to also support Vault.
 
+If you want to get started with secrets but don't have a GPG or KMS setup, you can use the secret ref type. Note that `ref` is not encrypted and is intented for development purposes only. *Do not use `ref` secrets if you're storing sensitive information!*
+
 The usual flow of creating and using an encrypted secret with kapitan is:
 
 - Define your GPG recipients or KMS key, see [common.yml class](./examples/kubernetes/inventory/classes/common.yml), `parameters.kapitan.secrets`. You can also define these per target.
@@ -453,6 +455,7 @@ The usual flow of creating and using an encrypted secret with kapitan is:
     GPG: kapitan secrets --write gpg:targets/minikube-mysql/mysql/password -t minikube-mysql -f <password file>
     gKMS: kapitan secrets --write gkms:targets/minikube-mysql/mysql/password -t minikube-mysql -f <password file>
     awsKMS: kapitan secrets --write awskms:targets/minikube-mysql/mysql/password -t minikube-mysql -f <password file>
+    ref: kapitan secrets --write ref:targets/minikube-mysql/mysql/password -t minikube-mysql -f <password file> # WARNING: ref is not encrypted and intended for dev use only
     OR use stdin:
     echo -n '<password>' | kapitan secrets --write [gpg/gkms/awskms]:targets/minikube-mysql/mysql/password -t minikube-mysql -f -
     ```

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -388,7 +388,7 @@ def secret_write(args, ref_controller):
         ref_controller[tag] = ref_obj
 
     else:
-        fatal_error("Invalid token: {name}. Try using gpg/gkms/awskms:{name}".format(name=token_name))
+        fatal_error("Invalid token: {name}. Try using gpg/gkms/awskms/ref:{name}".format(name=token_name))
 
 
 def secret_update(args, ref_controller):

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -19,6 +19,7 @@
 from __future__ import print_function
 
 import argparse
+import base64
 import json
 import logging
 import os
@@ -34,7 +35,7 @@ from kapitan.version import PROJECT_NAME, DESCRIPTION, VERSION
 from kapitan.lint import start_lint
 from kapitan.initialiser import initialise_skeleton
 
-from kapitan.refs.base import RefController, Revealer
+from kapitan.refs.base import RefController, Revealer, Ref
 from kapitan.refs.secrets.gpg import GPGSecret
 from kapitan.refs.secrets.gpg import lookup_fingerprints
 from kapitan.refs.secrets.gkms import GoogleKMSSecret
@@ -373,6 +374,19 @@ def secret_write(args, ref_controller):
         secret_obj = AWSKMSSecret(data, key, encode_base64=args.base64)
         tag = '?{{awskms:{}}}'.format(token_path)
         ref_controller[tag] = secret_obj
+
+    elif token_name.startswith("ref:"):
+        type_name, token_path = token_name.split(":")
+        _data = data.encode()
+        encoding = 'original'
+        if args.base64:
+            _data = base64.b64encode(_data).decode()
+            _data = _data.encode()
+            encoding = 'base64'
+        ref_obj = Ref(_data, encoding=encoding)
+        tag = '?{{ref:{}}}'.format(token_path)
+        ref_controller[tag] = ref_obj
+
     else:
         fatal_error("Invalid token: {name}. Try using gpg/gkms/awskms:{name}".format(name=token_name))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,6 +197,71 @@ class CliFuncsTest(unittest.TestCase):
 
         os.remove(test_tag_file)
 
+    def test_cli_secret_write_ref(self):
+        """
+        run $ kapitan secrets --write ref:test_secret
+        and $ kapitan secrets --reveal -f sometest_file
+        """
+        test_secret_content = "secret_value!"
+        test_secret_file = tempfile.mktemp()
+        with open(test_secret_file, "w") as fp:
+            fp.write(test_secret_content)
+
+        sys.argv = ["kapitan", "secrets", "--write", "ref:test_secret",
+                    "-f", test_secret_file,
+                    "--secrets-path", SECRETS_PATH]
+        main()
+
+        test_tag_content = "revealing: ?{ref:test_secret}"
+        test_tag_file = tempfile.mktemp()
+        with open(test_tag_file, "w") as fp:
+            fp.write(test_tag_content)
+        sys.argv = ["kapitan", "secrets", "--reveal",
+                    "-f", test_tag_file,
+                    "--secrets-path", SECRETS_PATH]
+
+        # set stdout as string
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            main()
+        self.assertEqual("revealing: {}".format(test_secret_content),
+                         stdout.getvalue())
+
+        os.remove(test_tag_file)
+
+    def test_cli_secret_write_base64_ref(self):
+        """
+        run $ kapitan secrets --write ref:test_secret --base64
+        and $ kapitan secrets --reveal -f sometest_file
+        """
+        test_secret_content = "secret_value!"
+        test_secret_content_b64 = base64.b64encode(test_secret_content.encode())
+        test_secret_file = tempfile.mktemp()
+        with open(test_secret_file, "w") as fp:
+            fp.write(test_secret_content)
+
+        sys.argv = ["kapitan", "secrets", "--write", "ref:test_secret",
+                    "--base64", "-f", test_secret_file,
+                    "--secrets-path", SECRETS_PATH]
+        main()
+
+        test_tag_content = "revealing: ?{ref:test_secret}"
+        test_tag_file = tempfile.mktemp()
+        with open(test_tag_file, "w") as fp:
+            fp.write(test_tag_content)
+        sys.argv = ["kapitan", "secrets", "--reveal",
+                    "-f", test_tag_file,
+                    "--secrets-path", SECRETS_PATH]
+
+        # set stdout as string
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            main()
+        self.assertEqual("revealing: {}".format(test_secret_content_b64.decode()),
+                         stdout.getvalue())
+
+        os.remove(test_tag_file)
+
     def test_cli_searchvar(self):
         """
         run $ kapitan searchvar mysql.replicas


### PR DESCRIPTION
Fixes issue #241 

Adds support for creating ref type secrets via command line:
```
$ kapitan secrets --write ref:my_password -f <(echo -n password123)
```
