### PR TITLE
Upgrade to Cloud SDK version (274.0.0)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -24,7 +24,7 @@ RUN chmod +x ./kapitan/inputs/helm/build.sh \
 # Build final image
 FROM python:3.7-buster
 
-ARG CLOUD_SDK_VERSION=267.0.0
+ARG CLOUD_SDK_VERSION=274.0.0
 
 ENV CLOUD_SDK_VERSION=$CLOUD_SDK_VERSION
 ENV KAPP_URL=https://github.com/k14s/kapp/releases/download/v0.14.0/kapp-linux-amd64


### PR DESCRIPTION
Fixes issue #440

## Proposed Changes

The google-cloud-sdk available in the ci image is not the latest.
Proposal is to upgrade it to the latest Cloud SDK version (274.0.0)