### PR TITLE
Deduplicate README and add instructions for publishing to gh-pages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 build/
 dist/
 _site/
+site/
 kapitan.egg-info/
 tags
 .python-version

--- a/README.md
+++ b/README.md
@@ -13,22 +13,9 @@ Use Kapitan to manage your Kubernetes manifests, your documentation, your Terraf
 * **London Meetup Group** [London Kapitan Meetup](https://www.meetup.com/London-Kapitan-Meetup/)
 
 
-How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please look at our [FAQ](#faq)!
+How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please look at our [FAQ](https://kapitan.dev/#faq)!
 
 <img src="./docs/images/kapitan_logo.png" width="250">
-
-# Table of Contents
-
-* [Main Features](#main-features)
-* [Quickstart](#quickstart)
-* [Example](#example)
-* [Main concepts](#main-concepts)
-* [Documentation](#documentation)
-* [Kapitan feature proposals](#kapitan-feature-proposals)
-* [Contributing](#contributing)
-* [Credits](#credits)
-* [FAQ](#faq)
-* [Related projects](#related-projects)
 
 # Main Features
 
@@ -40,136 +27,17 @@ How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please lo
 
 # Quickstart
 
-#### Docker (recommended)
-
-```
-docker run -t --rm -v $(pwd):/src:delegated deepmind/kapitan -h
-```
-
-On Linux you can add `-u $(id -u)` to `docker run` to preserve file permissions.
-
-For CI/CD usage, check out [CI.md](./docs/CI.md)
-
-#### Pip
-
-Kapitan needs Python 3.6.
-
-**Install Python 3.6:**
-
- * Linux: `sudo apt-get update && sudo apt-get install -y python3.6-dev python3-pip python3-yaml`
- * Mac: `brew install python3 libyaml`
-
-**Install Kapitan:**
-
-User (`$HOME/.local/lib/python3.6/bin` on Linux or `$HOME/Library/Python/3.6/bin` on macOS):
-
-```shell
-pip3 install --user --upgrade kapitan
-```
-
-System-wide (not recommended):
-
-```shell
-sudo pip3 install --upgrade kapitan
-```
-
-# Example
-
-The example below _compiles_ 2 targets inside the `examples/kubernetes` folder.
-Each target represents a different namespace in a minikube cluster.
-
-These targets generate the following resources:
-
-* Kubernetes `Namespace` for the targets
-* Kubernetes `StatefulSet` for ElasticSearch Master node
-* Kubernetes `StatefulSet` for ElasticSearch Client node
-* Kubernetes `StatefulSet` for ElasticSearch Data node
-* Kubernetes `Service` to expose ElasticSearch discovery port
-* Kubernetes `Service` to expose ElasticSearch service port
-* Kubernetes `StatefulSet` for MySQL
-* Kubernetes `Service` to expose MySQL service port
-* Kubernetes `Secret` for MySQL credentials
-* Scripts to configure kubectl context to control the targets and helpers to apply/delete objects.
-* Documentation
-
-![demo](./docs/images/demo.gif)
-
-```shell
-$ cd examples/kubernetes
-
-$ kapitan compile
-Compiled minikube-mysql
-Compiled minikube-es
-```
-
-# Main concepts
-
-<img src="./docs/images/kapitan_overview.png" width="600">
-
-### Inventory
-
-Inventory is a hierarchical database of variables, defined in yaml files, that are passed to the targets during compilation. This will be explained in detail in the [inventory](docs/inventory.md) section of the documentation.
-
-### Components
-
-Components will receive the inventory values for each individual target, and gets rendered and saved into the `compiled` directory. 
-
-For example, a component could be an application that will be deployed to a kubernetes cluster. This includes all necessary kubernetes objects (StatefulSet, Services, ConfigMaps) defined in jsonnet or kadet. 
-
-It may also include scripts, config files and dynamically generated documentation defined using Jinja templates.
-
-The available component/template types and how to use them is discussed in the [compile operation](docs/compile.md) section of the documentation.
+See https://kapitan.dev/#quickstart
 
 # Documentation
 
-See https://kapitan.dev/
-
-# Kapitan feature proposals
-
-See [kapitan_proposals/](docs/kap_proposals/).
-
-# Contributing
-
-See [CONTRIBUTING.md](CONTRIBUTING.md).
+See https://kapitan.dev/ or `docs/README.md` in the source code.
 
 # Credits
 
 * [Jsonnet](https://github.com/google/jsonnet)
 * [Jinja2](http://jinja.pocoo.org/docs/2.9/)
 * [reclass](https://github.com/salt-formulas/reclass)
-
-# FAQ
-
-## Why do we prefer Kapitan to `Helm`?
-
-Before developing Kapitan, we turned to [`Helm`](https://github.com/kubernetes/helm) in an attempt to improve our old Jinja based templating system.
-
-We quickly discovered that `Helm` did not fit well with our workflow, for the following reasons (which were true at the time of the evaluation):
-* `Helm` uses Go templates to define Kubernetes (yaml) manifests. We were already unsatisfied by using Jinja and we did not see a huge improvement from our previous system, the main reason being: YAML files are not suitable to be managed by text templating frameworks.
-* `Helm` does not have a solution for sharing values across charts, if not through subcharts. We wanted to be able to have one single place to define all values for all our templates. Sharing data between charts felt awkward and complicated.
-* `Helm` is component/chart based. We wanted to have something that would treat all our deployments as a whole.
-* We did not fancy the dependency on the tiller.
-
-In short, we feel `Helm` is trying to be `apt-get` for Kubernetes charts, while we are trying to take you further than that.
-
-## Why do I need Kapitan?
-With Kapitan, we worked to de-compose several problems that most of the other solutions are treating as one.
-
-1) ***Kubernetes manifests***: We like the jsonnet approach of using json as the working language. Jsonnet allows us to use inheritance and composition, and hide complexity at higher levels.
-
-2) ***Configuration files***: Most solutions will assume this problem is solved somewhere else. We feel Jinja (or your template engine of choice) have the upper hand here.
-
-3) ***Hierarchical inventory***: This is the feature that sets us apart from other solutions. We use the inventory (based on [reclass](https://github.com/salt-formulas/reclass)) to define variables and properties that can be reused across different projects/deployments. This allows us to limit repetition, but also to define a nicer interface with developers (or CI tools) which will only need to understand YAML to operate changes.
-
-4) ***Secrets***: We manage most of our secrets with kapitan using the GPG, Google Cloud KMS and AWS KMS integrations. Keys can be setup per class, per target or shared so you can easily and flexibly manage access per environment. They can also be dynamically generated on compilation, if you don't feel like generating random passwords or RSA private keys, and they can be referenced in the inventory like any other variables. We have plans to support other providers such as Vault, in addition to GPG, Google Cloud KMS and AWS KMS.
-
-5) ***Canned scripts***: We treat scripts as text templates, so that we can craft pre-canned scripts for the specific target we are working on. This can be used for instance to define scripts that setup clusters, contexts or allow running kubectl with all the correct settings. Most other solutions require you to define contexts and call kubectl with the correct settings. We take care of that for you. Less ambiguity, less mistakes.
-
-6) ***Documentation***: We also use templates to create documentation for the targets we deploy. Documentation lived alongside everything else and it is treated as a first class citizen.
-We feel most other solutions are pushing the limits of their capacity in order to provide for the above problems.
-Helm treats everything as a text template, while jsonnet tries to do everything as json.
-We believe that these approaches can be blended in a powerful new way, glued together by the inventory.
-
 
 # Related projects
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,18 +17,6 @@ How is it different from [`Helm`](https://github.com/kubernetes/helm)? Please lo
 
 <img src="./images/kapitan_logo.png" width="250">
 
-## Table of Contents
-
-* [Main Features](#main-features)
-* [Quickstart](#quickstart)
-* [Example](#example)
-* [Documentation](#documentation)
-* [Kapitan feature proposals](#kapitan-feature-proposals)
-* [Contributing](#contributing)
-* [Credits](#credits)
-* [FAQ](#faq)
-* [Related projects](#related-projects)
-
 ## Main Features
 
 * Use the Inventory as the single source of truth to tie together deployments, resources and documentation. [based on reclass](https://github.com/salt-formulas/reclass)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -53,6 +53,26 @@ Try to fix warnings from `make codestyle` before submitting to make sure you adh
 - Once reviewed and merged, Travis will auto-release.
 - The merge has to happen with a merge commit not with squash/rebase so that the commit message still mentions `deepmind/release-v*` inside.
 
+## Updating gh-pages docs
+
+### Local testing
+
+```
+# from project root
+pip install mkdocs mkdocs-material pymdown-extensions markdown-include
+mkdocs build
+mkdocs serve
+# open http://127.0.0.1:8000
+```
+
+### Deploying to Github
+
+```
+# locally, on master branch (which has your updated docs)
+mkdocs gh-deploy -m "Commit message" -f ./mkdocs.yml -b remote_branch_name
+# after it's pushed, create a PR that targets the gh-pages branch
+```
+
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ theme: material
 use_directory_urls: true
 nav:
 - Home: README.md
+- Contributing: contributing.md
 - Getting started:
   - Kapitan Overview: kapitan_overview.md
   - Inventory: inventory.md


### PR DESCRIPTION
## Proposed Changes

  - Move Contributing.md to docs/ and link to it on the website
  - Ignore site/ in git since that's the compiled mkdocs output.
  - Cleanup README.md from duplicate info also included in docs/README.md
  - Remove unnecessary Table of Contents in docs/README.md since that's generated via mkdocs.yml automatically and will cause confusion if repeated.
  - Add instructions for doc local testing and deploying to github.