### PR TITLE
Remote inventory proposal

### DIFF
--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -19,11 +19,17 @@ remoteInventory:
         output_path: <relative_output_path>
         ... type specific arguments
 ```
+
 The command for adding the remote inventories from the cli and fetching it will be:
+
 ``` $ kapitan inventory --fetch <output-path> <source> ```
+
 The command for only adding remote inventories to the .kapitan file from cli will be:
+
 ```$ kapitan inventory --add <inventory-name> <output-path> <source> ```
+
 The command for fetching all the inventory declared in .kapitan file will be:
+
 ```$ kapitan inventory --fetch-all```
 
 ## Copying inventory files to the output location

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -2,7 +2,6 @@
 
 This feature would add the ability to Kapitan to fetch parts of the inventory from remote locations (https/git). This would allow users to combine different inventories from different sources and build modular infrastructure reusable across various repos.
 
-
 Author: @alpharoy14
 
 ## Specification
@@ -19,19 +18,17 @@ remoteInventory:
         output_path: <relative_output_path>
         ... type specific arguments
 ```
-The command for adding remote inventories to the `.kapitan` file from cli will be:
-```$ kapitan inventory --add <inventory-name> <output-path> <source> ```
-The command for fetching remote inventories that is added to the `.kapitan` file will be:
-``` $ kapitan inventory --fetch <inventory-name> ```
-The command for fetching all the inventory declared in .kapitan file will be:
 
+The command for fetching a specific remote inventory declared in inventory configuration files will be:
+``` $ kapitan inventory --fetch <inventory-name> ```
+
+The command for fetching all the inventories declared in inventory configuration files will be:
 ```$ kapitan inventory --fetch-all```
 
 ## Copying inventory files to the output location
 The output path is the path to save the inventory items into. The path is relative to the `inventory/` directory. For example, it could be `/classes/`. The contents of the fetched inventory will be recursively copied.
 
