### PR TITLE
Update reclass and addict dependencies, start 0.23.1-rc.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.23.1-rc.0:
+- Add parseYaml function in jsonnet (#263)
+- Add support for specifying custom jinja2 filters (#267)
+- Update reclass (1.6.0) and other minor dependencies (#283)
+
 ## 0.23.0:
 - Add support for writing ref type secrets in cli (#242)
 - Validate target name matches target yml file name (#243)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,9 @@ python-gnupg==0.4.4
 six>=1.12.0
 cryptography>=2.6.1
 google-api-python-client==1.7.8
-boto3==1.9.120
+boto3==1.9.138
 requests>=2.21.0
-addict==2.2.0
+addict==2.2.1
 yamllint>=1.15.0
 # Reclass dependencies
 pyparsing


### PR DESCRIPTION
We haven't done an rc release in a while and it's good to keep a candidate release out there before actually releasing an update. 