### PR TITLE
Add key info for RefBackendError for easier debugging

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -29,17 +29,17 @@ import yaml
 from kapitan import cached
 from kapitan.errors import KapitanError, RefHashMismatchError
 from kapitan.initialiser import initialise_skeleton
+from kapitan.inputs.jinja2_filters import DEFAULT_JINJA2_FILTERS_PATH
 from kapitan.lint import start_lint
 from kapitan.refs.base import PlainRef, RefController, Revealer
 from kapitan.refs.base64 import Base64Ref
 from kapitan.refs.secrets.awskms import AWSKMSSecret
 from kapitan.refs.secrets.gkms import GoogleKMSSecret
-from kapitan.refs.secrets.vaultkv import VaultSecret
 from kapitan.refs.secrets.gpg import GPGSecret, lookup_fingerprints
+from kapitan.refs.secrets.vaultkv import VaultSecret
 from kapitan.resources import (inventory_reclass, resource_callbacks,
                                search_imports)
 from kapitan.targets import compile_targets, schema_validate_compiled
-from kapitan.inputs.jinja2_filters import DEFAULT_JINJA2_FILTERS_PATH
 from kapitan.utils import (PrettyDumper, check_version, deep_get, fatal_error,
                            flatten_dict, from_dot_kapitan, jsonnet_file,
                            search_target_token_paths, searchvar)
@@ -405,7 +405,7 @@ def ref_write(args, ref_controller):
             inv = inventory_reclass(args.inventory_path)
             kap_inv_params = inv['nodes'][args.target_name]['parameters']['kapitan']
             if 'secrets' not in kap_inv_params:
-                raise KapitanError("parameters.kapitan.secrets not defined in {}".format(args.target_name))
+                raise KapitanError("parameters.kapitan.secrets not defined in inventory of target {}".format(args.target_name))
 
             recipients = kap_inv_params['secrets']['gpg']['recipients']
         if not recipients:
@@ -422,7 +422,7 @@ def ref_write(args, ref_controller):
             inv = inventory_reclass(args.inventory_path)
             kap_inv_params = inv['nodes'][args.target_name]['parameters']['kapitan']
             if 'secrets' not in kap_inv_params:
-                raise KapitanError("parameters.kapitan.secrets not defined in {}".format(args.target_name))
+                raise KapitanError("parameters.kapitan.secrets not defined in inventory of target {}".format(args.target_name))
 
             key = kap_inv_params['secrets']['gkms']['key']
         if not key:
@@ -438,7 +438,7 @@ def ref_write(args, ref_controller):
             inv = inventory_reclass(args.inventory_path)
             kap_inv_params = inv['nodes'][args.target_name]['parameters']['kapitan']
             if 'secrets' not in kap_inv_params:
-                raise KapitanError("parameters.kapitan.secrets not defined in {}".format(args.target_name))
+                raise KapitanError("parameters.kapitan.secrets not defined in inventory of target {}".format(args.target_name))
 
             key = kap_inv_params['secrets']['awskms']['key']
         if not key:
@@ -468,7 +468,7 @@ def ref_write(args, ref_controller):
             inv = inventory_reclass(args.inventory_path)
             kap_inv_params = inv['nodes'][args.target_name]['parameters']['kapitan']
             if 'secrets' not in kap_inv_params:
-                raise KapitanError("parameters.kapitan.secrets not defined in {}".format(args.target_name))
+                raise KapitanError("parameters.kapitan.secrets not defined in inventory of target {}".format(args.target_name))
 
             vault_params = kap_inv_params['secrets']['vaultkv']
         if args.vault_auth:

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -26,10 +26,9 @@ import os
 import sys
 
 import yaml
-from kapitan import cached
+from kapitan import cached, defaults
 from kapitan.errors import KapitanError, RefHashMismatchError
 from kapitan.initialiser import initialise_skeleton
-from kapitan.inputs.jinja2_filters import DEFAULT_JINJA2_FILTERS_PATH
 from kapitan.lint import start_lint
 from kapitan.refs.base import PlainRef, RefController, Revealer
 from kapitan.refs.base64 import Base64Ref
