### PR TITLE
Compile refs in embedded format

### DIFF
--- a/examples/kubernetes/compiled/all-glob/manifests/mysql_secret_subvar.yml
+++ b/examples/kubernetes/compiled/all-glob/manifests/mysql_secret_subvar.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  MYSQL_ROOT_PASSWORD: ?{base64:targets/all-glob/mysql/subvars@var1.password:4d310147}
-  MYSQL_ROOT_PASSWORD_SHA256: ?{base64:targets/all-glob/mysql/subvars@var2.password_sha256:4d310147}
+  MYSQL_ROOT_PASSWORD: ?{base64:targets/all-glob/mysql/subvars@var1.password:fa652988}
+  MYSQL_ROOT_PASSWORD_SHA256: ?{base64:targets/all-glob/mysql/subvars@var2.password_sha256:fa652988}
 kind: Secret
 metadata:
   annotations: {}

--- a/examples/kubernetes/refs/targets/all-glob/mysql/subvars
+++ b/examples/kubernetes/refs/targets/all-glob/mysql/subvars
@@ -1,3 +1,3 @@
-data: dmFyMToKICBwYXNzd29yZDogb2xhb2xhCg==
+data: dmFyMToKICBwYXNzd29yZDogb2xhb2xhCnZhcjI6CiAgcGFzc3dvcmRfc2hhMjU2OiA1YjA1OGU0ZDZlM2I0YThhZDM5ZjBkNWFhMTdhOTk0YjA5ZGI4ZjAzMmYwM2MzMjIyYjJmNTk3YWRjNGJkNTJhCgo=
 encoding: original
 type: base64

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -163,6 +163,13 @@ def main():
         default=from_dot_kapitan("compile", "reveal", False),
     )
     compile_parser.add_argument(
+        "--embed-refs",
+        help="embed ref contents",
+        action="store_true",
+        default=from_dot_kapitan("compile", "embed-refs", False),
+    )
+
+    compile_parser.add_argument(
         "--inventory-path",
         default=from_dot_kapitan("compile", "inventory-path", "./inventory"),
         help='set inventory path, default is "./inventory"',
@@ -487,7 +494,7 @@ def main():
         if not args.ignore_version_check:
             check_version()
 
-        ref_controller = RefController(args.refs_path)
+        ref_controller = RefController(args.refs_path, embed_refs=args.embed_refs)
         # cache controller for use in reveal_maybe jinja2 filter
         cached.ref_controller_obj = ref_controller
         cached.revealer_obj = Revealer(ref_controller)

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -246,7 +246,7 @@ class Revealer(object):
                                  'matched in tag {}'.format(ref.embedded_subvar_path, tag))
                     return self._get_value_in_yaml_path(revealed_yaml, ref.embedded_subvar_path)
                 except KeyError:
-                    raise RefError("Revealer: cannot access {} sub-variable key {}".format(tag, subvar_path))
+                    raise RefError("Revealer: cannot access {} sub-variable key {}".format(tag, ref.embedded_subvar_path))
 
             # else this is just a ref
             else:

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -21,7 +21,6 @@ from kapitan.errors import RefBackendError, RefError, RefFromFuncError, RefHashM
 from kapitan.refs.functions import eval_func
 from kapitan.utils import PrettyDumper, list_all_paths
 
-from pdb import set_trace
 
 try:
     from yaml import CSafeLoader as YamlLoader
@@ -239,14 +238,20 @@ class Revealer(object):
                 # this should be yaml, decode, load and check
                 revealed_yaml = yaml.load(revealed_data, Loader=YamlLoader)
                 if not isinstance(revealed_yaml, dict):
-                    raise RefError("Revealer: revealed secret is not in yaml, "
-                                   "cannot access sub-variable at {}".format(ref.embedded_subvar_path))
+                    raise RefError(
+                        "Revealer: revealed secret is not in yaml, "
+                        "cannot access sub-variable at {}".format(ref.embedded_subvar_path)
+                    )
                 try:
-                    logger.debug('Revealer: embedded sub-variable path "{}"'
-                                 'matched in tag {}'.format(ref.embedded_subvar_path, tag))
+                    logger.debug(
+                        'Revealer: embedded sub-variable path "{}"'
+                        "matched in tag {}".format(ref.embedded_subvar_path, tag)
+                    )
                     return self._get_value_in_yaml_path(revealed_yaml, ref.embedded_subvar_path)
                 except KeyError:
