### PR TITLE
Fix dead CI-Dockerfile link by pointing to github

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,6 +1,6 @@
 # Kapitan: CI/CD usage
 
-The [Docker image](https://hub.docker.com/r/deepmind/kapitan/tags/) (`deepmind/kapitan:ci`) ([Dockerfile](./ci/Dockerfile)) comes pre-packaged with `gcloud`, `gsutil`, `bq`, `kubectl`, `terraform`, `promtool` and `kapitan`.
+The [Docker image](https://hub.docker.com/r/deepmind/kapitan/tags/) (`deepmind/kapitan:ci`) ([Dockerfile](https://github.com/deepmind/kapitan/blob/master/Dockerfile.ci)) comes pre-packaged with `gcloud`, `gsutil`, `bq`, `kubectl`, `terraform`, `promtool` and `kapitan`.
 
 ## Example workflow - Deploy to GKE
 


### PR DESCRIPTION
Fixes issue #476

## Proposed Changes
  - Point the website's CI-Dockerfile Link to the Dockerfile.ci in the github repository