@@ -78,7 +77,7 @@ def main():
                                 help='set search paths, default is ["."]')
     compile_parser.add_argument('--jinja2-filters', '-J2F', type=str,
                                 default=from_dot_kapitan('compile', 'jinja2-filters',
-                                                         DEFAULT_JINJA2_FILTERS_PATH),
+                                                         defaults.DEFAULT_JINJA2_FILTERS_PATH),
                                 metavar='FPATH',
                                 help='load custom jinja2 filters from any file, default is to put\
                                 them inside lib/jinja2_filters.py')

--- a/kapitan/defaults.py
+++ b/kapitan/defaults.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+# Copyright 2019 The Kapitan Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"default values for kapitan variables"
+
+import os
+
+DEFAULT_KUBERNETES_VERSION = '1.14.0'
+# standalone is used for standalone json schema (i.e. without external $refs)
+# strict is used as it behaves similarly to kubectl
+# see https://github.com/garethr/kubernetes-json-schema#kubernetes-json-schemas for more info
+SCHEMA_TYPE = 'standalone-strict'
+FILE_PATH_FORMAT = 'v{}-%s/{}.json' % SCHEMA_TYPE
+
+# default path from where user defined custom filters are read
+DEFAULT_JINJA2_FILTERS_PATH = os.path.join('lib', 'jinja2_filters.py')

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -47,7 +47,7 @@ class Copy(InputType):
                     shutil.rmtree(compile_path)
                 shutil.copytree(file_path, compile_path)
         except OSError as e:
-            logger.exception("Input dir not copied. Error: {}".format(e))
+            logger.exception(f"Input dir not copied. Error: {e}")
 
     def default_output_type(self):
         # no output_type options for copy

--- a/kapitan/inputs/jinja2_filters.py
+++ b/kapitan/inputs/jinja2_filters.py
@@ -26,15 +26,11 @@ from importlib import util
 from random import Random, shuffle
 
 import yaml
-from kapitan import cached, utils
+from kapitan import cached, defaults, utils
 from kapitan.errors import CompileError
 from six import string_types
 
 logger = logging.getLogger(__name__)
-
-# default path from where user defined custom filters are read
-DEFAULT_JINJA2_FILTERS_PATH = os.path.join('lib', 'jinja2_filters.py')
-
 
 def load_jinja2_filters(env):
     """Load Jinja2 custom filters into env"""
