### PR TITLE
Shift to debian image

### DIFF
--- a/kapitan/inputs/helm/__init__.py
+++ b/kapitan/inputs/helm/__init__.py
@@ -65,11 +65,15 @@ class Helm(InputType):
 
 def render_chart(chart_dir, output_path, **kwargs):
     """renders helm chart located at chart_dir, and stores the output to output_path"""
+    binding_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "libtemplate.so")
+    if not os.path.exists(binding_path):
+        raise HelmBindingUnavailableError("Helm binding is not available. Run 'make build_helm_binding' to create it")
     try:
         # lib is opened inside the function to allow multiprocessing
-        lib = ffi.dlopen(os.path.join(os.path.dirname(os.path.abspath(__file__)), "libtemplate.so"))
-    except (NameError, OSError):
-        raise HelmBindingUnavailableError("Helm binding is not available. Run 'make build_helm_binding' to create it")
+        lib = ffi.dlopen(binding_path)
+    except (NameError, OSError) as e:
+        raise HelmBindingUnavailableError('There was an error opening helm binding. '
+                                          'Refer to the exception below:\n' + str(e))
 
     if kwargs.get('helm_values_file', None):
         helm_values_file = ffi.new("char[]", kwargs['helm_values_file'].encode('ascii'))

--- a/kapitan/inputs/helm/build.sh
+++ b/kapitan/inputs/helm/build.sh
@@ -17,4 +17,4 @@ else
     echo "$so_name is missing. Exiting"
     exit 1
 fi
-python cffi_build.py
+python3 cffi_build.py


### PR DESCRIPTION
This PR serves more as a suggestion.

The Dockerfile in this PR is changed to `FROM python:3.7-slim-stretch`. This was chosen because it is one of the smaller debian images which have python 3.7 installed by default (the custom image is named as kapitan-debian below).

```
$ docker image ls
REPOSITORY           TAG                 IMAGE ID            CREATED             SIZE
kapitan-debian       latest              728041763c54        2 hours ago         1.04GB
deepmind/kapitan     latest              0670fbc69cde        4 days ago          860MB
python               3.7-alpine          39fb80313465        7 days ago          98.7MB
python               3.7-slim-stretch    7f8ea8958a02        7 days ago          155MB
```

I think the image size difference is not so bad (~ 160MB) given that musl-libc is going to be smaller than glibc to start with. 

So far the image is working just fine (tested with the examples folder, plus helm binding works as well). Got `decryption failed` error when using --reveal option but I also get that using `deepmind/kapitan` image so I may just be doing it wrongly.

If this is acceptable, we can move on to change the base image of `Dockerfile.ci` as well.