### PR TITLE
Fix requests version to circumvent urllib3 version conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ six>=1.12.0
 cryptography>=2.6.1
 google-api-python-client==1.7.8
 boto3==1.9.138
-requests>=2.21.0
+requests==2.21.0
 addict==2.2.1
 yamllint>=1.15.0
 # Reclass dependencies


### PR DESCRIPTION
Fixes issue #295 

requests module update from 2.21.0 to 2.22.0 is breaking the test. For the time being, it makes sense to fix it at 2.21.0.