### PR TITLE
Make jsonnet & Kadet support for plain text output_type

### DIFF
--- a/examples/docker/compiled/docker/jsonnet/Dockerfile.web
+++ b/examples/docker/compiled/docker/jsonnet/Dockerfile.web
@@ -1,0 +1,4 @@
+FROM amazoncorretto:11
+COPY target/blah.jar /app/blah.jar
+EXPOSE ${PORT}
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/examples/docker/compiled/docker/jsonnet/Dockerfile.worker
+++ b/examples/docker/compiled/docker/jsonnet/Dockerfile.worker
@@ -1,0 +1,3 @@
+FROM amazoncorretto:8
+COPY target/blah.jar /app/blah.jar
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/examples/docker/compiled/docker/kadet/Dockerfile.web
+++ b/examples/docker/compiled/docker/kadet/Dockerfile.web
@@ -1,0 +1,4 @@
+FROM amazoncorretto:11
+COPY target/blah.jar /app/blah.jar
+EXPOSE ${PORT}
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/examples/docker/compiled/docker/kadet/Dockerfile.worker
+++ b/examples/docker/compiled/docker/kadet/Dockerfile.worker
@@ -1,0 +1,3 @@
+FROM amazoncorretto:8
+COPY target/blah.jar /app/blah.jar
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/examples/docker/components/jsonnet/jsonnet.jsonnet
+++ b/examples/docker/components/jsonnet/jsonnet.jsonnet
@@ -1,0 +1,7 @@
+local kap = import "lib/kapitan.libjsonnet";
+local inventory = kap.inventory();
+
+{
+  ['Dockerfile.' + file.name]: kap.jinja2_template("templates/Dockerfile", file)
+  for file in inventory.parameters.dockerfiles
+}

--- a/examples/docker/components/kadet/__init__.py
+++ b/examples/docker/components/kadet/__init__.py
@@ -1,0 +1,14 @@
+import os
+import json
+from kapitan.resources import jinja2_render_file
+from kapitan.inputs import kadet
+inventory = kadet.inventory()
+
+
+def main():
+    path = os.path.dirname(__file__) + '/../../templates'
+    output = kadet.BaseObj()
+    for file in inventory.parameters.dockerfiles:
+        contents = jinja2_render_file([path], 'Dockerfile', json.dumps(file))
+        output.root['Dockerfile.' + file.name] = contents
+    return output

--- a/examples/docker/inventory/classes/dockerfiles.yml
+++ b/examples/docker/inventory/classes/dockerfiles.yml
@@ -1,0 +1,15 @@
+parameters:
+  your_component:
+    some_parameter: true
+  kapitan:
+    compile:
+      - output_path: jsonnet
+        input_type: jsonnet
+        output_type: plain
+        input_paths:
+          - components/jsonnet/jsonnet.jsonnet
+      - output_path: kadet
+        input_type: kadet
+        output_type: plain
+        input_paths:
+          - components/kadet

--- a/examples/docker/inventory/targets/docker.yml
+++ b/examples/docker/inventory/targets/docker.yml
@@ -1,0 +1,11 @@
+classes:
+  - dockerfiles
+parameters:
+  kapitan:
+    vars:
+      target: docker
+  dockerfiles:
+    - name: web
+      image: amazoncorretto:11
+    - name: worker
+      image: amazoncorretto:8

--- a/examples/docker/templates/Dockerfile
+++ b/examples/docker/templates/Dockerfile
@@ -1,0 +1,6 @@
+FROM {{image}}
+COPY target/blah.jar /app/blah.jar
+{% if 'web' == name %}
+EXPOSE ${PORT}
+{% endif %}
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/kapitan/inputs/jsonnet.py
+++ b/kapitan/inputs/jsonnet.py
@@ -70,8 +70,13 @@ class Jsonnet(InputType):
                 with CompiledFile(file_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name,
                                   indent=indent) as fp:
                     fp.write_yaml(item_value)
+            elif output == 'plain':
+                file_path = os.path.join(compile_path, '%s' % item_key)
+                with CompiledFile(file_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name,
+                                  indent=indent) as fp:
+                    fp.write(item_value)
             else:
-                raise ValueError('output is neither "json" or "yaml"')
+                raise ValueError('output is neither "json", "yaml" or "plain"')
 
     def default_output_type(self):
         return "yaml"

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -123,8 +123,13 @@ class Kadet(InputType):
                 with CompiledFile(file_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name,
                                   indent=indent) as fp:
                     fp.write_yaml(item_value)
+            elif output == 'plain':
+              file_path = os.path.join(compile_path, '%s' % item_key)
+              with CompiledFile(file_path, self.ref_controller, mode="w", reveal=reveal, target_name=target_name,
+                                indent=indent) as fp:
+                fp.write(item_value)
             else:
-                raise ValueError('output is neither "json" or "yaml"')
+                raise ValueError('output is neither "json", "yaml" or "plain"')
             logger.debug("Pruned output for: %s", file_path)
 
     def default_output_type(self):

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -102,3 +102,20 @@ class CompileTerraformTest(unittest.TestCase):
     def tearDown(self):
         os.chdir(os.getcwd() + '/../../')
         reset_cache()
+
+
+class PlainOutputTest(unittest.TestCase):
+    def setUp(self):
+        os.chdir(os.getcwd() + '/examples/docker/')
+
+    def test_compile(self):
+        sys.argv = ["kapitan", "compile"]
+        main()
+        compiled_dir_hash = directory_hash(os.getcwd() + '/compiled')
+        test_compiled_dir_hash = directory_hash(
+            os.getcwd() + '/../../tests/test_docker_compiled')
+        self.assertEqual(compiled_dir_hash, test_compiled_dir_hash)
+
+    def tearDown(self):
+        os.chdir(os.getcwd() + '/../../')
+        reset_cache()

--- a/tests/test_docker_compiled/docker/jsonnet/Dockerfile.web
+++ b/tests/test_docker_compiled/docker/jsonnet/Dockerfile.web
@@ -1,0 +1,4 @@
+FROM amazoncorretto:11
+COPY target/blah.jar /app/blah.jar
+EXPOSE ${PORT}
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/tests/test_docker_compiled/docker/jsonnet/Dockerfile.worker
+++ b/tests/test_docker_compiled/docker/jsonnet/Dockerfile.worker
@@ -1,0 +1,3 @@
+FROM amazoncorretto:8
+COPY target/blah.jar /app/blah.jar
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/tests/test_docker_compiled/docker/kadet/Dockerfile.web
+++ b/tests/test_docker_compiled/docker/kadet/Dockerfile.web
@@ -1,0 +1,4 @@
+FROM amazoncorretto:11
+COPY target/blah.jar /app/blah.jar
+EXPOSE ${PORT}
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]

--- a/tests/test_docker_compiled/docker/kadet/Dockerfile.worker
+++ b/tests/test_docker_compiled/docker/kadet/Dockerfile.worker
@@ -1,0 +1,3 @@
+FROM amazoncorretto:8
+COPY target/blah.jar /app/blah.jar
+ENTRYPOINT ["java", "-jar", "/app/blah.jar"]


### PR DESCRIPTION
This adds support for...
```yaml
      - input_type: jsonnet
        output_type: plain
```

...and...

```yaml
      - input_type: kadet
        output_type: plain
```

...as per discussion in [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3/p1557149564137100).