@@ -81,7 +77,7 @@ def load_jinja2_filters_from_file(env, jinja2_filters):
     else try to load module (which will throw error in case of non existence of file)
     """
     jinja2_filters = os.path.normpath(jinja2_filters)
-    if jinja2_filters == DEFAULT_JINJA2_FILTERS_PATH:
+    if jinja2_filters == defaults.DEFAULT_JINJA2_FILTERS_PATH:
         if not os.path.isfile(jinja2_filters):
             return
     load_module_from_path(env, jinja2_filters)

--- a/kapitan/inputs/jinja2_filters.py
+++ b/kapitan/inputs/jinja2_filters.py
@@ -14,22 +14,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import yaml
 import base64
-import glob
-import os
 import datetime
-import time
-import re
-import types
+import glob
 import logging
-
-from six import string_types
-from random import Random, shuffle
+import os
+import re
+import time
+import types
 from importlib import util
+from random import Random, shuffle
 
+import yaml
+from kapitan import cached, utils
 from kapitan.errors import CompileError
-from kapitan import utils, cached
+from six import string_types
 
 logger = logging.getLogger(__name__)
 

--- a/kapitan/inputs/jsonnet.py
+++ b/kapitan/inputs/jsonnet.py
@@ -84,7 +84,7 @@ class Jsonnet(InputType):
                                   indent=indent) as fp:
                     fp.write(item_value)
             else:
-                raise ValueError('output is neither "json", "yaml" or "plain"')
+                raise ValueError(f"Output type defined in inventory for {file_path} is neither 'json', 'yaml' nor 'plain'")
 
     def default_output_type(self):
         return "yaml"

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -129,7 +129,8 @@ class Kadet(InputType):
                                 indent=indent) as fp:
                     fp.write(item_value)
             else:
-                raise ValueError('output is neither "json", "yaml" or "plain"')
+                raise ValueError(
+                    f"Output type defined in inventory for {file_path} is neither 'json', 'yaml' nor 'plain'")
             logger.debug("Pruned output for: %s", file_path)
 
     def default_output_type(self):

--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -17,8 +17,8 @@
 import base64
 import errno
 import logging
-import yaml
 
+import yaml
 from kapitan.refs.base import PlainRef, PlainRefBackend
 
 try:
@@ -50,7 +50,7 @@ class Base64Ref(PlainRef):
 
     def compile(self):
         # XXX will only work if object read via backend
-        return "?{{{}:{}:{}}}".format(self.type_name, self.path, self.hash[:8])
+        return f"?{{{self.type_name}:{self.path}:{self.hash[:8]}}}"
 
     @classmethod
     def from_path(cls, ref_full_path, **kwargs):

--- a/kapitan/refs/functions.py
+++ b/kapitan/refs/functions.py
@@ -129,5 +129,4 @@ def reveal(ctx, secret_path):
         ctx.ref_encoding = ref_obj.encoding
         ctx.data = ref_obj.reveal()
     except KeyError:
-        raise RefError("|reveal function error: {secret_path} file in {}|reveal:{secret_path} does not exist"
-                       .format(ctx.token, secret_path=secret_path))
+        raise RefError(f"|reveal function error: {secret_path} file in {ctx.token}|reveal:{secret_path} does not exist")

--- a/kapitan/refs/secrets/gpg.py
+++ b/kapitan/refs/secrets/gpg.py
@@ -15,14 +15,14 @@
 "gpg secrets module"
 
 import base64
-import gnupg
 import logging
 import time
 
-from kapitan.refs.base import RefError
-from kapitan.refs.base64 import Base64Ref, Base64RefBackend
+import gnupg
 from kapitan import cached
 from kapitan.errors import KapitanError
+from kapitan.refs.base import RefError
+from kapitan.refs.base64 import Base64Ref, Base64RefBackend
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class GPGSecret(Base64Ref):
                 raise ValueError('target_inv not set')
 
             if 'secrets' not in target_inv['parameters']['kapitan']:
-                raise KapitanError("parameters.kapitan.secrets not defined in {}".format(target_name))
+                raise KapitanError(f"parameters.kapitan.secrets not defined in inventory of target {target_name}")
 
             recipients = target_inv['parameters']['kapitan']['secrets']['gpg']['recipients']
 
@@ -199,8 +199,9 @@ def fingerprint_non_expired(recipient_name):
             if (not key['expires']) or (time.time() < int(key['expires'])):
                 return key['fingerprint']
             else:
-                logger.debug("Key for recipient: %s with fingerprint: %s has expired, skipping",
-                             recipient_name, key['fingerprint'])
-        raise GPGError("Could not find valid key for recipient: %s" % recipient_name)
+                logger.debug(
+                    f"Key for recipient: {recipient_name} with fingerprint: {key['fingerprint']} has expired, skipping")
+        raise GPGError(
+            f"Could not find valid key for recipient: {recipient_name}")
     except IndexError as iexp:
         raise iexp

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -195,8 +195,8 @@ def search_imports(cwd, import_str, search_paths):
         # if found, set as full_import_path
         if os.path.exists(_full_import_path):
             full_import_path = _full_import_path
-            logger.debug("import_str: %s found in search_path: %s",
-                         import_str, install_path)
+            logger.debug(
+                f"import_str: {import_str} found in search_path: {install_path}")
         else:
             # if import_str not found, search in search_paths
             for path in search_paths:
@@ -204,8 +204,7 @@ def search_imports(cwd, import_str, search_paths):
                 # if found, set as full_import_path
                 if os.path.exists(_full_import_path):
                     full_import_path = _full_import_path
-                    logger.debug("import_str: %s found in search_path: %s",
-                                 import_str, path)
+                    logger.debug(f"import_str: {import_str} found in search_path: {path}")
                     break
 
     # if the above search did not find anything, let jsonnet error
@@ -239,7 +238,8 @@ def inventory(search_paths, target, inventory_path="inventory/"):
             break
 
     if not inv_path_exists:
-        raise InventoryError("Inventory not found in search paths: {}".format(search_paths))
+        raise InventoryError(
+            f"Inventory not found in search paths: {search_paths}")
 
     if target is None:
         return inventory_reclass(full_inv_path)["nodes"]
@@ -274,7 +274,7 @@ def inventory_reclass(inventory_path):
                     uri_path = os.path.join(inventory_path, uri_val)
                     normalised_path = os.path.normpath(uri_path)
                     reclass_config.update({uri: normalised_path})
-                logger.debug("Using reclass inventory config at: %s", cfg_file)
+                logger.debug(f"Using reclass inventory config at: {cfg_file}")
         except IOError as ex:
             # If file does not exist, ignore
             if ex.errno == errno.ENOENT:

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -31,11 +31,11 @@ import yaml
 from kapitan import cached
 from kapitan.dependency_manager.base import fetch_dependencies
 from kapitan.errors import CompileError, InventoryError, KapitanError
+from kapitan.inputs.copy import Copy
 from kapitan.inputs.helm import Helm
 from kapitan.inputs.jinja2 import Jinja2
 from kapitan.inputs.jsonnet import Jsonnet
 from kapitan.inputs.kadet import Kadet
-from kapitan.inputs.copy import Copy
 from kapitan.resources import inventory_reclass
 from kapitan.utils import dictionary_hash, directory_hash, hashable_lru_cache
 from kapitan.validator.kubernetes_validator import (
@@ -135,7 +135,7 @@ def compile_targets(inventory_path, search_paths, output_path, parallel, targets
         logger.debug("Compile pool terminated")
         # only print traceback for errors we don't know about
         if not isinstance(e, KapitanError):
-            logger.exception("Unknown (Non-Kapitan) Error occured")
+            logger.exception("Unknown (Non-Kapitan) Error occurred")
 
         logger.error("\n")
         logger.error(e)
@@ -539,20 +539,21 @@ def validate_matching_target_name(target_filename, target_obj, inventory_path):
     """Throws *InventoryError* if parameters.kapitan.vars.target is not set,
     or target does not have a corresponding yaml file in *inventory_path*
     """
-    logger.debug("validating target name matches the name of yml file%s", target_filename)
+    logger.debug(
+        f"validating target name matches the name of yml file {target_filename}")
     try:
         target_name = target_obj["vars"]["target"]
     except KeyError:
-        error_message = "Target missing: target \"{}\" is missing parameters.kapitan.vars.target\n" \
-                        "This parameter should be set to the target name"
-        raise InventoryError(error_message.format(target_filename))
+        error_message = (f"Target missing: target \"{target_filename}\" is missing parameters.kapitan.vars.target\n"
+                         "This parameter should be set to the target name")
+        raise InventoryError(error_message)
 
     if target_filename != target_name:
         target_path = os.path.join(os.path.abspath(inventory_path), "targets")
 
-        error_message = "Target \"{}\" is missing the corresponding yml file in {}\n" \
-                        "Target name should match the name of the target yml file in inventory"
-        raise InventoryError(error_message.format(target_name, target_path))
+        error_message = (f"Target \"{target_name}\" is missing the corresponding yml file in {target_path}\n"
+                         "Target name should match the name of the target yml file in inventory")
+        raise InventoryError(error_message)
 
 
 def schema_validate_compiled(targets, compiled_path, inventory_path, schema_cache_path, parallel):
@@ -560,12 +561,12 @@ def schema_validate_compiled(targets, compiled_path, inventory_path, schema_cach
     validates compiled output according to schemas specified in the inventory
     """
     if not os.path.isdir(compiled_path):
