### PR TITLE
Attempt #3 to fix travis pypi deployment, bin/kapitan artifacts are moved to bindist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.bak
 build/
 dist/
+bindist/
 _site/
 site/
 kapitan.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
       secure: VFZDeLYUZ/Fs+NTbIW7DjbANhqAtlbZTzsWods6MuSN3DmGibZwNBpHfNN/hCfJEBCKvmWBEzF2R14Pau+GMZAYaP0N0pCRuO8wtlXGe4ygc5bff4Y93BA98sTh/eRnLf+jsI+acliBWlm0WCRWDMsxfzhZTgWDO/IBdOrzwno5BqEeXbvsqe6MG9z3BLvp8t7WkI67NPoJfRGve7twb1VLMCLlRwXJwxefxgYHcH3pImhx4CMVjXKEMr4jQIMh+mlGA+aMhTAM/If2X3fhdbiA9KNNQ0FrZFLOw0iCLCYzaCHGm70eSMlXJr2kqEjzdZkR2J4TxnJqghTrnNVeXg917vtlFrTnJUxeOSQl3s3LOOQ0vM2wob8y+oPWYz7zw+KKqs8hA4crE7CngQmPGJvWQfYEGtW/5Zc9j+T/yplq5Zwqbe3ibsQ54V8jr6LU4IcLLXgT3qii13Zpg7pILQ+ObOge8c20EeUd6+HhBt9+5K0S67/GgSoa2Nd5+g4XgvEO95ncMZkWztNidk1ygVn00TLK5Dn8UHSaEoxlGXCfgVphzV1//MpOeJn67kQWxHvJxgqVfHAsbL2dlXMux/cuv+UQlRPQsw+8A18hpTUWcxRl7cLm9bMedW14CCtEmSWikanY/2lBEwFIjYndOu7v4VY4L3aNs6EsHrinoLVA=
     file:
       - CHANGELOG.md
-      - dist/kapitan-linux-amd64
+      - bindist/kapitan-linux-amd64
     prerelease: $PRERELEASE
     on:
       tags: true

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ package:
 
 .PHONY: clean
 clean:
-	rm -rf dist/ build/ kapitan.egg-info/
+	rm -rf dist/ build/ kapitan.egg-info/ bindist/
 
 .PHONY: codestyle
 codestyle:

--- a/scripts/build-binary.sh
+++ b/scripts/build-binary.sh
@@ -4,4 +4,4 @@
 set -e
 IMAGE_NAME='pyinstaller-debian'
 docker build -t $IMAGE_NAME -f Dockerfile.pyinstaller .
-docker run -it -v $(pwd)/dist:/kapitan/dist $IMAGE_NAME
+docker run -it -v $(pwd)/bindist:/kapitan/dist $IMAGE_NAME

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -16,3 +16,7 @@ pyi-makespec kapitan/"$entry".py --onefile \
     --exclude-module doctest --exclude-module pydoc
 pyinstaller "$entry".spec --clean
 mv dist/$entry dist/$output_name
+# Open permissions so that when this binary
+# is used outside of docker (on the volume mount) it
+# also can be deleted by Travis CI
+chmod 777 dist/$output_name


### PR DESCRIPTION
In an effort to fix this https://github.com/deepmind/kapitan/issues/345 
I added dist/kapitan-linux-amd64 to the list of artifacts that will be uploaded in `.travis.yml`

The build fails with https://travis-ci.org/deepmind/kapitan/builds/575917567 
```
Deploying application
dist/kapitan-linux-amd64 already exists, no checkout
kapitan/__pycache__/__init__.cpython-37.pyc already exists, no checkout
kapitan/__pycache__/version.cpython-37.pyc already exists, no checkout
Could not restore untracked files from stash entry
PyPI upload failed.
failed to deploy
```
For which the dist/ binary stays there because of the `warning: failed to remove dist/kapitan-linux-amd64: Permission denied` error just above in the build error.

The other .pyc artifacts might be another thing that still should be cleaned after the build. 

Trying to see if this MR fixes anything
