### PR TITLE
Remove skip_cleanup in travis, rename standalone binary to kapitan-linux-amd64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,9 @@ deploy:
   - provider: releases
     api_key:
       secure: VFZDeLYUZ/Fs+NTbIW7DjbANhqAtlbZTzsWods6MuSN3DmGibZwNBpHfNN/hCfJEBCKvmWBEzF2R14Pau+GMZAYaP0N0pCRuO8wtlXGe4ygc5bff4Y93BA98sTh/eRnLf+jsI+acliBWlm0WCRWDMsxfzhZTgWDO/IBdOrzwno5BqEeXbvsqe6MG9z3BLvp8t7WkI67NPoJfRGve7twb1VLMCLlRwXJwxefxgYHcH3pImhx4CMVjXKEMr4jQIMh+mlGA+aMhTAM/If2X3fhdbiA9KNNQ0FrZFLOw0iCLCYzaCHGm70eSMlXJr2kqEjzdZkR2J4TxnJqghTrnNVeXg917vtlFrTnJUxeOSQl3s3LOOQ0vM2wob8y+oPWYz7zw+KKqs8hA4crE7CngQmPGJvWQfYEGtW/5Zc9j+T/yplq5Zwqbe3ibsQ54V8jr6LU4IcLLXgT3qii13Zpg7pILQ+ObOge8c20EeUd6+HhBt9+5K0S67/GgSoa2Nd5+g4XgvEO95ncMZkWztNidk1ygVn00TLK5Dn8UHSaEoxlGXCfgVphzV1//MpOeJn67kQWxHvJxgqVfHAsbL2dlXMux/cuv+UQlRPQsw+8A18hpTUWcxRl7cLm9bMedW14CCtEmSWikanY/2lBEwFIjYndOu7v4VY4L3aNs6EsHrinoLVA=
-    skip_cleanup: true
     file:
       - CHANGELOG.md
-      - dist/kapitan
+      - dist/kapitan-linux-amd64
     prerelease: $PRERELEASE
     on:
       tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.24.0-rc.5:
+- Testing github release of standalone binary
+
 ## 0.24.0-rc.4:
 - Upgrade some packages in requirements.txt
 - Upgrade kapp and kbld to v0.11.0

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -7,7 +7,7 @@ set -e
 . /root/.bashrc
 
 entry='__main__'
-output_name='kapitan'
+output_name='kapitan-linux-amd64'
 pyi-makespec kapitan/"$entry".py --onefile \
     --add-data kapitan/reclass/reclass:reclass \
     --add-data kapitan/lib:kapitan/lib \


### PR DESCRIPTION
This fixes the build https://travis-ci.org/deepmind/kapitan/builds/575779357
which if I understand correctly failed to package kapitan for pypi because  of the previous resources on filesystem from the releases build step. 

Also rename standalone binary released to kapitan-linux-amd64 so it's more clear exactly what it is for. 