### PR TITLE
Improve json schema validation error display for inventory

### DIFF
--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 "kapitan targets"
-
+import json
 import logging
 import os
 import shutil
@@ -420,7 +420,11 @@ def valid_target_obj(target_obj):
         "required": ["compile"],
     }
 
-    return jsonschema.validate(target_obj, schema, format_checker=jsonschema.FormatChecker())
+    try:
+        jsonschema.validate(target_obj, schema, format_checker=jsonschema.FormatChecker())
+    except jsonschema.exceptions.ValidationError as e:
+        raise InventoryError('Invalid inventory structure\n\nError: {}\nOn instance:\n{}'.
+                             format(e.message, json.dumps(e.instance, indent=2, sort_keys=False)))
 
 
 def validate_matching_target_name(target_filename, target_obj, inventory_path):


### PR DESCRIPTION
While doing #317 I noticed that ValidationError raised in `valid_target_obj(target_obj)` is treated as 
`Unknown (Non-Kapitan) Error ocurred`, with stacktrace printed, since it is not an instance of Kapitan Error. This PR changes the raised error to InventoryError to better handle it, as well as to make the error message more readable.

### Proposed Changes
say `output_path` was misspelt as `output_pth`.

#### Before:

```

Unknown (Non-Kapitan) Error occured
Traceback (most recent call last):
  File "/home/yoshi/.local/lib/python3.6/site-packages/kapitan/targets.py", line 69, in compile_targets
    target_objs = load_target_inventory(inventory_path, updated_targets)
  File "/home/yoshi/.local/lib/python3.6/site-packages/kapitan/targets.py", line 285, in load_target_inventory
    valid_target_obj(target_obj)
  File "/home/yoshi/.local/lib/python3.6/site-packages/kapitan/utils.py", line 78, in lru_decorator
    return cached_function(*_args, **_kwargs)
  File "/home/yoshi/.local/lib/python3.6/site-packages/kapitan/utils.py", line 70, in func_with_serialized_params
    return func(*_args, **_kwargs)
  File "/home/yoshi/.local/lib/python3.6/site-packages/kapitan/targets.py", line 357, in valid_target_obj
    return jsonschema.validate(target_obj, schema)
  File "/home/yoshi/.local/lib/python3.6/site-packages/jsonschema/validators.py", line 899, in validate
    raise error
jsonschema.exceptions.ValidationError: 'output_path' is a required property

Failed validating 'required' in schema['properties']['compile']['items']:
    {'minItems': 1,
     'properties': {'input_paths': {'type': 'array'},
                    'input_type': {'type': 'string'},
                    'output_path': {'type': 'string'},
                    'output_type': {'type': 'string'}},
     'required': ['input_type', 'input_paths', 'output_path'],
     'type': 'object'}

On instance['compile'][2]:
    {'input_paths': ['scripts'],
     'input_type': 'jinja2',
     'output_pth': 'scripts'}


'output_path' is a required property

Failed validating 'required' in schema['properties']['compile']['items']:
    {'minItems': 1,
     'properties': {'input_paths': {'type': 'array'},
                    'input_type': {'type': 'string'},
                    'output_path': {'type': 'string'},
                    'output_type': {'type': 'string'}},
     'required': ['input_type', 'input_paths', 'output_path'],
     'type': 'object'}

On instance['compile'][2]:
    {'input_paths': ['scripts'],
     'input_type': 'jinja2',
     'output_pth': 'scripts'}
```

#### After:

```
Invalid inventory structure

Error: 'output_path' is a required property
On instance:
{
  "input_paths": [
    "scripts"
  ],
  "input_type": "jinja2",
  "output_pth": "scripts"
}
```