### PR TITLE
Fix issue #513: add kapitan/inputs/templates to pyinstaller configuration and start release-v0.27.3-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.27.3-rc.3:
+- Fix Vaultkv Error Handling (#512)
+- Fix Running init with kapitan binary doesn't work (#514)
+
 ## 0.27.3-rc.2:
 - Show traceback to explain source of the issue (#507)
 - Handle function calling logic in argparse instead of using equals (#509)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -83,6 +83,10 @@ mkdocs gh-deploy -m "Commit message" -f ./mkdocs.yml -b gh-pages
 
 After it's pushed, create a PR that targets our gh-pages branch from your gh-pages branch.
 
+## Packaging extra resources in python package or binary
+
+To package any extra resources/files in the pip package or the kapitan binary, make sure you modify both `MANIFEST.in` and `scripts/pyinstaller.sh`.
+
 ## Contributor License Agreement
 
 Contributions to this project must be accompanied by a Contributor License

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -10,6 +10,7 @@ output_name='kapitan-linux-amd64'
 pyi-makespec kapitan/"$entry".py --onefile \
     --add-data kapitan/reclass/reclass:reclass \
     --add-data kapitan/lib:kapitan/lib \
+    --add-data kapitan/inputs/templates:kapitan/inputs/templates \
     --add-data kapitan/inputs/helm/libtemplate.so:kapitan/inputs/helm \
     --hidden-import pyparsing --hidden-import jsonschema \
     --exclude-module doctest --exclude-module pydoc


### PR DESCRIPTION
Fix issue #513: add kapitan/inputs/templates to pyinstaller configuration and start release-v0.27.3-rc.3

