### PR TITLE
Fix issue #277: Change first '|' operator in secrets functions with '||'

### DIFF
--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -6,7 +6,7 @@ Inventory is a hierarchical database of variables that are passed to the targets
 
 By default, Kapitan will look for an `inventory/` directory to render the inventory from.
 
-There are 2 types of objects inside the inventory; [inventory classes](#inventory-classes) and [inventory targets](#inventory-targets). 
+There are 2 types of objects inside the inventory; [inventory classes](#inventory-classes) and [inventory targets](#inventory-targets).
 
 ### Inventory Classes
 
@@ -70,13 +70,13 @@ parameters:
     users:
       root:
         # If 'secrets/targets/${target_name}/mysql/password' doesn't exist, it will gen a random b64-encoded password
-        password: ?{gpg:targets/${target_name}/mysql/password|randomstr|base64}
-        # password: ?{gkms:targets/${target_name}/mysql/password|randomstr|base64}
-        # password: ?{awskms:targets/${target_name}/mysql/password|randomstr|base64}
+        password: ?{gpg:targets/${target_name}/mysql/password||randomstr|base64}
+        # password: ?{gkms:targets/${target_name}/mysql/password||randomstr|base64}
+        # password: ?{awskms:targets/${target_name}/mysql/password||randomstr|base64}
 
         # Generates the sha256 checksum of the previously declared B64'ed password
         # It's base64'ed again so that it can be used in kubernetes secrets
-        password_sha256: ?{gpg:targets/${target_name}/mysql/password_sha256|reveal:targets/${target_name}/mysql/password|sha256|base64}
+        password_sha256: ?{gpg:targets/${target_name}/mysql/password_sha256||reveal:targets/${target_name}/mysql/password|sha256|base64}
   kapitan:
     compile:
     - output_path: manifests
@@ -118,7 +118,7 @@ parameters:
     replicas: 2
 ```
 
-Targets can also be defined inside the `inventory`. 
+Targets can also be defined inside the `inventory`.
 
 **Note**: Each target must contain the property `parameters.kapitan.vars.target` whose value equals to the name of the target file. For example, for the target `inventory/targets/minikube-es.yml`, the rendered inventory must contain:
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -13,9 +13,9 @@ If you want to get started with secrets but don't have a GPG or KMS setup, you c
 
 The usual flow of creating and using an encrypted secret with kapitan is:
 
-#### 1. Define your GPG recipients, Vault client parameters or KMS key 
+#### 1. Define your GPG recipients, Vault client parameters or KMS key
 
-This is done in the inventory under `parameters.kapitan.secrets`. 
+This is done in the inventory under `parameters.kapitan.secrets`.
 
 Just like any other inventory parameters, this can be inherited from a common class or defined per target. For example, `common.yml` may contain:
 
@@ -62,14 +62,15 @@ Kapitan will inherit the secrets configuration for the specified target, and enc
 When referencing your secret in the inventory during compile, you can use the following functions to automatically generate, encrypt and save your secret:
 
 ```
-randomstr - Generates a random string. You can optionally pass the length you want i.e. `|randomstr:32`
-base64 - base64 encodes your secret; to be used as a secondary function i.e. `|randomstr|base64`
-sha256 - sha256 hashes your secret; to be used as a secondary function i.e. `|randomstr|sha256`. You can optionally pass a salt i.e `|randomstr|sha256:salt` -> becomes `sha256("salt:<generated random string>")`
-reveal - Decrypts a secret; to be used as a secondary function, useful for reuse of a secret like for different encodings i.e `|reveal:path/to/secret|base64`
-rsa - Generates an RSA 4096 private key (PKCS#8). You can optionally pass the key size i.e. `|rsa:2048`
-rsapublic - Derives an RSA public key from a revealed private key i.e. `|reveal:path/to/encrypted_private_key|rsapublic`
+randomstr - Generates a random string. You can optionally pass the length you want i.e. `||randomstr:32`
+base64 - base64 encodes your secret; to be used as a secondary function i.e. `||randomstr|base64`
+sha256 - sha256 hashes your secret; to be used as a secondary function i.e. `||randomstr|sha256`. You can optionally pass a salt i.e `||randomstr|sha256:salt` -> becomes `sha256("salt:<generated random string>")`
+reveal - Decrypts a secret; to be used as a secondary function, useful for reuse of a secret like for different encodings i.e `||reveal:path/to/secret|base64`
+rsa - Generates an RSA 4096 private key (PKCS#8). You can optionally pass the key size i.e. `||rsa:2048`
+rsapublic - Derives an RSA public key from a revealed private key i.e. `||reveal:path/to/encrypted_private_key|rsapublic`
 ```
 
+*Note*: The first operator here `||` is more similar to a logical OR. If the secret file doesn't exist, kapitan will generate it and apply the functions after the `||`. If the secret file already exists, no functions will run.
 *Note*: If you use `|reveal:/path/secret`, when changing the `/path/secret` file make sure you also delete any secrets referencing `/path/secret` so kapitan can regenerate them.
 *Note*: `vaultkv` can't be used to generate secrets automatically for now, manually create the secret using the command line.
 
@@ -143,22 +144,22 @@ To reference `secret_foo`inside this file, you can specify it in the inventory a
 
 ### Vaultkv Secret Backend (Read Only) - Addons
 
-Considering a key-value pair like `my_key`:`my_secret` in the path `secret/foo/bar` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret use:  
+Considering a key-value pair like `my_key`:`my_secret` in the path `secret/foo/bar` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret use:
 
-```shell  
-$ echo "foo/bar:my_key"  | kapitan secrets --write vaultkv:path/to/secret_inside_kapitan -t <target_name> -f -  
-```  
+```shell
+$ echo "foo/bar:my_key"  | kapitan secrets --write vaultkv:path/to/secret_inside_kapitan -t <target_name> -f -
+```
 
 Parameters in the secret file are collected from the inventory of the target we gave from CLI `-t <target_name>`. If target isn't provided then kapitan will identify the variables from the environment when revealing secret.
 
-Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.  
-Extra parameters that can be defined in inventory are:  
-* `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`  
-* `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)  
-* `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)  
-Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.  
+Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.
+Extra parameters that can be defined in inventory are:
+* `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
+* `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)
+* `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)
+Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.
 
-```yaml  
+```yaml
 parameters:
   kapitan:
     secrets:

--- a/examples/kubernetes/inventory/classes/component/mysql.yml
+++ b/examples/kubernetes/inventory/classes/component/mysql.yml
@@ -38,13 +38,13 @@ parameters:
     users:
       root:
         # If 'secrets/targets/${target_name}/mysql/password' doesn't exist, it will gen a random b64-encoded password
-        password: ?{gpg:targets/${target_name}/mysql/password|randomstr|base64}
-        # password: ?{gkms:targets/${target_name}/mysql/password|randomstr|base64}
-        # password: ?{awskms:targets/${target_name}/mysql/password|randomstr|base64}
+        password: ?{gpg:targets/${target_name}/mysql/password||randomstr|base64}
+        # password: ?{gkms:targets/${target_name}/mysql/password||randomstr|base64}
+        # password: ?{awskms:targets/${target_name}/mysql/password||randomstr|base64}
 
         # Generates the sha256 checksum of the previously declared B64'ed password
         # It's base64'ed again so that it can be used in kubernetes secrets
-        password_sha256: ?{gpg:targets/${target_name}/mysql/password_sha256|reveal:targets/${target_name}/mysql/password|sha256|base64}
+        password_sha256: ?{gpg:targets/${target_name}/mysql/password_sha256||reveal:targets/${target_name}/mysql/password|sha256|base64}
 
         password_subvar: ?{gpg:targets/${target_name}/mysql/subvars@var1.password}
         password_sha256_subvar: ?{gpg:targets/${target_name}/mysql/subvars@var2.password_sha256}

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -19,14 +19,14 @@ import errno
 import hashlib
 import json
 import logging
+import os
 import re
 import sys
-import os
 from functools import lru_cache
-import yaml
 
-from kapitan.errors import RefFromFuncError, RefBackendError, RefError
-from kapitan.errors import RefHashMismatchError
+import yaml
+from kapitan.errors import (RefBackendError, RefError, RefFromFuncError,
+                            RefHashMismatchError)
 from kapitan.refs.functions import eval_func
 from kapitan.utils import PrettyDumper, list_all_paths
 
@@ -37,8 +37,8 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
-# e.g. ?{ref:my/secret/token} or ?{ref:my/secret/token|func:param1:param2}
-REF_TOKEN_TAG_PATTERN = r"(\?{([\w\:\.\-\/@]+)([\|\w\:\.\-\/]+)?=*})"
+# e.g. ?{ref:my/secret/token} or ?{ref:my/secret/token||func:param1:param2}
+REF_TOKEN_TAG_PATTERN = r"(\?{([\w\:\.\-\/@]+)([\|\|\w\:\.\-\/]+)?=*})"
 REF_TOKEN_SUBVAR_PATTERN = r"(@[\w\.\-\_]+)"
 
 
@@ -397,7 +397,7 @@ class RefController(object):
 
     def tag_type(self, tag):
         "returns ref type for tag"
-        # ?{ref:my/secret/token} or ?{ref:my/secret/token|func:param1:param2} or ?{ref:my/secret/token:deadbeef}
+        # ?{ref:my/secret/token} or ?{ref:my/secret/token||func:param1:param2} or ?{ref:my/secret/token:deadbeef}
         _, token, _ = self.tag_params(tag)
         return self.token_type(token)
 
@@ -468,8 +468,8 @@ class RefController(object):
         evals and updates context ctx for func_str
         returns evaluated ctx
         """
-        assert(func_str.startswith('|'))
-        funcs = func_str[1:].split('|')
+        assert(func_str.startswith('||'))
+        funcs = func_str[2:].split('|')
 
         for func in funcs:
             func_name, *func_params = func.strip().split(':')

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -17,15 +17,15 @@
 "gpg secrets tests"
 
 import os
-import unittest
 import tempfile
+import unittest
 
 import kapitan.cached as cached
-from kapitan.refs.base import RefController, RefParams, Revealer
-from kapitan.refs.secrets.gpg import gpg_obj, GPGSecret, GPG_KWARGS, GPG_TARGET_FINGERPRINTS
-
-from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from kapitan.refs.base import RefController, RefParams, Revealer
+from kapitan.refs.secrets.gpg import (GPG_KWARGS, GPG_TARGET_FINGERPRINTS,
+                                      GPGSecret, gpg_obj)
 
 # set GNUPGHOME for test_cli
 GNUPGHOME = tempfile.mkdtemp()
@@ -81,7 +81,7 @@ class GPGSecretsTest(unittest.TestCase):
     def test_gpg_function_rsa(self):
         "write rsa (private and public), confirm secret file exists, reveal and check"
 
-        tag = '?{gpg:secret/rsa|rsa}'
+        tag = '?{gpg:secret/rsa||rsa}'
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, 'secret/rsa')))
 
@@ -96,7 +96,7 @@ class GPGSecretsTest(unittest.TestCase):
 
         REVEALER._reveal_tag_without_subvar.cache_clear()
         # Test with parameter key_size=2048
-        tag = '?{gpg:secret/rsa|rsa:2048}'
+        tag = '?{gpg:secret/rsa||rsa:2048}'
         REF_CONTROLLER[tag] = RefParams()
         revealed = REVEALER.reveal_raw_file(file_with_secret_tags)
 
@@ -109,7 +109,7 @@ class GPGSecretsTest(unittest.TestCase):
         self.assertEqual(private_key.key_size, 2048)
 
         # Test rsapublic with previous private key as the parameter
-        tag_rsapublic = '?{gpg:secret/rsapublic|reveal:secret/rsa|rsapublic}'
+        tag_rsapublic = '?{gpg:secret/rsapublic||reveal:secret/rsa|rsapublic}'
         REF_CONTROLLER[tag_rsapublic] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, 'secret/rsa')))
 

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 import unittest
 
-from kapitan.errors import RefFromFuncError, RefHashMismatchError, RefError
+from kapitan.errors import RefError, RefFromFuncError, RefHashMismatchError
 from kapitan.refs.base import PlainRef, RefController, RefParams, Revealer
 from kapitan.refs.base64 import Base64Ref
 from kapitan.utils import get_entropy
@@ -104,11 +104,11 @@ class Base64RefsTest(unittest.TestCase):
 
     def test_base64_ref_tag_func_name(self):
         "check ref tag func name is correct"
-        tag = '?{base64:my/ref5|randomstr}'
+        tag = '?{base64:my/ref5||randomstr}'
         tag, token, func_str = REF_CONTROLLER.tag_params(tag)
-        self.assertEqual(tag, '?{base64:my/ref5|randomstr}')
+        self.assertEqual(tag, '?{base64:my/ref5||randomstr}')
         self.assertEqual(token, 'base64:my/ref5')
-        self.assertEqual(func_str, '|randomstr')
+        self.assertEqual(func_str, '||randomstr')
 
     def test_base64_ref_path(self):
         "check ref tag path is correct"
@@ -126,7 +126,7 @@ class Base64RefsTest(unittest.TestCase):
         check new ref tag with function raises RefFromFuncError
         and then creates it using RefParams()
         """
-        tag = '?{base64:my/ref7|randomstr}'
+        tag = '?{base64:my/ref7||randomstr}'
         with self.assertRaises(RefFromFuncError):
             REF_CONTROLLER[tag]
         try:
@@ -218,7 +218,7 @@ class Base64RefsTest(unittest.TestCase):
     def test_ref_function_randomstr(self):
         "write randomstr to secret, confirm ref file exists, reveal and check"
 
-        tag = '?{base64:ref/randomstr|randomstr}'
+        tag = '?{base64:ref/randomstr||randomstr}'
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, 'ref/base64')))
 
