### PR TITLE
show traceback to explain source of the issue

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -516,6 +516,7 @@ def main():
             validate=args.validate,
             schemas_path=args.schemas_path,
             jinja2_filters=args.jinja2_filters,
+            verbose=hasattr(args, "verbose") and args.verbose,
         )
 
     elif cmd == "inventory":

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -137,7 +137,10 @@ def compile_targets(
             logger.exception("Unknown (Non-Kapitan) Error occurred")
 
         logger.error("\n")
-        logger.error(e)
+        if kwargs.get("verbose"):
+            logger.exception(e)
+        else:
+            logger.error(e)
         sys.exit(1)
     finally:
         # always wait for other worker processes to terminate


### PR DESCRIPTION
This fixes the issue where the error logged by kapitan is unclear when using jinja2. 
Because the traceback can be lengthy, I made it listen to the verbose flag for the compile command.

Before:
```
Jinja2 error: failed to render /home/paul/antenna/antenna-ops-kapitan/kubernetes-apps/components/lyst/manifests/django-secret.yaml: 'NoneType' object has no attribute 'encode'
Compile error: failed to compile target: staging
```

After:
```
Jinja2 error: failed to render /home/paul/redacted/redacted-ops-kapitan/kubernetes-apps/components/lyst/manifests/django-secret.yaml: 'NoneType' object has no attribute 'encode'
Compile error: failed to compile target: staging
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/utils.py", line 153, in render_jinja2
    "content": render_jinja2_file(
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/utils.py", line 121, in render_jinja2_file
    return env.get_template(filename).render(context)
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "/home/paul/redacted/redacted-ops-kapitan/kubernetes-apps/components/lyst/manifests/django-secret.yaml", line 21, in top-level template code
    REDACTED_BIGQUERY_DATASET: {{ params.redacted.bigquery_dataset | b64encode }}
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/inputs/jinja2_filters.py", line 87, in base64_encode
    return base64.b64encode(string.encode("UTF-8")).decode("UTF-8")
AttributeError: 'NoneType' object has no attribute 'encode'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/inputs/base.py", line 67, in compile_input_path
    self.compile_file(
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/inputs/jinja2.py", line 39, in compile_file
    for item_key, item_value in render_jinja2(
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/utils.py", line 159, in render_jinja2
    raise CompileError(f"Jinja2 error: failed to render {render_path}: {e}")
kapitan.errors.CompileError: Jinja2 error: failed to render /home/paul/redacted/redacted-ops-kapitan/kubernetes-apps/components/lyst/manifests/django-secret.yaml: 'NoneType' object has no attribute 'encode'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/targets.py", line 408, in compile_target
    input_compiler.compile_obj(comp_obj, ext_vars, **kwargs)
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/inputs/base.py", line 52, in compile_obj
    self.compile_input_path(input_path, comp_obj, ext_vars, **kwargs)
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/inputs/base.py", line 77, in compile_input_path
    raise CompileError("{}\nCompile error: failed to compile target: {}".format(e, target_name))
kapitan.errors.CompileError: Jinja2 error: failed to render /home/paul/redacted/redacted-ops-kapitan/kubernetes-apps/components/lyst/manifests/django-secret.yaml: 'NoneType' object has no attribute 'encode'
Compile error: failed to compile target: staging
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/targets.py", line 92, in compile_targets
    [p.get() for p in pool.imap_unordered(worker, target_objs) if p]
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/site-packages/kapitan/targets.py", line 92, in <listcomp>
    [p.get() for p in pool.imap_unordered(worker, target_objs) if p]
  File "/home/paul/redacted/redacted-ops-kapitan/venv/lib/python3.8/multiprocessing/pool.py", line 865, in next
    raise value
kapitan.errors.CompileError: Jinja2 error: failed to render /home/paul/redacted/redacted-ops-kapitan/kubernetes-apps/components/lyst/manifests/django-secret.yaml: 'NoneType' object has no attribute 'encode'
Compile error: failed to compile target: staging
```