### PR TITLE
Maintenance

### DIFF
--- a/docs/example-kubernetes.md
+++ b/docs/example-kubernetes.md
@@ -12,7 +12,7 @@ The following tree shows what this directory looks like (only showing tree level
 ├── inventory
 ├── lib
 ├── scripts
-├── secrets
+├── refs
 └── templates
 ```
 
@@ -131,7 +131,7 @@ local p = inventory.parameters;
 }
 ```
 
-The first two lines import libjsonnet files under `lib` folder: this is the folder that contains helper files used inside templates. For example, `kapitan.libjsonnet` allows you to access inventory values inside jsonnet templates, and `kube.libjsonnet` defines functions to generate popular kubernetes manifests. 
+The first two lines import libjsonnet files under `lib` folder: this is the folder that contains helper files used inside templates. For example, `kapitan.libjsonnet` allows you to access inventory values inside jsonnet templates, and `kube.libjsonnet` defines functions to generate popular kubernetes manifests.
 
 The actual object defined in `components/namespace/main.jsonnet` looks like this:
 
@@ -212,6 +212,6 @@ metadata:
 type: Opaque
 ```
 
-`MYSQL_ROOT_PASSWORD` refers to the secret stored in `secrets/targets/minikube-mysql/mysql/password` and so on.
+`MYSQL_ROOT_PASSWORD` refers to the secret stored in `refs/targets/minikube-mysql/mysql/password` and so on.
 
-You may reveal the secrets by running `kapitan secrets --reveal -f mysql_secret.yml` and use the manifest by piping the output to kubectl!
+You may reveal the secrets by running `kapitan refs --reveal -f mysql_secret.yml` and use the manifest by piping the output to kubectl!

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -69,7 +69,7 @@ parameters:
     image: mysql:latest
     users:
       root:
-        # If 'secrets/targets/${target_name}/mysql/password' doesn't exist, it will gen a random b64-encoded password
+        # If 'refs/targets/${target_name}/mysql/password' doesn't exist, it will gen a random b64-encoded password
         password: ?{gpg:targets/${target_name}/mysql/password||randomstr|base64}
         # password: ?{gkms:targets/${target_name}/mysql/password||randomstr|base64}
         # password: ?{awskms:targets/${target_name}/mysql/password||randomstr|base64}
@@ -236,7 +236,7 @@ parameters:
     address: https://localhost:8200
 ```
 
-Use `kapitan lint` to checkup on your inventory/secrets.
+Use `kapitan lint` to checkup on your inventory or refs.
 
 ### kapitan searchvar
 

--- a/docs/kap_proposals/kap_6_hashicorp_vault.md
+++ b/docs/kap_proposals/kap_6_hashicorp_vault.md
@@ -1,47 +1,47 @@
-# Hashicorp Vault  
-  
-This feature allows the user to fetch secrets from [Hashicorp Vault](https://www.vaultproject.io/), with the new secret backend keyword 'vaultkv'.  
-  
-Author: [@vaibahvk](https://github.com/vaibhavk) [@daminisatya](https://github.com/daminisatya)  
-## Specification  
-  
-The following variables need to be exported to the environment(depending on authentication used) where you will run `kapitan secrets --reveal` in order to authenticate to your HashiCorp Vault instance:  
-* VAULT_ADDR: URL for vault  
-* VAULT_SKIP_VERIFY=true: if set, do not verify presented TLS certificate before communicating with Vault server. Setting this variable is not recommended except during testing  
-* VAULT_TOKEN: token for vault or file (~/.vault-tokens)  
-* VAULT_ROLE_ID: required by approle  
-* VAULT_SECRET_ID: required by approle  
-* VAULT_USERNAME: username to login to vault  
-* VAULT_PASSWORD: password to login to vault  
-* VAULT_CLIENT_KEY: the path to an unencrypted PEM-encoded private key matching the client certificate  
-* VAULT_CLIENT_CERT: the path to a PEM-encoded client certificate for TLS authentication to the Vault server  
-* VAULT_CACERT: the path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate  
-* VAULT_CAPATH: the path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate  
-* VAULT_NAMESPACE: specify the Vault Namespace, if you have one  
-  
-Considering a key-value pair like `my_key`:`my_secret` ( in our case let’s store `hello`:`batman` inside the vault ) in the path `secret/foo` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret either follow:  
-  
-```shell  
-$ echo "foo:hello" > somefile.txt  
-$ kapitan secrets --write vaultkv:path/to/secret_inside_kapitan --file somefile.txt --target dev-sea  
-```  
-or in a single line  
-```shell  
-$ echo "foo:hello"  | kapitan secrets --write vaultkv:path/to/secret_inside_kapitan -t dev-sea -f -  
-```  
-The entire string __"foo:hello"__ is base64 encoded and stored in the secret_inside_kapitan. Now secret_inside_kapitan contains the following  
-  
-```yaml    
-data: Zm9vOmhlbGxvCg==  
-encoding: original  
-type: vaultkv  
-vault_params:  
+# Hashicorp Vault
+
+This feature allows the user to fetch secrets from [Hashicorp Vault](https://www.vaultproject.io/), with the new secret backend keyword 'vaultkv'.
+
+Author: [@vaibahvk](https://github.com/vaibhavk) [@daminisatya](https://github.com/daminisatya)
+## Specification
+
+The following variables need to be exported to the environment(depending on authentication used) where you will run `kapitan refs --reveal` in order to authenticate to your HashiCorp Vault instance:
+* VAULT_ADDR: URL for vault
+* VAULT_SKIP_VERIFY=true: if set, do not verify presented TLS certificate before communicating with Vault server. Setting this variable is not recommended except during testing
+* VAULT_TOKEN: token for vault or file (~/.vault-tokens)
+* VAULT_ROLE_ID: required by approle
+* VAULT_SECRET_ID: required by approle
+* VAULT_USERNAME: username to login to vault
+* VAULT_PASSWORD: password to login to vault
+* VAULT_CLIENT_KEY: the path to an unencrypted PEM-encoded private key matching the client certificate
+* VAULT_CLIENT_CERT: the path to a PEM-encoded client certificate for TLS authentication to the Vault server
+* VAULT_CACERT: the path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate
+* VAULT_CAPATH: the path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate
+* VAULT_NAMESPACE: specify the Vault Namespace, if you have one
+
+Considering a key-value pair like `my_key`:`my_secret` ( in our case let’s store `hello`:`batman` inside the vault ) in the path `secret/foo` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret either follow:
+
+```shell
+$ echo "foo:hello" > somefile.txt
+$ kapitan refs --write vaultkv:path/to/secret_inside_kapitan --file somefile.txt --target dev-sea
+```
+or in a single line
+```shell
+$ echo "foo:hello"  | kapitan refs --write vaultkv:path/to/secret_inside_kapitan -t dev-sea -f -
+```
+The entire string __"foo:hello"__ is base64 encoded and stored in the secret_inside_kapitan. Now secret_inside_kapitan contains the following
+
+```yaml
+data: Zm9vOmhlbGxvCg==
+encoding: original
+type: vaultkv
+vault_params:
   auth: token
-```  
-  
-Encoding tells the type of data given to kapitan, if it is `original` then after decoding base64 we'll get the original secret and if it is `base64` then after decoding once we still have a base64 encoded secret and have to decode again.  
-Parameters in the secret file are collected from the inventory of the target we gave from CLI `--target dev-sea`. If target isn't provided then kapitan will identify the variables from the environment, but providing `auth` is necessary as a key inside target parameters like the one shown:  
-```yaml  
+```
+
+Encoding tells the type of data given to kapitan, if it is `original` then after decoding base64 we'll get the original secret and if it is `base64` then after decoding once we still have a base64 encoded secret and have to decode again.
+Parameters in the secret file are collected from the inventory of the target we gave from CLI `--target dev-sea`. If target isn't provided then kapitan will identify the variables from the environment, but providing `auth` is necessary as a key inside target parameters like the one shown:
+```yaml
 parameters:
   kapitan:
     secrets:
@@ -55,16 +55,16 @@ parameters:
         VAULT_CLIENT_KEY: /path/to/key
         VAULT_CLIENT_CERT: /path/to/cert
 ```
-Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.  
-Extra parameters that can be defined in inventory are:  
-* `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`  
-* `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)  
-* `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)  
-Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.  
-This makes the secret_inside_kapitan file accessible throughout the inventory, where we can use the secret whenever necessary like `?{vaultkv:path/to/secret_inside_kapitan}`  
-  
-Following is the example file having a secret and pointing to the vault `?{vaultkv:path/to/secret_inside_kapitan}`  
-  
+Environment variables that can be defined in kapitan inventory are `VAULT_ADDR`, `VAULT_NAMESPACE`, `VAULT_SKIP_VERIFY`, `VAULT_CLIENT_CERT`, `VAULT_CLIENT_KEY`, `VAULT_CAPATH` & `VAULT_CACERT`.
+Extra parameters that can be defined in inventory are:
+* `auth`: specify which authentication method to use like `token`,`userpass`,`ldap`,`github` & `approle`
+* `mount`: specify the mount point of key's path. e.g if path=`alpha-secret/foo/bar` then `mount: alpha-secret` (default `secret`)
+* `engine`: secret engine used, either `kv-v2` or `kv` (default `kv-v2`)
+Environment variables cannot be defined in inventory are `VAULT_TOKEN`,`VAULT_USERNAME`,`VAULT_PASSWORD`,`VAULT_ROLE_ID`,` VAULT_SECRET_ID`.
+This makes the secret_inside_kapitan file accessible throughout the inventory, where we can use the secret whenever necessary like `?{vaultkv:path/to/secret_inside_kapitan}`
+
+Following is the example file having a secret and pointing to the vault `?{vaultkv:path/to/secret_inside_kapitan}`
+
 ```yaml
 parameters:
   releases:
@@ -76,9 +76,9 @@ parameters:
     args:
       - --verbose=${verbose}
       - --password=?{vaultkv:path/to/secret_inside_kapitan}
-```  
-when `?{vaultkv:path/to/secret_inside_kapitan}` is compiled, it will look same with an 8 character prefix of sha256 hash added at the end like:  
-```yaml  
+```
+when `?{vaultkv:path/to/secret_inside_kapitan}` is compiled, it will look same with an 8 character prefix of sha256 hash added at the end like:
+```yaml
 kind: Deployment
 metadata:
   name: cod
@@ -96,17 +96,17 @@ spec:
             - --password=?{vaultkv:path/to/secret_inside_kapitan:57d6f9b7}
           image: alledm/cod:v2.0.0
           name: cod
-``` 
-  
-Only the user with the required tokens/permissions can reveal the secrets. Please note that the roles and permissions will be handled at the Vault level. We need not worry about it within Kapitan. Use the following command to reveal the secrets:  
+```
 
-```shell  
-$ kapitan secrets --reveal -f compile/file/containing/secret 
-```  
+Only the user with the required tokens/permissions can reveal the secrets. Please note that the roles and permissions will be handled at the Vault level. We need not worry about it within Kapitan. Use the following command to reveal the secrets:
+
+```shell
+$ kapitan refs --reveal -f compile/file/containing/secret
+```
 
 Following is the result of the cod-deployment.md file after Kapitan reveal.
 
-```yaml  
+```yaml
 kind: Deployment
 metadata:
   name: cod
@@ -124,8 +124,8 @@ spec:
             - --password=batman
           image: alledm/cod:v2.0.0
           name: cod
-```  
+```
 
-## Dependencies  
- 
+## Dependencies
+
 - [hvac](https://github.com/hvac/hvac) is a python client for Hashicorp Vault

--- a/docs/kapitan_overview.md
+++ b/docs/kapitan_overview.md
@@ -31,7 +31,7 @@ The bare minimum structure that makes use of kapitan features may look as follow
 │       ├── dev.yml
 │       ├── staging.yml
 │       └── prod.yml
-├── secrets
+├── refs
 │   ├── targets
 │   │   ├── prod
 │   │   │   └── password
@@ -43,11 +43,11 @@ The bare minimum structure that makes use of kapitan features may look as follow
 - `templates`: stores Jinja2 and Kadet templates
 - `inventory/targets`: stores target files
 - `inventory/classes`: stores inventory values to be inherited by targets
-- `secrets`: stores secrets referenced inside the inventory
+- `refs`: stores secrets referenced inside the inventory
 
 #### Example: kubernetes deployment
 
-Refer to the structure below for more production-like uses of kapitan for kubernetes deployment: 
+Refer to the structure below for more production-like uses of kapitan for kubernetes deployment:
 
 ```
 .
@@ -79,7 +79,7 @@ Refer to the structure below for more production-like uses of kapitan for kubern
 │       ├── dev-cluster1-elasticsearch.yml
 │       ├── prod-cluster1-elasticsearch.yml
 │       └── prod-cluster2-frontend.yml
-├── secrets
+├── refs
 │   ├── targets
 │   │   ├── prod-cluster1-elasticsearch
 │   │   │   └── password

--- a/docs/pyenv-scl.md
+++ b/docs/pyenv-scl.md
@@ -2,15 +2,15 @@
 
 ## Introduction
 
-Kapitan requires Python 3.6, and you need to be able to install the dependencies in the 
-[requirements file](../requirements.txt).  However, sometimes this isn't entirely straightforward, and you may not be able or willing to install new versions of Python system-wide.  
+Kapitan requires Python 3.6, and you need to be able to install the dependencies in the
+[requirements file](../requirements.txt).  However, sometimes this isn't entirely straightforward, and you may not be able or willing to install new versions of Python system-wide.
 
 We do provide a [dockerfile](../Dockerfile) which you can use to run Kapitan in a container, but if this isn't practical or possible either, you may wish to use one of the following options:
 
 * [PyEnv](https://github.com/pyenv/pyenv) (Linux, distro-agnostic)
 * [Software Collections](https://www.softwarecollections.org) (RHEL-based distros)
 
-Both of these projects allow you to use a different version of Python specifically for your work with or on Kapitan.  They work similarly to [Python Virtual Environments](https://docs.python.org/3/tutorial/venv.html) but with more isolation from the lower-level OS-wide Python installation.  Both of these projects manipulate your shell environment variables to make sure you're using the right binaries and modules.  This document assumes you're using the bash shell. 
+Both of these projects allow you to use a different version of Python specifically for your work with or on Kapitan.  They work similarly to [Python Virtual Environments](https://docs.python.org/3/tutorial/venv.html) but with more isolation from the lower-level OS-wide Python installation.  Both of these projects manipulate your shell environment variables to make sure you're using the right binaries and modules.  This document assumes you're using the bash shell.
 
 PyEnv and Software Collections are not Google projects, so please exercise your judgment as to whether these projects are suitable for your circumstances.
 
@@ -22,7 +22,7 @@ Take a look at the [PyEnv](https://github.com/pyenv/pyenv) project on Github.  T
 
 ### The Automated Installer
 
-To use the installer, we would recommend downloading the installer script and examining it before you execute it. 
+To use the installer, we would recommend downloading the installer script and examining it before you execute it.
 ```console
 $ curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer > pyenv-installer
 ```
@@ -36,12 +36,12 @@ Instructions on updating and removing the tool when you've installed it with the
 Take a look at the README.md on the PyEnv project page and follow the installation instructions there.
 
 ### Using Kapitan with PyEnv
-Once you have successfully installed PyEnv, you'll need to restart your shell.  Either open a new shell session or source your .bashrc file like so: 
+Once you have successfully installed PyEnv, you'll need to restart your shell.  Either open a new shell session or source your .bashrc file like so:
 ```$ source ~/.bashrc```
 
 Now that you have PyEnv ready to go, we can check it runs:
 ```console
-$ pyenv 
+$ pyenv
 pyenv 1.2.8
 Usage: pyenv <command> [<args>]
 ...
@@ -61,7 +61,7 @@ Installed Python-3.7.1 to /home/mikejo/.pyenv/versions/3.7.1
 $ pyenv local 3.7.1
 $ python --version
 Python 3.7.1
-$ 
+$
 ```
 Once it completes, we can activate the newer Python installation and set about installing Kapitan!
 Make sure PyEnv is activated using the ```$ pyenv local 3.7.1``` command above and then run the following:
@@ -80,7 +80,7 @@ Add that line to the end of your .bashrc if you'd like it to take effect in all 
 You can now check everything installed correctly and start using Kapitan!
 ```console
 $ kapitan
-usage: kapitan [-h] [--version] {eval,compile,inventory,searchvar,secrets} ...
+usage: kapitan [-h] [--version] {eval,compile,inventory,searchvar,refs} ...
 ```
 ## On RHEL-based Operating Systems - Software Collections
 PyEnv will work on RHEL-based operating systems (including the upstream Fedora project).  Another option is to use the [Software Collections](https://www.softwarecollections.org/) project.  It's a community project with backing from Red Hat, and it includes both official Red Hat releases of some software collections and third-party contributions.  While Kapitan only needs you to install an official Red Hat collection release, please remember this isn't a Google project and to use your judgment as to whether this is appropriate for your circumstances.
@@ -91,7 +91,7 @@ Software Collections has installation documentation available [here](https://www
 
 As this procedure needs you to add a repository to the OS package manager, you'll need to be root.  Use ```su``` or run the following with ```sudo``` as appropriate.
 
-Once you've completed the installation of the scl tool, install the Python 3.5 SCL package (YUM/DNF package names are identical to the name of the Software Collection).  
+Once you've completed the installation of the scl tool, install the Python 3.5 SCL package (YUM/DNF package names are identical to the name of the Software Collection).
 ```console
 # yum install rh-python35
 ```
@@ -117,7 +117,7 @@ You can now check everything installed correctly and start using Kapitan!
 $ kapitan
 usage: kapitan [-h] [--version] {eval,compile,inventory,searchvar,secrets} ...
 ```
-When you come back to using this method after restarting your shell, you can switch back to the rh-python35 collection either by creating a shell alias for the kapitan command to ``` 'scl enable rh-python35 kapitan'``` 
+When you come back to using this method after restarting your shell, you can switch back to the rh-python35 collection either by creating a shell alias for the kapitan command to ``` 'scl enable rh-python35 kapitan'```
 but we recommend that you can use the scl command to start a new shell using
 ``` '$ scl enable rh-python35 bash' ```
 Once you finish using the software collection, exit the shell with ``` exit ```  or ``` Ctrl+D ```

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -44,7 +44,7 @@ parameters:
 ##### Manually via command line:
 
 ```shell
-$ kapitan secrets --write <secret_type>:path/to/secret/file -t <target_name> -f <secret_file>
+$ kapitan refs --write <secret_type>:path/to/secret/file -t <target_name> -f <secret_file>
 ```
 
 ​	where `<secret_type>` can be any of:
@@ -97,7 +97,7 @@ During compile, kapitan will search for the path `targets/${target_name}/mysql/p
 You can reveal the secrets referenced in the outputs of `kapitan compile` via:
 
 ```
-$ kapitan secrets --reveal -f path/to/rendered/template
+$ kapitan refs --reveal -f path/to/rendered/template
 ```
 
 For example, `compiled/minikube-mysql/manifests/mysql_secret.yml` with the following content:
@@ -120,14 +120,14 @@ type: Opaque
 can be revealed as follows:
 
 ```
-$ kapitan secrets --reveal -f compiled/minikube-mysql/manifests/mysql_secret.yml
+$ kapitan refs --reveal -f compiled/minikube-mysql/manifests/mysql_secret.yml
 ```
 
 This will substitute the referenced secrets with the actual decrypted secrets stored at the referenced paths and display the file content.
 
 ## Secret sub-variables
 
-As illustrated above, one file corresponds to one secret. It is now possible for users who would like to reduce the decryption overhead to manually create a yaml file that contains multiple secrets, each of which can be referenced by its object key. For example, consider the secret file `secrets/mysql_secrets`:
+As illustrated above, one file corresponds to one secret. It is now possible for users who would like to reduce the decryption overhead to manually create a yaml file that contains multiple secrets, each of which can be referenced by its object key. For example, consider the secret file `refs/mysql_secrets`:
 
 ```yaml
 mysql_passwords:
@@ -138,7 +138,7 @@ mysql_passwords:
 This can be manually encrypted by:
 
 ```
-$ kapitan secrets --write gpg:components/secrets/mysql_secrets -t prod -f secrets/mysql_secrets
+$ kapitan refs --write gpg:components/secrets/mysql_secrets -t prod -f secrets/mysql_secrets
 ```
 
 To reference `secret_foo`inside this file, you can specify it in the inventory as follows:
@@ -150,7 +150,7 @@ To reference `secret_foo`inside this file, you can specify it in the inventory a
 Considering a key-value pair like `my_key`:`my_secret` in the path `secret/foo/bar` in a kv-v2(KV version 2) secret engine on the vault server, to use this as a secret use:
 
 ```shell
-$ echo "foo/bar:my_key"  | kapitan secrets --write vaultkv:path/to/secret_inside_kapitan -t <target_name> -f -
+$ echo "foo/bar:my_key"  | kapitan refs --write vaultkv:path/to/secret_inside_kapitan -t <target_name> -f -
 ```
 
 Parameters in the secret file are collected from the inventory of the target we gave from CLI `-t <target_name>`. If target isn't provided then kapitan will identify the variables from the environment when revealing secret.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,7 +17,7 @@ positional arguments:
     compile             compile targets
     inventory           show inventory
     searchvar           show all inventory files where var is declared
-    secrets             manage secrets
+    refs                manage secrets
     lint                linter for inventory and secrets
     init                initialize a directory with the recommended kapitan
                         project skeleton.

--- a/examples/kubernetes/compiled/minikube-es/scripts/apply.sh
+++ b/examples/kubernetes/compiled/minikube-es/scripts/apply.sh
@@ -19,5 +19,5 @@ DIR=$(dirname ${BASH_SOURCE[0]})
 for SECTION in pre-deploy manifests
 do
   echo "## run kubectl apply for ${SECTION}"
-  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+  kapitan refs --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
 done

--- a/examples/kubernetes/compiled/minikube-mysql/scripts/apply.sh
+++ b/examples/kubernetes/compiled/minikube-mysql/scripts/apply.sh
@@ -19,5 +19,5 @@ DIR=$(dirname ${BASH_SOURCE[0]})
 for SECTION in pre-deploy manifests
 do
   echo "## run kubectl apply for ${SECTION}"
-  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+  kapitan refs --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
 done

--- a/examples/kubernetes/scripts/apply.sh
+++ b/examples/kubernetes/scripts/apply.sh
@@ -20,5 +20,5 @@ DIR=$(dirname ${BASH_SOURCE[0]})
 for SECTION in pre-deploy manifests
 do
   echo "## run kubectl apply for ${SECTION}"
-  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+  kapitan refs --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
 done

--- a/kapitan/lint.py
+++ b/kapitan/lint.py
@@ -23,7 +23,6 @@ from pprint import pformat
 
 from kapitan.errors import KapitanError
 from kapitan.utils import list_all_paths
-
 from yamllint import linter
 from yamllint.config import YamlLintConfig
 
@@ -72,7 +71,7 @@ def start_lint(
         skip_yamllint (bool): whether to skip checking yaml files for lint problems
         inventory_path (string): path to your inventory/ folder
         search_secrets (bool): whether to search for secret related warnings or not
-        secrets_path (string): path to your secrets/ folder
+        secrets_path (string): path to your refs/ folder
         compiled_path (string): path to your compiled/ folder
     Yields:
         checks_sum (int): the number of lint warnings found
@@ -110,12 +109,12 @@ def start_lint(
 
 
 def lint_orphan_secrets(compiled_path, secrets_path):
-    """ Checks your secrets/ folder for unused secrets files by:
+    """ Checks your refs/ folder for unused secrets files by:
         - iterating the secrets_path/ dir and extracting all secrets names from the file paths
         - does a text search over the entire compiled_path/ to find usages of those secrets
     Args:
         compiled_path (string): path to your compiled/ folder
-        secrets_path (string): path to your secrets/ folder
+        secrets_path (string): path to your refs/ folder
     Yields:
         checks_sum (int): the number of orphan secrets found
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,20 +1,20 @@
 # kapitan dependencies
 jsonnet==0.14.0
-pyyaml>=5.1
-Jinja2>=2.10
-jsonschema==3.1.1
+pyyaml>=5.2
+Jinja2>=2.10.3
+jsonschema==3.2.0
 python-gnupg==0.4.5
-six>=1.12.0
-cryptography>=2.6.1
+six>=1.13.0
+cryptography>=2.8
 google-api-python-client==1.7.11
-boto3>=1.9.138
+boto3>=1.10.46
 requests==2.22.0
 addict==2.2.1
-yamllint>=1.15.0
+yamllint>=1.20.0
 cffi
 rfc3987==1.3.8
-GitPython==3.0.3
-hvac==0.9.5
+GitPython==3.0.5
+hvac==0.9.6
 docker==4.1.0
 # Reclass dependencies
 pyparsing

--- a/tests/test_kubernetes_compiled/minikube-es/scripts/apply.sh
+++ b/tests/test_kubernetes_compiled/minikube-es/scripts/apply.sh
@@ -19,5 +19,5 @@ DIR=$(dirname ${BASH_SOURCE[0]})
 for SECTION in pre-deploy manifests
 do
   echo "## run kubectl apply for ${SECTION}"
-  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+  kapitan refs --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
 done

--- a/tests/test_kubernetes_compiled/minikube-mysql/scripts/apply.sh
+++ b/tests/test_kubernetes_compiled/minikube-mysql/scripts/apply.sh
@@ -19,5 +19,5 @@ DIR=$(dirname ${BASH_SOURCE[0]})
 for SECTION in pre-deploy manifests
 do
   echo "## run kubectl apply for ${SECTION}"
-  kapitan secrets --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
+  kapitan refs --reveal -f ${DIR}/../${SECTION}/ | ${DIR}/kubectl.sh apply -f - | column -t
 done


### PR DESCRIPTION
## Proposed Changes

  - Update docs and examples to use `refs` instead of deprecated `secrets`
  - Update requirements.txt with latest dependency versions (tested on own repos -> works)
  - Close docker client socket in vault tests to fix 'ResourceWarning: unclosed <socket.socket> error.' in Travis.


Dependencies were updated with `pur`:

```
$ pur -r requirements.txt 
Updated pyyaml: 5.1 -> 5.2
Updated Jinja2: 2.10 -> 2.10.3
Updated jsonschema: 3.1.1 -> 3.2.0
Updated six: 1.12.0 -> 1.13.0
Updated cryptography: 2.6.1 -> 2.8
Updated boto3: 1.9.138 -> 1.10.46
Updated yamllint: 1.15.0 -> 1.20.0
Updated GitPython: 3.0.3 -> 3.0.5
Updated hvac: 0.9.5 -> 0.9.6
All requirements up-to-date.
```
Don't forget to run `pip3 install -r requirements.txt` if you develop on kapitan locally after this PR. 