-                    raise RefError("Revealer: cannot access {} sub-variable key {}".format(tag, ref.embedded_subvar_path))
+                    raise RefError(
+                        "Revealer: cannot access {} sub-variable key {}".format(tag, ref.embedded_subvar_path)
+                    )
 
             # else this is just a ref
             else:
@@ -264,8 +269,10 @@ class Revealer(object):
             plaintext = self._reveal_tag_without_subvar(tag_without_yaml_path)
             revealed_yaml = yaml.load(plaintext, Loader=YamlLoader)
             if not isinstance(revealed_yaml, dict):
-                raise RefError("Revealer: revealed secret is not in yaml, "
-                               "cannot access {} sub-variable at {}".format(subvar_path, tag))
+                raise RefError(
+                    "Revealer: revealed secret is not in yaml, "
+                    "cannot access {} sub-variable at {}".format(subvar_path, tag)
+                )
             try:
                 return self._get_value_in_yaml_path(revealed_yaml, subvar_path)
             except KeyError:
@@ -467,7 +474,7 @@ class RefController(object):
     def ref_from_embedded(self, type_name, b64_path):
         "returns ref from embedded (base64 and json) b64_path"
         # deserialise base64 and json data from b64_path
-        json_data  = base64.b64decode(b64_path).decode()
+        json_data = base64.b64decode(b64_path).decode()
         json_data = json.loads(json_data)
         backend = self._get_backend(type_name)
         # strip useless keys
@@ -479,7 +486,6 @@ class RefController(object):
         # note that encrypt=False is only for secret ref types, others will ignore
         # from_base64 is True because data is always base64 encoded in embedded form
         ref = backend.ref_type(data, encrypt=False, from_base64=True, **json_data)
-
 
         return ref
 
@@ -508,7 +514,9 @@ class RefController(object):
                     return ref
                 else:
                     raise RefHashMismatchError(
-                        "{}: token hash does not match with stored reference hash: {}".format(token, ref.token)
+                        "{}: token hash does not match with stored reference hash: {}".format(
+                            token, ref.token
+                        )
                     )
         else:
             return None

--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -45,9 +45,9 @@ class Base64Ref(PlainRef):
     def compile_embedded(self):
         dump = self.dump()
         # if subvar is set, save in 'embedded_subvar_path' key
-        subvar = self.path.split('@')
+        subvar = self.path.split("@")
         if len(subvar) > 1:
-            dump['embedded_subvar_path'] = subvar[1]
+            dump["embedded_subvar_path"] = subvar[1]
         dump_data = base64.b64encode(json.dumps(dump).encode()).decode()
         return f"?{{{self.type_name}:{dump_data}:embedded}}"
 

--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -7,6 +7,7 @@
 
 import base64
 import errno
+import json
 import logging
 
 import yaml
@@ -29,6 +30,8 @@ class Base64Ref(PlainRef):
         super().__init__(data, **kwargs)
         self.type_name = "base64"
         self.encoding = kwargs.get("encoding", "original")
+        self.embed_refs = kwargs.get("embed_refs", False)
+
         # TODO data should be bytes only
         if from_base64:
             self.data = data
@@ -39,8 +42,21 @@ class Base64Ref(PlainRef):
         # TODO data should be bytes only
         return base64.b64decode(self.data).decode()
 
+    def compile_embedded(self):
+        dump = self.dump()
+        # if subvar is set, save in 'embedded_subvar_path' key
+        subvar = self.path.split('@')
+        if len(subvar) > 1:
+            dump['embedded_subvar_path'] = subvar[1]
+        dump_data = base64.b64encode(json.dumps(dump).encode()).decode()
+        return f"?{{{self.type_name}:{dump_data}:embedded}}"
+
     def compile(self):
         # XXX will only work if object read via backend
+
+        if self.embed_refs:
+            return self.compile_embedded()
+
         return f"?{{{self.type_name}:{self.path}:{self.hash[:8]}}}"
 
     @classmethod
@@ -68,6 +84,6 @@ class Base64Ref(PlainRef):
 
 
 class Base64RefBackend(PlainRefBackend):
-    def __init__(self, path, ref_type=Base64Ref):
-        super().__init__(path, ref_type)
+    def __init__(self, path, ref_type=Base64Ref, **ref_kwargs):
+        super().__init__(path, ref_type, **ref_kwargs)
         self.type_name = "base64"

