### PR TITLE
Fix gh-pages domain, remove old jekyll config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,0 @@
-theme: jekyll-theme-cayman
-include: CONTRIBUTING.md

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+kapitan.dev


### PR DESCRIPTION
Docs have been deployed to gh-pages based on instructions from https://www.mkdocs.org/user-guide/deploying-your-docs/ 
This PR also removes the old _config.yml jekyll configuration and updates the CNAME of the custom domain for the gh page. 

Followup from #331 