### PR TITLE
Add yamllint in kapitan linter checks

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -24,24 +24,22 @@ import json
 import logging
 import os
 import sys
+
 import yaml
-
-from kapitan.utils import jsonnet_file, PrettyDumper, flatten_dict, searchvar
-from kapitan.utils import deep_get, from_dot_kapitan, check_version, fatal_error
-from kapitan.utils import search_target_token_paths
-from kapitan.targets import compile_targets
-from kapitan.resources import search_imports, resource_callbacks, inventory_reclass
-from kapitan.version import PROJECT_NAME, DESCRIPTION, VERSION
-from kapitan.lint import start_lint
-from kapitan.initialiser import initialise_skeleton
-
-from kapitan.refs.base import RefController, Revealer, Ref
-from kapitan.refs.secrets.gpg import GPGSecret
-from kapitan.refs.secrets.gpg import lookup_fingerprints
-from kapitan.refs.secrets.gkms import GoogleKMSSecret
-from kapitan.refs.secrets.awskms import AWSKMSSecret
-
 from kapitan.errors import KapitanError, RefHashMismatchError
+from kapitan.initialiser import initialise_skeleton
+from kapitan.lint import start_lint
+from kapitan.refs.base import Ref, RefController, Revealer
+from kapitan.refs.secrets.awskms import AWSKMSSecret
+from kapitan.refs.secrets.gkms import GoogleKMSSecret
+from kapitan.refs.secrets.gpg import GPGSecret, lookup_fingerprints
+from kapitan.resources import (inventory_reclass, resource_callbacks,
+                               search_imports)
+from kapitan.targets import compile_targets
+from kapitan.utils import (PrettyDumper, check_version, deep_get, fatal_error,
+                           flatten_dict, from_dot_kapitan, jsonnet_file,
+                           search_target_token_paths, searchvar)
+from kapitan.version import DESCRIPTION, PROJECT_NAME, VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -196,8 +194,13 @@ def main():
                              action='store_true',
                              help='exit with failure code if warnings exist, default is False')
     lint_parser.add_argument('--skip-class-checks',
+                             action='store_true',
                              help='skip checking for unused classes, default is False',
                              default=from_dot_kapitan('lint', 'skip-class-checks', False))
