### PR TITLE
Add additional content type header for fetching GZIP files

### DIFF
--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -136,7 +136,7 @@ def fetch_http_dependency(dep_mapping, save_dir):
                 zfile.extractall(output_path)
                 zfile.close()
                 is_unpacked = True
-            elif content_type == 'application/octet-stream':
+            elif content_type in ['application/octet-stream', 'application/x-gzip']:
                 if re.search(r'(\.tar\.gz|\.tgz)$', source):
                     tar = tarfile.open(copy_src_path)
                     tar.extractall(path=output_path)

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -75,4 +75,3 @@ class DependencyManagerTest(unittest.TestCase):
     def tearDown(self):
         os.chdir('../../')
         reset_cache()
-


### PR DESCRIPTION
Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>

## Proposed Changes

* Adds an additional `Content-Type` header for fetching Tar GZip files over HTTP/S that is commonly set when the response body is not streamed.