--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -44,7 +44,7 @@ class Base64Ref(PlainRef):
 
     def compile_embedded(self):
         dump = self.dump()
-        # if subvar is set, save in 'embedded_subvar_path' key
+        # if subvar is set, save path in 'embedded_subvar_path' key
         subvar = self.path.split("@")
         if len(subvar) > 1:
             dump["embedded_subvar_path"] = subvar[1]

--- a/kapitan/refs/secrets/awskms.py
+++ b/kapitan/refs/secrets/awskms.py
@@ -65,7 +65,7 @@ class AWSKMSSecret(Base64Ref):
 
     @classmethod
     def from_path(cls, ref_full_path, **kwargs):
-        return super().from_path(ref_full_path, encrypt=False)
+        return super().from_path(ref_full_path, encrypt=False, **kwargs)
 
     def reveal(self):
         """
@@ -145,7 +145,7 @@ class AWSKMSSecret(Base64Ref):
 
 
 class AWSKMSBackend(Base64RefBackend):
-    def __init__(self, path, ref_type=AWSKMSSecret):
+    def __init__(self, path, ref_type=AWSKMSSecret, **ref_kwargs):
         "init AWSKMSBackend ref backend type"
-        super().__init__(path, ref_type)
+        super().__init__(path, ref_type, **ref_kwargs)
         self.type_name = "awskms"

--- a/kapitan/refs/secrets/gkms.py
+++ b/kapitan/refs/secrets/gkms.py
@@ -76,7 +76,7 @@ class GoogleKMSSecret(Base64Ref):
 
     @classmethod
     def from_path(cls, ref_full_path, **kwargs):
-        return super().from_path(ref_full_path, encrypt=False)
+        return super().from_path(ref_full_path, encrypt=False, **kwargs)
 
     def reveal(self):
         """
@@ -163,7 +163,7 @@ class GoogleKMSSecret(Base64Ref):
 
 
 class GoogleKMSBackend(Base64RefBackend):
-    def __init__(self, path, ref_type=GoogleKMSSecret):
+    def __init__(self, path, ref_type=GoogleKMSSecret, **ref_kwargs):
         "init GoogleKMSBackend ref backend type"
-        super().__init__(path, ref_type)
+        super().__init__(path, ref_type, **ref_kwargs)
         self.type_name = "gkms"

--- a/kapitan/refs/secrets/gpg.py
+++ b/kapitan/refs/secrets/gpg.py
@@ -92,7 +92,7 @@ class GPGSecret(Base64Ref):
 
     @classmethod
     def from_path(cls, ref_full_path, **kwargs):
-        return super().from_path(ref_full_path, encrypt=False)
+        return super().from_path(ref_full_path, encrypt=False, **kwargs)
 
     def reveal(self):
         """
@@ -159,9 +159,9 @@ class GPGSecret(Base64Ref):
 
 
 class GPGBackend(Base64RefBackend):
-    def __init__(self, path, ref_type=GPGSecret):
+    def __init__(self, path, ref_type=GPGSecret, **ref_kwargs):
         "init GPGBackend ref backend type"
-        super().__init__(path, ref_type)
+        super().__init__(path, ref_type, **ref_kwargs)
         self.type_name = "gpg"
 
 

--- a/kapitan/refs/secrets/vaultkv.py
+++ b/kapitan/refs/secrets/vaultkv.py
@@ -162,7 +162,7 @@ class VaultSecret(Base64Ref):
 
     @classmethod
     def from_path(cls, ref_full_path, **kwargs):
-        return super().from_path(ref_full_path, encrypt=False)
+        return super().from_path(ref_full_path, encrypt=False, **kwargs)
 
     def reveal(self):
         """
@@ -223,7 +223,7 @@ class VaultSecret(Base64Ref):
 
 
 class VaultBackend(Base64RefBackend):
-    def __init__(self, path, ref_type=VaultSecret):
+    def __init__(self, path, ref_type=VaultSecret, **ref_kwargs):
         "init VaultBackend ref backend type"
-        super().__init__(path, ref_type)
+        super().__init__(path, ref_type, **ref_kwargs)
         self.type_name = "vaultkv"

--- a/tests/test_gpg.py
+++ b/tests/test_gpg.py
@@ -38,6 +38,7 @@ REVEALER = Revealer(REF_CONTROLLER)
 REF_CONTROLLER_EMBEDDED = RefController(REFS_HOME, embed_refs=True)
 REVEALER_EMBEDDED = Revealer(REF_CONTROLLER_EMBEDDED)
 