-The fetched inventory files will be cached in a temp directory.
-The temp directory (`remote_inventories/`) will be in the path pointed by the $XDG_CACHE_HOME environment variable. In case that does not exist, we can check the `$KAPITAN_CACHE_DIR`. Which, by default, will be set to the root folder of the project.
+The fetched inventory files will be cached in the `.kapitan_cache` directory.
 
 ## Force fetching
 While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will raise an error saying so.

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -1,0 +1,62 @@
+# Remote Inventory Federation
+
+This feature would add the ability to Kapitan to fetch parts of the Inventory from remote locations (https/git). This would allow users to combine different inventories from different sources and build modular infrastructure reusable across various repos.
+
+
+Author: @alpharoy14
+
+## Specification
+
+The configuration and declaration of remote inventories would be done in the hidden file `​.kapitan`
+
+The file specifications are as follows:
+
+```yaml
+remoteInventory:
+    -   name: <inventory_name> #user defined
+        type: <inventory_type> #git\https
+        source: <source_of_inventory>
+        output_path: <relative_output_path>
+        ... type specific arguments
+```
+The command for adding the remote inventories from the cli and fetching it will be:
+``` $ kapitan inventory --fetch <output-path> <source> ```
+he command for only adding remote inventories to the .kapitan file from cli will be:
+```$ kapitan inventory --add <output-path> <source> ```
+The command for fetching all the inventory declared in .kapitan file will be:
+```$ kapitan inventory --fetch-all```
+
+## Copying inventory files to the output location
+The output path is the path to save the invertory intems into. The path is relative to the `inventory/` directory. For example, it could be `/classes/`. The contents of the fetched inventory will be reccursively copied.
+
+The fetched inveltory files will be cached in a temp directory.
+The temp directory (`remote_inventories/`) will be in the path pointed by the $XDG_CACHE_HOME environment variable. In case that does not exist, we can check the `$KAPITAN_CACHE_DIR`. Which, by default, will be set to the root folder of the project.
+
+## Force fetching
+While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will raise an error saying so.
+
+To overwrite the files with the newly downloaded inventory items, we can add the --force flag to the fetch command as shown below.
+
+`$ kapitan inventory --fetch-all --force`
+`$ kapitan inventory --fetch <output-path> <source> --force`
+
+## URL type
+The URL type (Http/git) will be infered from the <source> address. Depending on the URL type, the configuration file may have aditional arguments.
+
+E.g Git type may also include aditional `ref` parameter as illustrated below:
+
+```yaml
+remoteInventory:
+    -   name: <inventory_name> #user defined
+        type: <inventory_type> #git\https
+        source: <source_of_inventory>
+        output_path: <relative_output_path>
+        ref: <commit_hash/branch/tag>
+```
+
+## Implementation details
+
+### Dependencies
+
+- [GitPython](https://github.com/gitpython-developers/GitPython) module (and git executable) for git type
+- requests module for http[s]

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -6,24 +6,21 @@ Author: @alpharoy14
 
 ## Specification
 
-The configuration and declaration of remote inventories would be done in the hidden file `​.kapitan`.
+The configuration and declaration of remote inventories would be done in the inventory files.
 
 The file specifications are as follows:
 
 ```yaml
-remoteInventory:
-    -   name: <inventory_name> #user defined
-        type: <inventory_type> #git\https
-        source: <source_of_inventory>
-        output_path: <relative_output_path>
-        ... type specific arguments
+parameters:
+ kapitan:
+  inventory:
+   - type: <inventory_type> #git\https
+     source: <source_of_inventory>
+     output_path: <relative_output_path>
 ```
 
-The command for fetching a specific remote inventory declared in inventory configuration files will be:
-``` $ kapitan inventory --fetch <inventory-name> ```
+On executing the ``` $ kapitan compile``` command, first the remote inventories will be fetched followed by fetching of external dependencies and finally reclass will be used to compile.
 
-The command for fetching all the inventories declared in inventory configuration files will be:
-```$ kapitan inventory --fetch-all```
 
 ## Copying inventory files to the output location
 The output path is the path to save the inventory items into. The path is relative to the `inventory/` directory. For example, it could be `/classes/`. The contents of the fetched inventory will be recursively copied.
@@ -31,25 +28,23 @@ The output path is the path to save the inventory items into. The path is relati
 The fetched inventory files will be cached in the `.kapitan_cache` directory.
 
 ## Force fetching
-While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will raise an error saying so.
+While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will skip fetching it.
 
-To overwrite the files with the newly downloaded inventory items, we can add the --force flag to the fetch command, as shown below.
+To overwrite the files with the newly downloaded inventory items, we can add the `--force` flag to the compile command, as shown below.
 
-`$ kapitan inventory --fetch-all --force`
-`$ kapitan inventory --fetch <inventory-name> --force`
+`$ kapitan compile --force`
 
 ## URL type
-The URL type (Http/git) will be inferred from the <source> address. Depending on the URL type, the configuration file may have additional arguments.
+The URL type can be either git or http(s). Depending on the URL type, the configuration file may have additional arguments.
 
 E.g Git type may also include aditional `ref` parameter as illustrated below:
 
 ```yaml
-remoteInventory:
-    -   name: <inventory_name> #user defined
-        type: <inventory_type> #git\https
-        source: <source_of_inventory>
-        output_path: <relative_output_path>
-        ref: <commit_hash/branch/tag>
+inventory:
+ - type: git #git\https
+   source: <source_of_inventory>
+   output_path: <output_path>
+   ref: <commit_hash/branch/tag>
 ```
 
 ## Implementation details

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -21,8 +21,8 @@ remoteInventory:
 ```
 The command for adding the remote inventories from the cli and fetching it will be:
 ``` $ kapitan inventory --fetch <output-path> <source> ```
-he command for only adding remote inventories to the .kapitan file from cli will be:
-```$ kapitan inventory --add <output-path> <source> ```
+The command for only adding remote inventories to the .kapitan file from cli will be:
+```$ kapitan inventory --add <inventory-name> <output-path> <source> ```
 The command for fetching all the inventory declared in .kapitan file will be:
 ```$ kapitan inventory --fetch-all```
 

--- a/docs/kap_proposals/kap_7_remote_inventory.md
+++ b/docs/kap_proposals/kap_7_remote_inventory.md
@@ -1,13 +1,13 @@
 # Remote Inventory Federation
 
-This feature would add the ability to Kapitan to fetch parts of the Inventory from remote locations (https/git). This would allow users to combine different inventories from different sources and build modular infrastructure reusable across various repos.
+This feature would add the ability to Kapitan to fetch parts of the inventory from remote locations (https/git). This would allow users to combine different inventories from different sources and build modular infrastructure reusable across various repos.
 
 
 Author: @alpharoy14
 
 ## Specification
 
-The configuration and declaration of remote inventories would be done in the hidden file `​.kapitan`
+The configuration and declaration of remote inventories would be done in the hidden file `​.kapitan`.
 
 The file specifications are as follows:
 
@@ -19,35 +19,30 @@ remoteInventory:
         output_path: <relative_output_path>
         ... type specific arguments
 ```
-
-The command for adding the remote inventories from the cli and fetching it will be:
-
-``` $ kapitan inventory --fetch <output-path> <source> ```
-
-The command for only adding remote inventories to the .kapitan file from cli will be:
-
+The command for adding remote inventories to the `.kapitan` file from cli will be:
 ```$ kapitan inventory --add <inventory-name> <output-path> <source> ```
-
+The command for fetching remote inventories that is added to the `.kapitan` file will be:
+``` $ kapitan inventory --fetch <inventory-name> ```
 The command for fetching all the inventory declared in .kapitan file will be:
 
 ```$ kapitan inventory --fetch-all```
 
 ## Copying inventory files to the output location
-The output path is the path to save the invertory intems into. The path is relative to the `inventory/` directory. For example, it could be `/classes/`. The contents of the fetched inventory will be reccursively copied.
+The output path is the path to save the inventory items into. The path is relative to the `inventory/` directory. For example, it could be `/classes/`. The contents of the fetched inventory will be recursively copied.
 
-The fetched inveltory files will be cached in a temp directory.
+The fetched inventory files will be cached in a temp directory.
 The temp directory (`remote_inventories/`) will be in the path pointed by the $XDG_CACHE_HOME environment variable. In case that does not exist, we can check the `$KAPITAN_CACHE_DIR`. Which, by default, will be set to the root folder of the project.
 
 ## Force fetching
 While fetching, the output path will be recursively checked to see if it contains any file with the same name. If so, kapitan will raise an error saying so.
 
-To overwrite the files with the newly downloaded inventory items, we can add the --force flag to the fetch command as shown below.
+To overwrite the files with the newly downloaded inventory items, we can add the --force flag to the fetch command, as shown below.
 
 `$ kapitan inventory --fetch-all --force`
-`$ kapitan inventory --fetch <output-path> <source> --force`
+`$ kapitan inventory --fetch <inventory-name> --force`
 
 ## URL type
-The URL type (Http/git) will be infered from the <source> address. Depending on the URL type, the configuration file may have aditional arguments.
+The URL type (Http/git) will be inferred from the <source> address. Depending on the URL type, the configuration file may have additional arguments.
 
 E.g Git type may also include aditional `ref` parameter as illustrated below:
 
@@ -61,6 +56,7 @@ remoteInventory:
 ```
 
 ## Implementation details
+TODO
 
 ### Dependencies
 


### PR DESCRIPTION
# query related to .kapitan file 
In the proposal, I mentioned that `.kapitan`can be used to store the remote inventory configuration. From the codebase, I could figure out that `.kapitan` is used to store the arguments of various flags as well. However, after compilation when I list the items (` $ ls -al`) of the root directory  of the project I don't see any `.kapitan` file. Where can I find the `.kapitan` file so that I can manually see its contents?
# query related to command line arguments
## The proposed method of adding remote inventory details from cli is as follows

The command for adding the remote inventories from the cli and fetching it will be:
``` $ kapitan inventory --fetch <output-path> <source> ```
The command for only adding remote inventories to the .kapitan file from cli will be:
```$ kapitan inventory --add <inventory-name> <output-path> <source> ```
The command for fetching all the inventory declared in .kapitan file will be:
```$ kapitan inventory --fetch-all```
## Alternative 
Does it make more sense to have ``` $ kapitan inventory --fetch <inventory-name>  ``` instead of ``` $ kapitan inventory --fetch <output-path> <source> ``` ?
This way we can add the remote inventories using ```$ kapitan inventory --add <inventory-name> <output-path> <source> ``` and fetch it using ``` $ kapitan inventory --fetch <inventory-name>  ```. 
We can also force fetch an existing inventory using `$ kapitan inventory --fetch <inventory-name> --force`.

