### PR TITLE
adding ssh-client explicitly as it is only recommended by git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ WORKDIR ${SEARCHPATH}
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
         git \
+        ssh-client \
         gnupg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
apt-get ignores recommendations (--no-install-recommends flag) and git recommends ssh-client, so it is not installed, adding ssh-client fixes it.

Reference: https://packages.ubuntu.com/xenial/git