-        logger.error("compiled-path {} not found".format(compiled_path))
+        logger.error(f"compiled-path {compiled_path} not found")
         sys.exit(1)
 
     if not os.path.isdir(schema_cache_path):
         os.makedirs(schema_cache_path)
-        logger.info("created schema-cache-path at {}".format(schema_cache_path))
+        logger.info(f"created schema-cache-path at {schema_cache_path}")
 
     worker = partial(schema_validate_kubernetes_output, cache_dir=schema_cache_path)
     pool = multiprocessing.Pool(parallel)
@@ -607,7 +608,7 @@ def create_validate_mapping(target_objs, compiled_path):
     for target_obj in target_objs:
         target_name = target_obj['vars']['target']
         if 'validate' not in target_obj:
-            logger.debug("target '{}' does not have 'validate' parameter. skipping".format(target_name))
+            logger.debug("target '{}' does not have 'validate' parameter in inventory. skipping".format(target_name))
             continue
 
         for validate_item in target_obj['validate']:
@@ -618,12 +619,12 @@ def create_validate_mapping(target_objs, compiled_path):
                 for output_path in validate_item['output_paths']:
                     full_output_path = os.path.join(compiled_path, target_name, output_path)
                     if not os.path.isfile(full_output_path):
-                        logger.warning("{} does not exist for target '{}'. skipping".
-                                       format(output_path, target_name))
+                        logger.warning(f"{output_path} does not exist for target '{target_name}'. skipping")
                         continue
                     validate_files_map[kind_version_pair].append(full_output_path)
             else:
