### PR TITLE
adding openssh-client explicitly as it is recommended by git package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR ${SEARCHPATH}
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         git \
+	openssh-client \
         gnupg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
apt-get ignores recommendations (--no-install-recommends flag) and git recommends ssh-client, so it is not installed, adding ssh-client or openssh-client (ssh-client is a virtual package) fixes it.

Reference: https://packages.ubuntu.com/xenial/git