### PR TITLE
Multi-document yaml outputs

### DIFF
--- a/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_app.yml
+++ b/examples/kubernetes/compiled/minikube-mysql/manifests/mysql_app.yml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+spec:
+  replicas: 1
+  serviceName: example-mysql
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: example-mysql
+    spec:
+      containers:
+        - args: []
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MYSQL_ROOT_PASSWORD
+                  name: example-mysql
+          image: mysql:latest
+          imagePullPolicy: Always
+          name: mysql
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts: []
+      imagePullSecrets: []
+      initContainers: []
+      volumes: []
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        annotations:
+          volume.beta.kubernetes.io/storage-class: standard
+        labels:
+          name: data
+        name: data
+        namespace: minikube-mysql
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10G
+---
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: ?{gpg:targets/minikube-mysql/mysql/password:ec3d54de}
+  MYSQL_ROOT_PASSWORD_SHA256: ?{gpg:targets/minikube-mysql/mysql/password_sha256:122d2732}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+spec:
+  clusterIP: None
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector:
+    name: example-mysql
+  type: ClusterIP

--- a/examples/kubernetes/components/mysql/main.jsonnet
+++ b/examples/kubernetes/components/mysql/main.jsonnet
@@ -9,9 +9,9 @@ local name = inv.parameters.mysql.instance_name;
 
 {
   local c = self,
+
   mysql_statefulset: statefulset.MySQLStatefulSet(name, self.mysql_secret),
   mysql_secret: secret.MySQLSecret(name),
-
 
   // The following is an example to show how you can use a simple json file
   // and simply inject variables from the inventory, a-la helm
@@ -21,4 +21,11 @@ local name = inv.parameters.mysql.instance_name;
   mysql_service_jsonnet: kube.Service(name + "-jsonnet") {
       target_pod:: c["mysql_statefulset"].spec.template,
       target_container_name:: "mysql"} { spec+: { clusterIP: "None" }},
+
+  // You can also put the manifests in a single file
+  mysql_app: [
+    $.mysql_statefulset,
+    $.mysql_secret,
+    headless_service
+  ],
 }

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -18,6 +18,7 @@ import logging
 import os
 import yaml
 import json
+import collections
 
 from kapitan.errors import CompileError, KapitanError
 from kapitan.refs.base import Revealer
@@ -111,7 +112,12 @@ class CompilingFile(object):
             self.revealer.reveal_obj(obj)
         else:
             self.revealer.compile_obj(obj, target_name=target_name)
-        yaml.dump(obj, stream=self.fp, indent=indent, Dumper=PrettyDumper, default_flow_style=False)
+
+        if isinstance(obj, collections.Mapping):
+            yaml.dump(obj, stream=self.fp, indent=indent, Dumper=PrettyDumper, default_flow_style=False)
+        else:
+            yaml.dump_all(obj, stream=self.fp, indent=indent, Dumper=PrettyDumper, default_flow_style=False)
+
         logger.debug("Wrote %s", self.fp.name)
 
     def write_json(self, obj):

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -192,9 +192,9 @@ class Revealer(object):
         if filename.endswith('.yml') or filename.endswith('.yaml'):
             logger.debug("Revealer: revealing yml file: %s", filename)
             with open(filename) as fp:
-                obj = yaml.load(fp, Loader=YamlLoader)
+                obj = yaml.load_all(fp, Loader=YamlLoader)
                 rev_obj = self.reveal_obj(obj)
-                return yaml.dump(rev_obj, Dumper=PrettyDumper, default_flow_style=False, explicit_start=True), 'yaml'
+                return yaml.dump_all(rev_obj, Dumper=PrettyDumper, default_flow_style=False, explicit_start=True), 'yaml'
         elif filename.endswith('.json'):
             logger.debug("Revealer: revealing json file: %s", filename)
             with open(filename) as fp:

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -192,7 +192,7 @@ class Revealer(object):
         if filename.endswith('.yml') or filename.endswith('.yaml'):
             logger.debug("Revealer: revealing yml file: %s", filename)
             with open(filename) as fp:
-                obj = yaml.load_all(fp, Loader=YamlLoader)
+                obj = [o for o in yaml.load_all(fp, Loader=YamlLoader)]
                 rev_obj = self.reveal_obj(obj)
                 return yaml.dump_all(rev_obj, Dumper=PrettyDumper, default_flow_style=False, explicit_start=True), 'yaml'
         elif filename.endswith('.json'):

--- a/tests/test_kubernetes_compiled/minikube-mysql/manifests/mysql_app.yml
+++ b/tests/test_kubernetes_compiled/minikube-mysql/manifests/mysql_app.yml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  annotations: {}
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+spec:
+  replicas: 1
+  serviceName: example-mysql
+  template:
+    metadata:
+      annotations: {}
+      labels:
+        name: example-mysql
+    spec:
+      containers:
+        - args: []
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: MYSQL_ROOT_PASSWORD
+                  name: example-mysql
+          image: mysql:latest
+          imagePullPolicy: Always
+          name: mysql
+          ports:
+            - containerPort: 3306
+              name: mysql
+          volumeMounts: []
+      imagePullSecrets: []
+      initContainers: []
+      volumes: []
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        annotations:
+          volume.beta.kubernetes.io/storage-class: standard
+        labels:
+          name: data
+        name: data
+        namespace: minikube-mysql
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10G
+---
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: ?{gpg:targets/minikube-mysql/mysql/password:ec3d54de}
+  MYSQL_ROOT_PASSWORD_SHA256: ?{gpg:targets/minikube-mysql/mysql/password_sha256:122d2732}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+type: Opaque
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+spec:
+  clusterIP: None
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: mysql
+  selector:
+    name: example-mysql
+  type: ClusterIP


### PR DESCRIPTION
This way we can have a multi-document yaml file (see [this](https://pyyaml.org/wiki/PyYAMLDocumentation#dumping-yaml) for more info).

As an example, consider this jsonnet:
```jsonnet
{
  'foo': [
    {'a': 1}, {'a': 2}, {'a': 3}
  ]
}
```
Previously the output (when type=yaml) would be:
```yaml
- a: 1
- a: 2
- a: 3
```

With this change, it's:
```yaml
a: 1
---
a: 2
---
a: 3
```