-                logger.warning('type {} is not supported for validation. skipping'.format(validate_type))
+                logger.warning(
+                    f"type {validate_type} is not supported for validation. skipping")
 
     return validate_files_map
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -28,7 +28,7 @@ from functools import partial
 
 import jsonschema
 import yaml
-from kapitan import cached
+from kapitan import cached, defaults
 from kapitan.dependency_manager.base import fetch_dependencies
 from kapitan.errors import CompileError, InventoryError, KapitanError
 from kapitan.inputs.copy import Copy
@@ -38,8 +38,7 @@ from kapitan.inputs.jsonnet import Jsonnet
 from kapitan.inputs.kadet import Kadet
 from kapitan.resources import inventory_reclass
 from kapitan.utils import dictionary_hash, directory_hash, hashable_lru_cache
-from kapitan.validator.kubernetes_validator import (
-    DEFAULT_KUBERNETES_VERSION, KubernetesManifestValidator)
+from kapitan.validator.kubernetes_validator import KubernetesManifestValidator
 
 from reclass.errors import NotFoundError, ReclassException
 
@@ -615,7 +614,7 @@ def create_validate_mapping(target_objs, compiled_path):
             validate_type = validate_item['type']
             if validate_type == 'kubernetes':
                 kind_version_pair = (validate_item['kind'],
-                                     validate_item.get('version', DEFAULT_KUBERNETES_VERSION))
+                                     validate_item.get('version', defaults.DEFAULT_KUBERNETES_VERSION))
                 for output_path in validate_item['output_paths']:
                     full_output_path = os.path.join(compiled_path, target_name, output_path)
                     if not os.path.isfile(full_output_path):

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -16,29 +16,31 @@
 
 from __future__ import print_function
 
-import requests
-
-"random utils"
-
-import logging
-import os
-import sys
-import stat
 import collections
 import json
-import jinja2
-import _jsonnet as jsonnet
-import yaml
+import logging
 import math
+import os
+import stat
+import sys
 from collections import Counter, defaultdict
 from functools import lru_cache, wraps
 from hashlib import sha256
 
-from kapitan.version import VERSION
-from kapitan.errors import CompileError
-from kapitan.inputs.jinja2_filters import (load_jinja2_filters, load_jinja2_filters_from_file,
-                                           DEFAULT_JINJA2_FILTERS_PATH)
+import _jsonnet as jsonnet
+import jinja2
 import kapitan.cached as cached
+import requests
+import yaml
+from kapitan.errors import CompileError
+from kapitan.inputs.jinja2_filters import (DEFAULT_JINJA2_FILTERS_PATH,
+                                           load_jinja2_filters,
+                                           load_jinja2_filters_from_file)
+from kapitan.version import VERSION
+
+"random utils"
+
+
 
 
 logger = logging.getLogger(__name__)
@@ -64,7 +66,8 @@ def hashable_lru_cache(func):
         try:
             return json.loads(value)
         except Exception:
