### PR TITLE
support to create secrets on vault if file doesn't exist

### DIFF
--- a/kapitan/refs/secrets/vaultkv.py
+++ b/kapitan/refs/secrets/vaultkv.py
@@ -201,6 +201,12 @@ class VaultSecret(Base64Ref):
 
         return self._decrypt()
 
+    def create_secret(self,value):
+        """
+        Authenticate with vault & create the secret having <path>@<key>
+        equivalent of '$ vault kv put <path> <key>=<value>'
+        """
+
     def _decrypt(self):
         """
         Authenticate with Vault server & returns value of the key from secret


### PR DESCRIPTION
Fixes issue #105 
Current vaultkv secret backend works for read-only vault secrets, where creating a secret through kapitan isn't possible.
## Proposed Changes
  - Create secret on vault if the current user is authorised to do so
  - Automatic vaultkv secret creation using the similar syntax of subvar i.e. `?{vaultkv:path/on/vault@key|randstr}`
  - if the file exists, using the content of the file instead of creating new secrets
cc @ramaro 