+
 class GPGSecretsTest(unittest.TestCase):
     "Test GPG secrets"
 
@@ -65,7 +66,6 @@ class GPGSecretsTest(unittest.TestCase):
             fp.write("I am a file with a {}".format(ref_obj.compile()))
         revealed = REVEALER_EMBEDDED.reveal_raw_file(file_with_secret_tags)
         self.assertEqual("I am a file with a super secret value", revealed)
-
 
     def test_gpg_base64_write_reveal(self):
         """
@@ -101,7 +101,6 @@ class GPGSecretsTest(unittest.TestCase):
             fp.write("I am a file with a {}".format(ref_obj.compile()))
         revealed = REVEALER_EMBEDDED.reveal_raw_file(file_with_secret_tags)
         self.assertEqual("I am a file with a c3VwZXIgc2VjcmV0IHZhbHVl", revealed)
-
 
     def test_gpg_function_ed25519(self):
         "write ed25519 (private and public), confirm secret file exists, reveal and check"

--- a/tests/test_kubernetes_compiled/all-glob/manifests/mysql_secret_subvar.yml
+++ b/tests/test_kubernetes_compiled/all-glob/manifests/mysql_secret_subvar.yml
@@ -1,7 +1,7 @@
 apiVersion: v1
 data:
-  MYSQL_ROOT_PASSWORD: ?{base64:targets/all-glob/mysql/subvars@var1.password:4d310147}
-  MYSQL_ROOT_PASSWORD_SHA256: ?{base64:targets/all-glob/mysql/subvars@var2.password_sha256:4d310147}
+  MYSQL_ROOT_PASSWORD: ?{base64:targets/all-glob/mysql/subvars@var1.password:fa652988}
+  MYSQL_ROOT_PASSWORD_SHA256: ?{base64:targets/all-glob/mysql/subvars@var2.password_sha256:fa652988}
 kind: Secret
 metadata:
   annotations: {}

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -57,8 +57,10 @@ class Base64RefsTest(unittest.TestCase):
         REF_CONTROLLER_EMBEDDED[tag] = Base64Ref(b"ref 1 data")
         ref_obj = REF_CONTROLLER_EMBEDDED[tag]
         compiled_embedded = ref_obj.compile()
-        embedded_tag = ("?{base64:eyJkYXRhIjogImNtVm1JREVnWkdGMFlRPT0iLCAiZW5jb2"
-                "RpbmciOiAib3JpZ2luYWwiLCAidHlwZSI6ICJiYXNlNjQifQ==:embedded}")
+        embedded_tag = (
+            "?{base64:eyJkYXRhIjogImNtVm1JREVnWkdGMFlRPT0iLCAiZW5jb2"
+            "RpbmciOiAib3JpZ2luYWwiLCAidHlwZSI6ICJiYXNlNjQifQ==:embedded}"
+        )
         self.assertEqual(compiled_embedded, embedded_tag)
 
     def test_base64_ref_recompile(self):
@@ -228,7 +230,6 @@ class Base64RefsTest(unittest.TestCase):
         self.assertEqual(ref_obj1.embedded_subvar_path, "var1")
         self.assertEqual(ref_obj2.embedded_subvar_path, "var2")
         self.assertEqual(ref_obj3.embedded_subvar_path, "var3.var4")
-
 
     def test_compile_embedded_subvars(self):
         """

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -202,7 +202,7 @@ class Base64RefsTest(unittest.TestCase):
         revealed_data = REVEALER.reveal_raw(data)
         self.assertEqual("message here: world", revealed_data)
 
-        with self.assertRaises(KeyError):
+        with self.assertRaises(RefError):
             tag_subvar = "?{base64:ref/subvars@var3.varDoesntExist}"
             data = "message here: {}".format(tag_subvar)
             revealed_data = REVEALER.reveal_raw(data)


### PR DESCRIPTION
## Proposed Changes
Adds support for embedding content of a ref in the compiled output.

This allows for revealing compiled files without needing access to ref files.

By running `$ kapitan compile --embed-refs`, compiled files with refs will have embedded compiled refs under the following format (gkms as an example): 

`?{gkms:ReallyLongBase64HereZ2FyZ2FiZQo=:embedded}`

Which means that compiled outputs with embedded refs can be completely distributed without the need to access ref contents in their refs directory.

Related to #435

Also fixes issue #499