-            logger.debug("hashable_lru_cache: %s not serialiseable, using generic lru_cache instead", value)
+            logger.debug(
+                f"hashable_lru_cache: {value} not serialiseable, using generic lru_cache instead")
             return value
 
     def func_with_serialized_params(*args, **kwargs):
@@ -163,7 +166,7 @@ def render_jinja2(path, context, jinja2_filters=DEFAULT_JINJA2_FILTERS_PATH):
                     "mode": file_mode(render_path)
                 }
             except Exception as e:
-                raise CompileError("Jinja2 error: failed to render {}: {}".format(render_path, e))
+                raise CompileError(f"Jinja2 error: failed to render {render_path}: {e}")
 
     return rendered
 
@@ -182,7 +185,8 @@ def jsonnet_file(file_path, **kwargs):
     try:
         return jsonnet.evaluate_file(file_path, **kwargs)
     except Exception as e:
-        raise CompileError("Jsonnet error: failed to compile {}:\n {}".format(file_path, e))
+        raise CompileError(
+            f"Jsonnet error: failed to compile {file_path}:\n {e}")
 
 
 def prune_empty(d):
@@ -300,10 +304,12 @@ def searchvar(flat_var, inventory_path, pretty_print):
 def directory_hash(directory):
     """Return the sha256 hash for the file contents of a directory"""
     if not os.path.exists(directory):
-        raise IOError("utils.directory_hash failed, {} dir doesn't exist".format(directory))
+        raise IOError(
+            f"utils.directory_hash failed, {directory} dir doesn't exist")
 
     if not os.path.isdir(directory):
-        raise IOError("utils.directory_hash failed, {} is not a directory".format(directory))
+        raise IOError(
+            f"utils.directory_hash failed, {directory} is not a directory")
 
     try:
         hash = sha256()
@@ -320,9 +326,9 @@ def directory_hash(directory):
                             binary_file_hash = sha256(f.read())
                             hash.update(binary_file_hash.hexdigest().encode("UTF-8"))
                     else:
-                        raise CompileError("utils.directory_hash failed to open {}: {}".format(file_path, e))
+                        raise CompileError(f"utils.directory_hash failed to open {file_path}: {e}")
     except Exception as e:
-        raise CompileError("utils.directory_hash failed: {}".format(e))
+        raise CompileError(f"utils.directory_hash failed: {e}")
 
     return hash.hexdigest()
 
@@ -422,19 +428,23 @@ def check_version():
             result = compare_versions(dot_kapitan_version, VERSION)
             if result == "equal":
                 return
-            print("{}Current version: {}".format(termcolor.WARNING, VERSION))
-            print("Version in .kapitan: {}{}\n".format(dot_kapitan_version, termcolor.ENDC))
+            print(f"{termcolor.WARNING}Current version: {VERSION}")
+            print(f"Version in .kapitan: {dot_kapitan_version}{termcolor.ENDC}\n")
 
             # If .kapitan version is greater than current version
             if result == "greater":
-                print("Upgrade kapitan to '{}' in order to keep results consistent:\n".format(dot_kapitan_version))
+                print(
+                    f"Upgrade kapitan to '{dot_kapitan_version}' in order to keep results consistent:\n")
             # If .kapitan version is lower than current version
             elif result == "lower":
-                print("Option 1: You can update the version in .kapitan to '{}' and recompile\n".format(VERSION))
-                print("Option 2: Downgrade kapitan to '{}' in order to keep results consistent:\n".format(dot_kapitan_version))
+                print(
+                    f"Option 1: You can update the version in .kapitan to '{VERSION}' and recompile\n")
+                print(f"Option 2: Downgrade kapitan to '{dot_kapitan_version}' in order to keep results consistent:\n")
 
-            print("Docker: docker pull deepmind/kapitan:{}".format(dot_kapitan_version))
-            print("Pip (user): pip3 install --user --upgrade kapitan=={}\n".format(dot_kapitan_version))
+            print(
+                f"Docker: docker pull deepmind/kapitan:{dot_kapitan_version}")
+            print(
+                f"Pip (user): pip3 install --user --upgrade kapitan=={dot_kapitan_version}\n")
             print("Check https://github.com/deepmind/kapitan#quickstart for more info.\n")
             print("If you know what you're doing, you can skip this check by adding '--ignore-version-check'.")
             sys.exit(1)
