### PR TITLE
Validate target name matches target yml file name

### DIFF
--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -360,10 +360,15 @@ def valid_target_obj(target_obj):
 
 
 def validate_matching_target_name(target_filename, target_obj, inventory_path):
-    """if target does not have a corresponding yaml file in *inventory_path*,
-    throws *InventoryError*
+    """Throws *InventoryError* if parameters.kapitan.vars.target is not set,
+    or target does not have a corresponding yaml file in *inventory_path*
     """
-    target_name = target_obj["vars"]["target"]
+    try:
+        target_name = target_obj["vars"]["target"]
+    except KeyError:
+        error_message = "Target missing: target \"{}\" is missing parameters.kapitan.vars.target\n" \
+                        "This parameter should be set to the target name"
+        raise InventoryError(error_message.format(target_filename))
 
     if target_filename != target_name:
         target_path = os.path.join(os.path.abspath(inventory_path), "targets")

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -269,7 +269,8 @@ def save_inv_cache(compile_path, targets):
 
 
 def load_target_inventory(inventory_path, targets):
-    """retuns a list of target objects from the inventory"""
+    """returns a list of target objects from the inventory.
+    """
     target_objs = []
     inv = inventory_reclass(inventory_path)
 
@@ -282,7 +283,7 @@ def load_target_inventory(inventory_path, targets):
     for target_name in targets_list:
         try:
             target_obj = inv['nodes'][target_name]['parameters']['kapitan']
-            valid_target_obj(target_obj)
+            validate_matching_target_name(target_name, target_obj, inventory_path)
             logger.debug("load_target_inventory: found valid kapitan target %s", target_name)
             target_objs.append(target_obj)
         except KeyError:
@@ -355,3 +356,17 @@ def valid_target_obj(target_obj):
     }
 
     return jsonschema.validate(target_obj, schema)
+
+
+def validate_matching_target_name(target_filename, target_obj, inventory_path):
+    """if target does not have a corresponding yaml file in *inventory_path*,
+    throws *InventoryError*
+    """
+    target_name = target_obj["vars"]["target"]
+
+    if target_filename != target_name:
+        target_path = os.path.join(os.path.abspath(inventory_path), "targets")
+
+        error_message = "Target \"{}\" is missing the corresponding yml file in {}\n" \
+                        "Target name should match the name of the target yml file in inventory"
+        raise InventoryError(error_message.format(target_name, target_path))

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -269,8 +269,7 @@ def save_inv_cache(compile_path, targets):
 
 
 def load_target_inventory(inventory_path, targets):
-    """returns a list of target objects from the inventory.
-    """
+    """returns a list of target objects from the inventory"""
     target_objs = []
     inv = inventory_reclass(inventory_path)
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -283,6 +283,7 @@ def load_target_inventory(inventory_path, targets):
     for target_name in targets_list:
         try:
             target_obj = inv['nodes'][target_name]['parameters']['kapitan']
+            valid_target_obj(target_obj)
             validate_matching_target_name(target_name, target_obj, inventory_path)
             logger.debug("load_target_inventory: found valid kapitan target %s", target_name)
             target_objs.append(target_obj)

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -363,6 +363,7 @@ def validate_matching_target_name(target_filename, target_obj, inventory_path):
     """Throws *InventoryError* if parameters.kapitan.vars.target is not set,
     or target does not have a corresponding yaml file in *inventory_path*
     """
+    logger.debug("validating target name matches the name of yml file%s", target_filename)
     try:
         target_name = target_obj["vars"]["target"]
     except KeyError:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -50,9 +50,7 @@ class CompileKubernetesTest(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
     def test_compile_not_matching_targets(self):
-        stdout_redirect = io.StringIO()
-        sys.stdout = stdout_redirect
-        with self.assertLogs(logger='kapitan.targets', level='ERROR') as cm:
+        with self.assertLogs(logger='kapitan.targets', level='ERROR') as cm, contextlib.redirect_stdout(io.StringIO()):
             # as of now, we cannot capture stdout with contextlib.redirect_stdout
             # since we only do logger.error(e) in targets.py before exiting
             with self.assertRaises(SystemExit) as ca:
@@ -67,8 +65,8 @@ class CompileKubernetesTest(unittest.TestCase):
                     # correct the filename again, even if assertion fails
                     if os.path.exists(unmatched_filename):
                         os.rename(src=unmatched_filename, dst=correct_filename)
-        error_message = "Target \"minikube-es\" is missing the corresponding yml file"
-        self.assertTrue(' '.join(cm.output).find(error_message) != -1)
+        error_message_substr = "is missing the corresponding yml file"
+        self.assertTrue(' '.join(cm.output).find(error_message_substr) != -1)
 
     def test_compile_vars_target_missing(self):
         inventory_path = "inventory"

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -24,6 +24,9 @@ import contextlib
 from kapitan.cli import main
 from kapitan.utils import directory_hash
 from kapitan.cached import reset_cache
+from kapitan.targets import validate_matching_target_name
+from kapitan.resources import inventory_reclass
+from kapitan.errors import InventoryError
 
 
 class CompileKubernetesTest(unittest.TestCase):
@@ -45,6 +48,41 @@ class CompileKubernetesTest(unittest.TestCase):
                 sys.argv = ["kapitan"]
                 main()
         self.assertEqual(cm.exception.code, 1)
+
+    def test_compile_not_matching_targets(self):
+        stdout_redirect = io.StringIO()
+        sys.stdout = stdout_redirect
+        with self.assertLogs(logger='kapitan.targets', level='ERROR') as cm:
+            # as of now, we cannot capture stdout with contextlib.redirect_stdout
+            # since we only do logger.error(e) in targets.py before exiting
+            with self.assertRaises(SystemExit) as ca:
+                unmatched_filename = "inventory/targets/minikube-es-fake.yml"
+                correct_filename = "inventory/targets/minikube-es.yml"
+                os.rename(src=correct_filename, dst=unmatched_filename)
+                sys.argv = ["kapitan", "compile"]
+
+                try:
+                    main()
+                finally:
+                    # correct the filename again, even if assertion fails
+                    if os.path.exists(unmatched_filename):
+                        os.rename(src=unmatched_filename, dst=correct_filename)
+        error_message = "Target \"minikube-es\" is missing the corresponding yml file"
+        self.assertTrue(' '.join(cm.output).find(error_message) != -1)
+
+    def test_compile_vars_target_missing(self):
+        inventory_path = "inventory"
+        target_filename = "minikube-es"
+        target_obj = inventory_reclass(inventory_path)['nodes'][target_filename]['parameters']['kapitan']
+        # delete vars.target
+        del target_obj["vars"]["target"]
+
+        with self.assertRaises(InventoryError) as ie:
+            validate_matching_target_name(target_filename, target_obj, inventory_path)
+
+        error_message = "Target missing: target \"{}\" is missing parameters.kapitan.vars.target\n" \
+                        "This parameter should be set to the target name"
+        self.assertTrue(error_message.format(target_filename), ie.exception.args[0])
 
     def tearDown(self):
         os.chdir(os.getcwd() + '/../../')


### PR DESCRIPTION
Fixes issue #203, #147 

Before compilation, validates whether each target name has a corresponding target yml file in inventory. Target name is derived from `vars.target`. Should this parameter not be set, the following error is given:

```
Target missing: target "<target_filename>" is missing parameters.kapitan.vars.target
This parameter should be set to the target name
```

If the target name does not match the file name, the following error message is provided:
```
Target "<target_name>" is missing the corresponding yml file in <abs_inventory_path>/targets
Target name should match the name of the target yml file in inventory
```
