### PR TITLE
Fix dependency manager's behaviour for files to unpack

### DIFF
--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -5,9 +5,9 @@ import logging
 from distutils.dir_util import copy_tree
 from functools import partial
 from shutil import copyfile
-import requests
 import hashlib
 import tarfile
+import re
 from zipfile import ZipFile
 from git import Repo
 
@@ -28,10 +28,13 @@ def fetch_dependencies(target_objs, pool):
     """
     temp_dir = tempfile.mkdtemp()
     # there could be multiple dependency items per source_uri due to reclass inheritance or
-    # other user requirements. So create a mapping from source_uri to a list of dependencies with
+    # other user requirements. So create a mapping from source_uri to a set of dependencies with
     # that source_uri
     git_deps = defaultdict(list)
     http_deps = defaultdict(list)
+
+    # this dict is to make sure no duplicated output_paths exist per source
+    deps_output_paths = defaultdict(set)
     for target_obj in target_objs:
         try:
             dependencies = target_obj["dependencies"]
@@ -42,9 +45,17 @@ def fetch_dependencies(target_objs, pool):
                     # should only be used in test environment
                     item["output_path"] = os.path.join(DEPENDENCY_OUTPUT_CONFIG["root_dir"], item["output_path"])
                 output_path = item["output_path"]
-                if os.path.exists(os.path.abspath(output_path)):
+                if os.path.exists(os.path.abspath(output_path)) and not item.get('unpack', False):
+                    # if unpack: True, then allow the user to specify the parent directory as output_path where the
+                    # files will be extracted to
                     logger.info("Dependency {} : already exists. Ignoring".format(output_path))
                     continue
+
+                if output_path in deps_output_paths[source_uri]:
+                    # if the output_path is duplicated for the same source_uri
+                    continue
+                else:
+                    deps_output_paths[source_uri].add(output_path)
 
                 if dependency_type == "git":
                     git_deps[source_uri].append(item)
@@ -89,8 +100,6 @@ def fetch_git_dependency(dep_mapping, save_dir):
                 raise GitSubdirNotFoundError("Dependency {} : subdir {} not found in repo".format(source, sub_dir))
 
         if not os.path.exists(os.path.abspath(output_path)):
-            # output_path could exist if this dependency is duplicated by inheritance or otherwise.
-            # in such cases, simply skip the copy process
             copy_tree(copy_src_path, output_path)
             logger.info("Dependency {} : saved to {}".format(source, output_path))
 
@@ -113,23 +122,33 @@ def fetch_http_dependency(dep_mapping, save_dir):
     copy_src_path = os.path.join(save_dir, path_hash + os.path.basename(source))
     for dep in deps:
         output_path = dep["output_path"]
-        if not os.path.exists(output_path):
-            # output_path could exist if this dependency is duplicated by inheritance.
-            # in such cases, simply skip the copy
-            os.makedirs(os.path.dirname(output_path), exist_ok=True)
-            if dep.get('unpack', False):
-                if content_type == 'application/x-tar':
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        if dep.get('unpack', False):
+            is_unpacked = False
+            if content_type == 'application/x-tar':
+                tar = tarfile.open(copy_src_path)
+                tar.extractall(path=output_path)
+                tar.close()
+                is_unpacked = True
+            elif content_type == 'application/zip':
+                zfile = ZipFile(copy_src_path)
+                zfile.extractall(output_path)
+                zfile.close()
+                is_unpacked = True
+            elif content_type == 'application/octet-stream':
+                if re.search(r'(\.tar\.gz|\.tgz)$', source):
                     tar = tarfile.open(copy_src_path)
                     tar.extractall(path=output_path)
                     tar.close()
-                elif content_type == 'application/zip':
-                    zfile = ZipFile(copy_src_path)
-                    zfile.extractall(output_path)
-                    zfile.close()
-                else:
-                    logger.info("Dependency {} : Content-Type {} is not supported for unpack. Skipping").format(source, content_type)
+                    is_unpacked = True
+            if is_unpacked:
+                logger.info("Dependency {} : extracted to {}".format(source, output_path))
             else:
-                copyfile(copy_src_path, output_path)
+                logger.info("Dependency {} : Content-Type {} is not supported for unpack. Ignoring save".
+                            format(source, content_type))
+
+        else:
+            copyfile(copy_src_path, output_path)
             logger.info("Dependency {} : saved to {}".format(source, output_path))
 
 

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -62,13 +62,12 @@ class DependencyManagerTest(unittest.TestCase):
         self.assertTrue(os.path.isdir(os.path.join(output_dir, "subdir")))
 
     def test_compile_fetch(self):
-
         temp = tempfile.mkdtemp()
         DEPENDENCY_OUTPUT_CONFIG["root_dir"] = temp
         sys.argv = ["kapitan", "compile", "--fetch", "--output-path", temp, "-t", "nginx", "nginx-dev", "--fetch", "-p", "4"]
         main()
         self.assertTrue(os.path.isdir(os.path.join(temp, "components", "tests")))
-        self.assertTrue(os.path.isdir(os.path.join(temp, "components", "acs-engine-autoscaler-0.1.0")))
+        self.assertTrue(os.path.isdir(os.path.join(temp, "components", "acs-engine-autoscaler")))
         self.assertTrue(os.path.isdir(os.path.join(temp, "components", "kapitan-repository")))
         self.assertTrue(os.path.isdir(os.path.join(temp, "components", "source")))
 

--- a/tests/test_resources/inventory/targets/nginx-dev.yml
+++ b/tests/test_resources/inventory/targets/nginx-dev.yml
@@ -22,6 +22,6 @@ parameters:
         subdir: kapitan
         source: https://github.com/deepmind/kapitan.git
       - type: http
-        output_path: components/acs-engine-autoscaler-0.1.0
+        output_path: components/
         source: https://kubernetes-charts.storage.googleapis.com/acs-engine-autoscaler-0.1.0.tgz
         unpack: true


### PR DESCRIPTION
### background
We allow users to download `.zip`, `.tar.gz` files etc. and unpack them onto `output_path`. There are a few  issues with the way I implemented some of the stuff

### Proposed changes
1. we use the content-type in HTTP header to decide the file type to unpack. There are some files, such as the charts at `https://helm.nginx.com/stable/index.yaml` whose extensions are `.tgz` but the content-type is `application/octet-stream`. In such cases, we should just look at the extension using regex and decide how to unpack this file
2. when unpacking archive files, the parent directory should be allowed to be the `output_path` into which the files are extracted. For example, if we want to download a helm chart `nginx-ingress` then we should be able to do:

```yaml
- type: https
  source: https://helm.nginx.com/stable/nginx-ingress-0.3.3.tgz
  output_path: components/charts
  unpack: True
```
which stores the chart at `components/charts/nginx-ingress`. 
Basically the issue as of now is that the `.tgz` contains another root folder `nginx-ingress`, so if we specify `components/charts/nginx-ingress` as the `output_path` then it would end up as `components/charts/nginx-ingress/nginx-ingress`. 