@@ -459,7 +469,7 @@ def search_target_token_paths(target_secrets_path, targets):
                 except KeyError:
                     # Backwards compatible with gpg secrets that didn't have type in yaml
                     secret_type = "gpg"
-                secret_path = "?{{{}:{}}}".format(secret_type, secret_path)
+                secret_path = f"?{{{secret_type}:{secret_path}}}"
             logger.debug('search_target_token_paths: found %s', secret_path)
             target_files[target_name].append(secret_path)
     return target_files

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -29,12 +29,11 @@ from hashlib import sha256
 
 import _jsonnet as jsonnet
 import jinja2
-import kapitan.cached as cached
 import requests
 import yaml
+from kapitan import cached, defaults
 from kapitan.errors import CompileError
-from kapitan.inputs.jinja2_filters import (DEFAULT_JINJA2_FILTERS_PATH,
-                                           load_jinja2_filters,
+from kapitan.inputs.jinja2_filters import (load_jinja2_filters,
                                            load_jinja2_filters_from_file)
 from kapitan.version import VERSION
 
@@ -117,7 +116,7 @@ def sha256_string(string):
     return sha256(string.encode("UTF-8")).hexdigest()
 
 
-def render_jinja2_file(name, context, jinja2_filters=DEFAULT_JINJA2_FILTERS_PATH):
+def render_jinja2_file(name, context, jinja2_filters=defaults.DEFAULT_JINJA2_FILTERS_PATH):
     """Render jinja2 file name with context"""
     path, filename = os.path.split(name)
     env = jinja2.Environment(
@@ -132,7 +131,7 @@ def render_jinja2_file(name, context, jinja2_filters=DEFAULT_JINJA2_FILTERS_PATH
     return env.get_template(filename).render(context)
 
 
-def render_jinja2(path, context, jinja2_filters=DEFAULT_JINJA2_FILTERS_PATH):
+def render_jinja2(path, context, jinja2_filters=defaults.DEFAULT_JINJA2_FILTERS_PATH):
     """
     Render files in path with context
     Returns a dict where the is key is the filename (with subpath)

--- a/tests/test_kubernetes_validator.py
+++ b/tests/test_kubernetes_validator.py
@@ -14,15 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from shutil import copyfile
 import sys
-import unittest
 import tempfile
+import unittest
+from shutil import copyfile
+
 import yaml
+from kapitan import defaults
 from kapitan.cached import reset_cache
 from kapitan.cli import main
 from kapitan.errors import KubernetesManifestValidationError
-from kapitan.validator.kubernetes_validator import KubernetesManifestValidator, FILE_PATH_FORMAT
+from kapitan.validator.kubernetes_validator import KubernetesManifestValidator
 
 
 class KubernetesValidatorTest(unittest.TestCase):
@@ -36,7 +38,7 @@ class KubernetesValidatorTest(unittest.TestCase):
         version = '1.14.0'
         downloaded_schema = self.validator._get_schema_from_web(kind, version)
         self.validator._cache_schema(kind, version, downloaded_schema)
-        self.assertTrue(os.path.isfile(os.path.join(self.cache_dir, FILE_PATH_FORMAT.format(version, kind))))
+        self.assertTrue(os.path.isfile(os.path.join(self.cache_dir, defaults.FILE_PATH_FORMAT.format(version, kind))))
 
     def test_load_from_cache(self):
         kind = 'deployment'


### PR DESCRIPTION
Related to issue #430 
Slightly hard to generalize and add more information (like current filename processed for example)
because references are set/read in multiple places in cli.py as well in various use cases.
It might be feasible to add nicer exception messages there too with the same approach. 

New message looks like this:
```
no backend for ref type: gpsafasg
  for key ?{gpsafasg:targets/minikube-mysql/mysql/password||randomstr|base64}
Compile error: failed to compile target: minikube-mysql
```
Which is slightly more helpful but not perfect. 