### PR TITLE
Jsonschema function for jsonnet

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -118,6 +118,51 @@ gzip_b64 - returns base64 encoded gzip of obj
 inventory - returns a dictionary with the inventory for target
 jsonschema - validates obj with schema, returns object with 'valid' and 'reason' keys
 ```
+##### Jsonschema validation from jsonnet
+
+Given the follow example inventory:
+
+```
+mysql:
+  storage: 10G
+  storage_class: standard
+  image: mysql:latest
+```
+
+The yaml inventory structure can be validated with the new `jsonschema()` function:
+
+```
+local schema = {
+    type: "object",
+    properties: {
+        storage: { type: "string", pattern: "^[0-9]+[MGT]{1}$"},
+        image: { type: "string" },
+    }
+};
+// run jsonschema validation
+local validation = kap.jsonschema(inv.parameters.mysql, schema);
+// assert valid, otherwise error with validation.reason
+assert validation.valid: validation.reason;
+```
+
+If `validation.valid` is not true, it will then fail compilation and display `validation.reason`.
+
+For example, if defining the `storage` value with an invalid pattern (`10Z`), compile fails:
+
+```
+Jsonnet error: failed to compile /code/components/mysql/main.jsonnet:
+ RUNTIME ERROR: '10Z' does not match '^[0-9]+[MGT]{1}$'
+
+Failed validating 'pattern' in schema['properties']['storage']:
+    {'pattern': '^[0-9]+[MGT]{1}$', 'type': 'string'}
+
+On instance['storage']:
+    '10Z'
+
+/code/mysql/main.jsonnet:(19:1)-(43:2)
+
+Compile error: failed to compile target: minikube-mysql
+```
 
 ##### Jinja2 jsonnet templating
 

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -116,6 +116,7 @@ jinja2_template - renders the jinja2 file with context specified
 sha256_string - returns sha256 of string
 gzip_b64 - returns base64 encoded gzip of obj
 inventory - returns a dictionary with the inventory for target
+jsonschema - validates obj with schema, returns object with 'valid' and 'reason' keys
 ```
 
 ##### Jinja2 jsonnet templating

--- a/examples/kubernetes/components/mysql/main.jsonnet
+++ b/examples/kubernetes/components/mysql/main.jsonnet
@@ -7,6 +7,17 @@ local secret = import "./secret.jsonnet";
 
 local name = inv.parameters.mysql.instance_name;
 
+// sample jsonschema for mysql inventory parameters
+local schema = { type: "object",
+                 properties: {
+                   storage: { type: "string", pattern: "^[0-9]+[MGT]{1}$"},
+                   image: { type: "string" },
+                 }};
+// run jsonschema validation
+local validation = kap.jsonschema(inv.parameters.mysql, schema);
+// assert valid, otherwise error with validation.reason
+assert validation.valid: validation.reason;
+
 {
   local c = self,
 

--- a/kapitan/lib/kapitan.libjsonnet
+++ b/kapitan/lib/kapitan.libjsonnet
@@ -7,4 +7,5 @@
   yaml_dump(obj):: std.native("yaml_dump")(std.toString(obj)),
   sha256(obj):: std.native("sha256_string")(std.toString(obj)),
   gzip_b64(obj):: std.native("gzip_b64")(std.toString(obj)),
+  jsonschema(obj, schema_obj):: std.native("jsonschema_validate")(std.toString(obj), std.toString(schema_obj)),
 }


### PR DESCRIPTION
Introduces new `jsonschema` function in jsonnet.

It can be used to validate the inventory with jsonschema.

Given this inventory:

```yaml
mysql:                   
  storage: 10G           
  storage_class: standard
  image: mysql:latest    
```
The yaml inventory structure can be validated with the new `jsonschema()` function:

```jsonnet
local schema = { type: "object",
                 properties: {
                   storage: { type: "string", pattern: "^[0-9]+[MGT]{1}$"},
                   image: { type: "string" },
                 }};
// run jsonschema validation
local validation = kap.jsonschema(inv.parameters.mysql, schema);
// assert valid, otherwise error with validation.reason
assert validation.valid: validation.reason;
```

If `validation.valid` is not true, it will then fail compilation and display `validation.reason`.

For example, if defining the `storage` value with an invalid pattern (`10Z`), compile fails:

```
Jsonnet error: failed to compile /code/components/mysql/main.jsonnet:
 RUNTIME ERROR: '10Z' does not match '^[0-9]+[MGT]{1}$'

Failed validating 'pattern' in schema['properties']['storage']:
    {'pattern': '^[0-9]+[MGT]{1}$', 'type': 'string'}

On instance['storage']:
    '10Z'

/code/mysql/main.jsonnet:(19:1)-(43:2)

Compile error: failed to compile target: minikube-mysql
```



Partially fixes issue #346
