### PR TITLE
new yaml_dump_stream() native jsonnet function

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -111,6 +111,7 @@ In addition, importing `kapitan.libjsonnet` makes available the following native
 ```
 yaml_load - returns a json string of the specified yaml file
 yaml_dump - returns a string yaml from a json string
+yaml_dump_stream - returns a string yaml stream from a json string
 file_read - reads the file specified
 jinja2_template - renders the jinja2 file with context specified
 sha256_string - returns sha256 of string

--- a/kapitan/lib/kapitan.libjsonnet
+++ b/kapitan/lib/kapitan.libjsonnet
@@ -5,6 +5,7 @@
   inventory(target=std.extVar("target"), inv_path="inventory/"):: std.native("inventory")(target, inv_path),
   inventory_global(target=null, inv_path="inventory/"):: std.native("inventory")(target, inv_path),
   yaml_dump(obj):: std.native("yaml_dump")(std.toString(obj)),
+  yaml_dump_stream(obj):: std.native("yaml_dump_stream")(std.toString(obj)),
   sha256(obj):: std.native("sha256_string")(std.toString(obj)),
   gzip_b64(obj):: std.native("gzip_b64")(std.toString(obj)),
   jsonschema(obj, schema_obj):: std.native("jsonschema_validate")(std.toString(obj), std.toString(schema_obj)),

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -60,6 +60,7 @@ def resource_callbacks(search_paths):
             "sha256_string": (("obj",), sha256_string),
             "gzip_b64": (("obj",), gzip_b64),
             "yaml_dump": (("obj",), yaml_dump),
+            "yaml_dump_stream": (("obj",), yaml_dump_stream),
             "yaml_load": (("name",),
                           partial(yaml_load, search_paths)),
             "jsonschema_validate": (("obj", "schema_obj"), jsonschema_validate),
@@ -86,6 +87,12 @@ def yaml_dump(obj):
     """Dumps jsonnet obj as yaml"""
     _obj = json.loads(obj)
     return yaml.safe_dump(_obj, default_flow_style=False)
+
+
+def yaml_dump_stream(obj):
+    """Dumps jsonnet obj as yaml stream"""
+    _obj = json.loads(obj)
+    return yaml.safe_dump_all(_obj, default_flow_style=False)
 
 
 def gzip_b64(obj):

--- a/tests/test_jsonnet.py
+++ b/tests/test_jsonnet.py
@@ -21,7 +21,7 @@ import jsonschema
 import unittest
 import os
 
-from kapitan.resources import yaml_dump, gzip_b64, yaml_load, jsonschema_validate
+from kapitan.resources import yaml_dump, yaml_dump_stream, gzip_b64, yaml_load, jsonschema_validate
 from kapitan.utils import sha256_string, prune_empty
 
 
@@ -30,6 +30,11 @@ class JsonnetNativeFuncsTest(unittest.TestCase):
         """dump json string to yaml"""
         yaml = yaml_dump("{\"key\":\"value\"}")
         self.assertEqual(yaml, "key: value\n")
+
+    def test_yaml_dump_stream(self):
+        """dump json string to yaml"""
+        yaml = yaml_dump_stream("[{\"key\":\"value\"},{\"key\":\"value\"}]")
+        self.assertEqual(yaml, "key: value\n---\nkey: value\n")
 
     def test_yaml_load(self):
         """


### PR DESCRIPTION
Add a new yaml_dump_stream native jsonnet function
Similar to https://github.com/deepmind/kapitan/issues/404 but with dump instead of load.

## Proposed Changes
- Add a new yaml_dump_stream native jsonnet function able to dump a list of json objects into a yaml stream