+    lint_parser.add_argument('--skip-yamllint',
+                             action='store_true',
+                             help='skip running yamllint on inventory, default is False',
+                             default=from_dot_kapitan('lint', 'skip-yamllint', False))
     lint_parser.add_argument('--search-secrets',
                              default=from_dot_kapitan('lint', 'search-secrets', False),
                              action='store_true',
@@ -292,7 +295,7 @@ def main():
         searchvar(args.searchvar, args.inventory_path, args.pretty_print)
 
     elif cmd == 'lint':
-        start_lint(args.fail_on_warning, args.skip_class_checks, args.inventory_path, args.search_secrets, args.secrets_path, args.compiled_path)
+        start_lint(args.fail_on_warning, args.skip_class_checks, args.skip_yamllint, args.inventory_path, args.search_secrets, args.secrets_path, args.compiled_path)
 
     elif cmd == 'init':
         initialise_skeleton(args.directory)

--- a/kapitan/lint.py
+++ b/kapitan/lint.py
@@ -21,17 +21,46 @@ import os
 import sys
 from pprint import pformat
 
-from kapitan.utils import list_all_paths
 from kapitan.errors import KapitanError
+from kapitan.utils import list_all_paths
+from yamllint import linter
+from yamllint.config import YamlLintConfig
 
 logger = logging.getLogger(__name__)
 
+yamllint_config = """
+# https://yamllint.readthedocs.io/en/stable/rules.html
+rules:
+  braces: enable
+  brackets: enable
+  colons: disable
+  commas: disable
+  comments: disable
+  comments-indentation: disable
+  document-end: disable
+  document-start: disable
+  empty-lines: disable
+  empty-values: enable
+  hyphens: enable
+  indentation: disable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: enable
+  quoted-strings: disable
+  trailing-spaces: disable
+  truthy: disable
+"""
 
-def start_lint(fail_on_warning, skip_class_checks, inventory_path, search_secrets, secrets_path, compiled_path):
+
+def start_lint(fail_on_warning, skip_class_checks, skip_yamllint, inventory_path, search_secrets, secrets_path, compiled_path):
     """ Runs all lint operations available
     Args:
         fail_on_warning (bool): if set to True, function will exit if any warning is found
         skip_class_checks (bool): whether to skip checking for class related warnings or not
+        skip_yamllint (bool): whether to skip checking yaml files for lint problems
         inventory_path (string): path to your inventory/ folder
         search_secrets (bool): whether to search for secret related warnings or not
         secrets_path (string): path to your secrets/ folder
@@ -39,9 +68,19 @@ def start_lint(fail_on_warning, skip_class_checks, inventory_path, search_secret
     Yields:
         checks_sum (int): the number of lint warnings found
     """
-    if skip_class_checks and not search_secrets:
+    if skip_class_checks and skip_yamllint and not search_secrets:
         logger.info("Nothing to check. Remove --skip-class-checks or add --search-secrets to lint secrets")
         sys.exit(1)
+    
+    status_yamllint = 0
+    if not skip_yamllint:
+        if not os.path.isdir(inventory_path):
+            logger.info(
+                "\nInventory path is invalid or not provided, skipping class checks\n")
+        else:
+            logger.info("\nRunning yamllint on all inventory files...\n")
+            status_yamllint = lint_yamllint(inventory_path)
+
 
     status_class_checks = 0
     if not skip_class_checks:
@@ -56,7 +95,7 @@ def start_lint(fail_on_warning, skip_class_checks, inventory_path, search_secret
         logger.info("\nChecking for orphan secrets files...\n")
         status_secrets = lint_orphan_secrets(compiled_path, secrets_path)
 
-    checks_sum = status_secrets + status_class_checks
+    checks_sum = status_secrets + status_class_checks + status_yamllint
     if fail_on_warning and checks_sum > 0:
         sys.exit(1)
 
@@ -146,5 +185,42 @@ def lint_unused_classes(inventory_path):
     checks_sum = len(class_paths)
     if checks_sum > 0:
         logger.info("No usage found for the following {} classes:\n{}\n".format(len(class_paths), pformat(class_paths)))
+
+    return checks_sum
+
+def lint_yamllint(inventory_path):
+    """ Run yamllint on all yaml files in inventory
+    Args:
+        inventory_path (string): path to your inventory/ folder
+    Yields:
+        checks_sum (int): the number of yaml lint issues found
+    """
+    logger.debug("Running yamllint for " + inventory_path)
+    
+    checks_sum = 0
+    for path in list_all_paths(inventory_path):
+        if os.path.isfile(path) and (path.endswith(".yml") or path.endswith(".yaml")):
+            with open(path, "r") as yaml_file:
+                file_contents = yaml_file.read()
+
+                if os.path.isfile('.yamllint'):
+                    conf = YamlLintConfig(file='.yamllint')
+                else:
+                    conf = YamlLintConfig(yamllint_config)
+
+                try:
+                    problems = list(linter.run(file_contents, conf))
+                except EnvironmentError as e:
+                    logger.error(e)
+                    sys.exit(-1)
+  
+                if len(problems) > 0:
+                    checks_sum += len(problems)
+                    logger.info("File {} has the following issues:\n".format(path))
+                    for problem in problems:
+                        logger.info("\t{}".format(problem))
+
+    if checks_sum > 0:
+        logger.info("\nTotal yamllint issues found: {}".format(checks_sum))
 
     return checks_sum

--- a/kapitan/lint.py
+++ b/kapitan/lint.py
@@ -76,7 +76,7 @@ def start_lint(fail_on_warning, skip_class_checks, skip_yamllint, inventory_path
     if not skip_yamllint:
         if not os.path.isdir(inventory_path):
             logger.info(
-                "\nInventory path is invalid or not provided, skipping class checks\n")
+                "\nInventory path is invalid or not provided, skipping yamllint checks\n")
         else:
             logger.info("\nRunning yamllint on all inventory files...\n")
             status_yamllint = lint_yamllint(inventory_path)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,6 @@ google-api-python-client==1.7.8
 boto3==1.9.68
 requests>=2.20.1
 addict==2.2.0
-
+yamllint>=1.15.0
 # Reclass dependencies
 pyparsing

--- a/tests/test_linter.py
+++ b/tests/test_linter.py
@@ -27,11 +27,12 @@ logger = logging.getLogger(__name__)
 
 class LinterTest(unittest.TestCase):
     def test_lint(self):
-        output = start_lint(fail_on_warning=False,
+        num_issues_found = start_lint(fail_on_warning=False,
                             skip_class_checks=False,
+                            skip_yamllint=False,
                             inventory_path="./tests/test_resources/inventory",
                             search_secrets=True,
                             secrets_path="./tests/test_resources/secrets",
                             compiled_path="./tests/test_resources/compiled")
-        desired_output = 2
-        self.assertEqual(output, desired_output)
+        desired_output = 3
+        self.assertEqual(num_issues_found, desired_output)

--- a/tests/test_resources/inventory/classes/component/mysql.yml
+++ b/tests/test_resources/inventory/classes/component/mysql.yml
@@ -29,3 +29,4 @@ parameters:
         # Generates the sha256 checksum of the previously declared B64'ed password
         # It's base64'ed again so that it can be used in kubernetes secrets 
         password_sha256: ?{gpg:mysql/root/password_sha256|reveal:mysql/root/password|sha256|base64}
+    storage: 20G # should trigger yamllint error


### PR DESCRIPTION
Adds a yaml lint check for every file in a given inventory to help debug yaml issues.
Uses a very relaxed yamllint config by default but can be overriden with the rules in a local '.yamlllint' file if that file exists.

Rules taken from https://yamllint.readthedocs.io/en/stable/rules.html
 