@@ -230,7 +230,7 @@ class Base64RefsTest(unittest.TestCase):
         self.assertTrue(get_entropy(revealed) > 4)
 
         # Test with parameter nbytes=16, correlating with string length 16
-        tag = '?{base64:ref/randomstr|randomstr:16}'
+        tag = '?{base64:ref/randomstr||randomstr:16}'
         REF_CONTROLLER[tag] = RefParams()
         REVEALER._reveal_tag_without_subvar.cache_clear()
         revealed = REVEALER.reveal_raw_file(file_with_tags)
@@ -239,7 +239,7 @@ class Base64RefsTest(unittest.TestCase):
     def test_ref_function_base64(self):
         "write randomstr to ref and base64, confirm ref file exists, reveal and check"
 
-        tag = '?{base64:ref/base64|randomstr|base64}'
+        tag = '?{base64:ref/base64||randomstr|base64}'
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, 'ref/base64')))
 
@@ -253,7 +253,7 @@ class Base64RefsTest(unittest.TestCase):
     def test_ref_function_sha256(self):
         "write randomstr to ref and sha256, confirm ref file exists, reveal and check"
 
-        tag = '?{base64:ref/sha256|randomstr|sha256}'
+        tag = '?{base64:ref/sha256||randomstr|sha256}'
         REF_CONTROLLER[tag] = RefParams()
         self.assertTrue(os.path.isfile(os.path.join(REFS_HOME, 'ref/sha256')))
 


### PR DESCRIPTION
Fixes issue #277 

## Proposed Changes

  - Replace the first occurence of '|' in refs/secrets to '||' for clarity.

This is a __breaking change__ and requires modifying all your refs/secrets.

Before:
`${<ref_type>:<file_path>:<hash_digest>|<func_str|func2|func3>}`

After: 
`${<ref_type>:<file_path>:<hash_digest>||<func_str|func2|func3>}`

Another example:

Before:
`?{gpg:targets/${target_name}/mysql/password|randomstr|base64}`

After:
`?{gpg:targets/${target_name}/mysql/password||randomstr|base64}`

