### PR TITLE
Fix issues #535 and #536 by resolving relative paths in the copy input type and not clobbering the output dir

### DIFF
--- a/examples/kubernetes/compiled/busybox/copy/copy_target
+++ b/examples/kubernetes/compiled/busybox/copy/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/examples/kubernetes/compiled/busybox/copy_target
+++ b/examples/kubernetes/compiled/busybox/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/examples/kubernetes/compiled/minikube-es/copy/copy_target
+++ b/examples/kubernetes/compiled/minikube-es/copy/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/examples/kubernetes/compiled/minikube-es/copy_target
+++ b/examples/kubernetes/compiled/minikube-es/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/examples/kubernetes/copy_target
+++ b/examples/kubernetes/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/examples/kubernetes/inventory/classes/component/busybox.yml
+++ b/examples/kubernetes/inventory/classes/component/busybox.yml
@@ -8,3 +8,13 @@ parameters:
         input_type: copy
         input_paths:
           - components/busybox/pod.yml
+      # test copying over existing output_path to check for clobbering
+      - input_type: copy
+        input_paths:
+          - copy_target
+        output_path: ./copy
+      # test copying over root output_path
+      - input_type: copy
+        input_paths:
+          - copy_target
+        output_path: .

--- a/kapitan/inputs/copy.py
+++ b/kapitan/inputs/copy.py
@@ -8,6 +8,7 @@
 import logging
 import os
 import shutil
+from distutils.dir_util import copy_tree
 
 from kapitan.inputs.base import InputType
 
@@ -33,9 +34,8 @@ class Copy(InputType):
                     os.makedirs(compile_path, exist_ok=True)
                     shutil.copy2(file_path, os.path.join(compile_path, os.path.basename(file_path)))
             else:
-                if os.path.exists(compile_path):
-                    shutil.rmtree(compile_path)
-                shutil.copytree(file_path, compile_path)
+                compile_path = os.path.abspath(compile_path)  # Resolve relative paths
+                copy_tree(file_path, compile_path)
         except OSError as e:
             logger.exception(f"Input dir not copied. Error: {e}")
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -6,16 +6,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 "copy tests"
-import os
-import sys
-import shutil
+import filecmp
 import hashlib
+import os
+import shutil
+import sys
 import unittest
 
 from kapitan.cli import main
-from kapitan.utils import directory_hash
 from kapitan.inputs.copy import Copy
-
+from kapitan.utils import directory_hash
 
 search_path = ""
 ref_controller = ""
@@ -85,19 +85,28 @@ class CompileCopyTest(unittest.TestCase):
     def setUp(self):
         os.chdir(os.path.join(os.getcwd(), "examples", "kubernetes"))
 
+    def validate_files_were_copied(self):
+        original_filepath = os.path.join("components", "busybox", "pod.yml")
+        copied_filepath = os.path.join("compiled", "busybox", "copy", "pod.yml")
+        self.assertTrue(filecmp.cmp(original_filepath, copied_filepath))
+
+        original_filepath = os.path.join("copy_target")
+        copied_filepath = os.path.join("compiled", "busybox", "copy", "copy_target")
+        self.assertTrue(filecmp.cmp(original_filepath, copied_filepath))
+
+        original_filepath = os.path.join("copy_target")
+        copied_filepath = os.path.join("compiled", "busybox", "copy_target")
+        self.assertTrue(filecmp.cmp(original_filepath, copied_filepath))
+
     def test_compiled_copy_target(self):
         sys.argv = ["kapitan", "compile", "-t", "busybox"]
         main()
-        file_path_hash = directory_hash(os.path.join("components", "busybox"))
-        compile_path_hash = directory_hash(os.path.join("compiled", "busybox", "copy"))
-        self.assertEqual(file_path_hash, compile_path_hash)
+        self.validate_files_were_copied()
 
     def test_compiled_copy_all_targets(self):
         sys.argv = ["kapitan", "compile"]
         main()
-        file_path_hash = directory_hash(os.path.join("components", "busybox"))
-        compile_path_hash = directory_hash(os.path.join("compiled", "busybox", "copy"))
-        self.assertEqual(file_path_hash, compile_path_hash)
+        self.validate_files_were_copied()
 
     def tearDown(self):
         os.chdir(os.path.join(os.getcwd(), "..", ".."))

--- a/tests/test_kubernetes_compiled/busybox/copy/copy_target
+++ b/tests/test_kubernetes_compiled/busybox/copy/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/tests/test_kubernetes_compiled/busybox/copy_target
+++ b/tests/test_kubernetes_compiled/busybox/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/tests/test_kubernetes_compiled/minikube-es/copy/copy_target
+++ b/tests/test_kubernetes_compiled/minikube-es/copy/copy_target
@@ -1,0 +1,1 @@
+for_testing

--- a/tests/test_kubernetes_compiled/minikube-es/copy_target
+++ b/tests/test_kubernetes_compiled/minikube-es/copy_target
@@ -1,0 +1,1 @@
+for_testing


### PR DESCRIPTION
Added some examples too so they're tested continuously in the future.