### PR TITLE
Copy - input that allows you to get your components plain unaltered to your compile targets

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -11,7 +11,7 @@ parameters:
   kapitan:
     compile:
     - output_path: <output_path_in_target_dir>
-      input_type: jinja | jsonnet | kadet | helm
+      input_type: jinja | jsonnet | kadet | helm | copy
       input_paths:
         - path/to/input/dir/or/file
         - globbed/path/*/main.jsonnet
@@ -26,6 +26,7 @@ Kapitan supports the following input template types:
 - [jsonnet](#jsonnet)
 - [kadet](#kadet) (alpha)
 - [helm](#helm) (alpha)
+- [copy](#copy)
 
 
 ### jinja
@@ -296,3 +297,10 @@ This requires Go >= 1.12.
 This binding supports helm subcharts. However, since the [external dependency manager](external_dependencies.md) does not parse `requirements.yaml` in order to detect chart dependencies, you are required to manually download the entire chart including the parent charts.
 
 *Supported output types:* N/A (no need to specify `output_type`)
+
+### Copy
+
+This input type simply copies the input templates to the output directory without any rendering/processing.
+For Copy, `input_paths` can be either a file or a directory: in case of a directory, all the templates in the directory will be copied and outputted to `output_path`.
+
+*Supported output types*: N/A (no need to specify `output_type`)

--- a/examples/kubernetes/compiled/busybox/copy/pod.yml
+++ b/examples/kubernetes/compiled/busybox/copy/pod.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always

--- a/examples/kubernetes/compiled/busybox/pre-deploy/00_namespace.yml
+++ b/examples/kubernetes/compiled/busybox/pre-deploy/00_namespace.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: busybox
+  name: busybox
+  namespace: busybox
+spec: {}

--- a/examples/kubernetes/compiled/busybox/pre-deploy/10_serviceaccount.yml
+++ b/examples/kubernetes/compiled/busybox/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: default
+  name: default
+  namespace: busybox

--- a/examples/kubernetes/compiled/minikube-es/copy/pod.yml
+++ b/examples/kubernetes/compiled/minikube-es/copy/pod.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always

--- a/examples/kubernetes/components/busybox/pod.yml
+++ b/examples/kubernetes/components/busybox/pod.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always

--- a/examples/kubernetes/inventory/classes/component/busybox.yml
+++ b/examples/kubernetes/inventory/classes/component/busybox.yml
@@ -1,0 +1,10 @@
+parameters:
+  kapitan:
+    vars:
+      target: ${target_name}
+      namespace: ${target_name}
+    compile:
+      - output_path: ./copy
+        input_type: copy
+        input_paths:
+          - components/busybox/pod.yml

--- a/examples/kubernetes/inventory/targets/busybox.yml
+++ b/examples/kubernetes/inventory/targets/busybox.yml
@@ -1,0 +1,6 @@
+classes: 
+  - common
+  - component.busybox
+
+parameters:
+  target_name: busybox

--- a/examples/kubernetes/inventory/targets/minikube-es.yml
+++ b/examples/kubernetes/inventory/targets/minikube-es.yml
@@ -2,6 +2,7 @@ classes:
   - common
   - cluster.minikube
   - component.elasticsearch
+  - component.busybox
 
 parameters:
   target_name: minikube-es

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import shutil
+
+from kapitan.inputs.base import InputType
+
+logger = logging.getLogger(__name__)
+
+
+class Copy(InputType):
+    def __init__(self, compile_path, search_paths, ref_controller):
+        super().__init__("copy", compile_path, search_paths, ref_controller)
+
+    def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
+        """
+        Write items in path as plain rendered files to compile_path.
+        path can be either a file or directory.
+        """
+
+        try:
+            logger.debug("Copying {} to {}.".format(file_path, compile_path))
+            if os.path.isfile(file_path):
+                if os.path.isfile(compile_path):
+                    shutil.copy2(file_path, compile_path)
+                else:
+                    os.makedirs(compile_path, exist_ok=True)
+                    shutil.copy2(file_path, os.path.join(
+                        compile_path, os.path.basename(file_path)))
+            else:
+                if os.path.exists(compile_path):
+                    shutil.rmtree(compile_path)
+                shutil.copytree(file_path, compile_path)
+        except OSError as e:
+            logger.exception("Input dir not copied. Error: {}".format(e))
+
+    def default_output_type(self):
+        # no output_type options for copy
+        return None

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -35,6 +35,7 @@ from kapitan.inputs.helm import Helm
 from kapitan.inputs.jinja2 import Jinja2
 from kapitan.inputs.jsonnet import Jsonnet
 from kapitan.inputs.kadet import Kadet
+from kapitan.inputs.copy import Copy
 from kapitan.resources import inventory_reclass
 from kapitan.utils import dictionary_hash, directory_hash, hashable_lru_cache
 from kapitan.validator.kubernetes_validator import (
@@ -359,6 +360,7 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, **kwa
     jsonnet_compiler = Jsonnet(compile_path, search_paths, ref_controller)
     kadet_compiler = Kadet(compile_path, search_paths, ref_controller)
     helm_compiler = Helm(compile_path, search_paths, ref_controller)
+    copy_compiler = Copy(compile_path, search_paths, ref_controller)
 
     for comp_obj in compile_objs:
         input_type = comp_obj["input_type"]
@@ -375,8 +377,10 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, **kwa
             if 'helm_params' in comp_obj:
                 helm_compiler.set_helm_params(comp_obj['helm_params'])
             input_compiler = helm_compiler
+        elif input_type == "copy":
+            input_compiler = copy_compiler
         else:
-            err_msg = "Invalid input_type: \"{}\". Supported input_types: jsonnet, jinja2, kadet, helm"
+            err_msg = "Invalid input_type: \"{}\". Supported input_types: jsonnet, jinja2, kadet, helm, copy"
             raise CompileError(err_msg.format(input_type))
 
         input_compiler.make_compile_dirs(target_name, output_path)
@@ -424,7 +428,7 @@ def valid_target_obj(target_obj):
                         {
                             "properties": {
                                 "input_type": {
-                                    "enum": ["jsonnet", "kadet"]
+                                    "enum": ["jsonnet", "kadet", "copy"]
                                 },
                                 "output_type": {
                                     "enum": ["yaml", "json", "plain"]

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"copy tests"
+import os
+import sys
+import shutil
+import hashlib
+import unittest
+
+from kapitan.cli import main
+from kapitan.utils import directory_hash
+from kapitan.inputs.copy import Copy
+
+
+search_path = ""
+ref_controller = ""
+test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_copy")
+compile_path = os.path.join(test_path, "output")
+file_path = os.path.join(test_path, "input")
+test_file_path = os.path.join(file_path, "test_copy_input")
+test_file_compiled_path = os.path.join(compile_path, "test_copy_input")
+test_file_content = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine
+  namespace: default
+spec:
+  containers:
+  - image: alpine:3.2
+    command:
+      - /bin/sh
+      - "-c"
+      - "sleep 60m"
+    imagePullPolicy: IfNotPresent
+    name: alpine
+  restartPolicy: Always
+"""
+
+
+def test_dirs_bootstrap_helper():
+    for folder in [file_path, compile_path]:
+        os.makedirs(folder, exist_ok=True)
+        with open(test_file_path, "w") as f:
+            f.write(test_file_content)
+
+
+class CopyTest(unittest.TestCase):
+
+    def setUp(self):
+        try:
+            shutil.rmtree(test_path)
+        except FileNotFoundError:
+            pass
+
+        self.copy_compiler = Copy(
+            compile_path, search_path, ref_controller)
+
+    def test_copy_file_folder(self):
+        test_dirs_bootstrap_helper()
+        self.copy_compiler.compile_file(
+            test_file_path, compile_path, None)
+        self.test_file_hash = hashlib.sha1(
+            test_file_content.encode()).digest()
+        with open(test_file_compiled_path) as f:
+            test_file_compiled_hash = hashlib.sha1(f.read().encode()).digest()
+            self.assertEqual(self.test_file_hash, test_file_compiled_hash)
+
+    def test_copy_folder_folder(self):
+        test_dirs_bootstrap_helper()
+        self.copy_compiler.compile_file(
+            file_path, compile_path, None)
+        file_path_hash = directory_hash(file_path)
+        compile_path_hash = directory_hash(compile_path)
+        self.assertEqual(file_path_hash, compile_path_hash)
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(test_path)
+        except FileNotFoundError:
+            pass
+
+
+class CompileCopyTest(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir(os.path.join(os.getcwd(), "examples", "kubernetes"))
+
+    def test_compiled_copy_target(self):
+        sys.argv = ["kapitan", "compile", "-t", "busybox"]
+        main()
+        file_path_hash = directory_hash(os.path.join("components", "busybox"))
+        compile_path_hash = directory_hash(os.path.join("compiled", "busybox", "copy"))
+        self.assertEqual(file_path_hash, compile_path_hash)
+
+    def test_compiled_copy_all_targets(self):
+        sys.argv = ["kapitan", "compile"]
+        main()
+        file_path_hash = directory_hash(os.path.join("components", "busybox"))
+        compile_path_hash = directory_hash(os.path.join("compiled", "busybox", "copy"))
+        self.assertEqual(file_path_hash, compile_path_hash)
+
+    def tearDown(self):
+        os.chdir(os.path.join(os.getcwd(), "..", ".."))

--- a/tests/test_kubernetes_compiled/busybox/copy/pod.yml
+++ b/tests/test_kubernetes_compiled/busybox/copy/pod.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always

--- a/tests/test_kubernetes_compiled/busybox/pre-deploy/00_namespace.yml
+++ b/tests/test_kubernetes_compiled/busybox/pre-deploy/00_namespace.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    name: busybox
+  name: busybox
+  namespace: busybox
+spec: {}

--- a/tests/test_kubernetes_compiled/busybox/pre-deploy/10_serviceaccount.yml
+++ b/tests/test_kubernetes_compiled/busybox/pre-deploy/10_serviceaccount.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: default
+  name: default
+  namespace: busybox

--- a/tests/test_kubernetes_compiled/minikube-es/copy/pod.yml
+++ b/tests/test_kubernetes_compiled/minikube-es/copy/pod.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+  namespace: default
+spec:
+  containers:
+    - image: busybox
+      command:
+        - sleep
+        - "3600"
+      imagePullPolicy: IfNotPresent
+      name: busybox
+  restartPolicy: Always


### PR DESCRIPTION
# Proposed Changes

  - The code provides an input feature of copy
  - This feature is to give an opportunity for a plain copy of a component without any alterations. Those can happen by other compiled steps
  - The use case come from the fact that the ArgoCD helm plugin requires a helm chart as it is and value files. By default, the directory plugin of Argo do not understand helm hooks. With this feature you can copy the helm chart and render additional value files at convenience.
