### PR TITLE
Speed up build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,18 @@ FROM golang:1.14.4-stretch AS helm-builder
 RUN mkdir /kapitan
 WORKDIR /kapitan
 
+COPY ./kapitan/inputs/helm ./kapitan/inputs/helm
+RUN chmod +x ./kapitan/inputs/helm/build.sh \
+    && ./kapitan/inputs/helm/build.sh
+
+COPY ./kapitan/dependency_manager/helm ./kapitan/dependency_manager/helm
+RUN chmod +x ./kapitan/dependency_manager/helm/build.sh \
+    && ./kapitan/dependency_manager/helm/build.sh
+
 COPY ./kapitan ./kapitan
 COPY ./MANIFEST.in ./MANIFEST.in
 COPY ./requirements.txt ./requirements.txt
 COPY ./setup.py ./setup.py
-
-RUN chmod +x ./kapitan/inputs/helm/build.sh \
-    && ./kapitan/inputs/helm/build.sh
-
-RUN chmod +x ./kapitan/dependency_manager/helm/build.sh \
-    && ./kapitan/dependency_manager/helm/build.sh
 
 # Build the virtualenv for Kapitan
 FROM python:3.7-slim-stretch AS python-builder

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -13,16 +13,18 @@ FROM golang:1.14.4-stretch AS helm-builder
 RUN mkdir /kapitan
 WORKDIR /kapitan
 
+COPY ./kapitan/inputs/helm ./kapitan/inputs/helm
+RUN chmod +x ./kapitan/inputs/helm/build.sh \
+    && ./kapitan/inputs/helm/build.sh
+
+COPY ./kapitan/dependency_manager/helm ./kapitan/dependency_manager/helm
+RUN chmod +x ./kapitan/dependency_manager/helm/build.sh \
+    && ./kapitan/dependency_manager/helm/build.sh
+
 COPY ./kapitan ./kapitan
 COPY ./MANIFEST.in ./MANIFEST.in
 COPY ./requirements.txt ./requirements.txt
 COPY ./setup.py ./setup.py
-
-RUN chmod +x ./kapitan/inputs/helm/build.sh \
-    && ./kapitan/inputs/helm/build.sh
-
-RUN chmod +x ./kapitan/dependency_manager/helm/build.sh \
-    && ./kapitan/dependency_manager/helm/build.sh
 
 # Build final image
 FROM python:3.7-buster

--- a/Dockerfile.pyinstaller
+++ b/Dockerfile.pyinstaller
@@ -16,6 +16,7 @@ RUN chmod +x ./kapitan/dependency_manager/helm/build.sh \
 COPY ./kapitan ./kapitan
 COPY ./MANIFEST.in ./MANIFEST.in
 COPY ./requirements.txt ./requirements.txt
+COPY ./scripts/pyinstaller.sh ./pyinstaller.sh
 COPY ./setup.py ./setup.py
 
 

--- a/Dockerfile.pyinstaller
+++ b/Dockerfile.pyinstaller
@@ -5,17 +5,19 @@ FROM golang:1.14.4-stretch AS helm-builder
 RUN mkdir /kapitan
 WORKDIR /kapitan
 
-COPY ./kapitan ./kapitan
-COPY ./MANIFEST.in ./MANIFEST.in
-COPY ./requirements.txt ./requirements.txt
-COPY ./scripts/pyinstaller.sh ./pyinstaller.sh
-COPY ./setup.py ./setup.py
-
+COPY ./kapitan/inputs/helm ./kapitan/inputs/helm
 RUN chmod +x ./kapitan/inputs/helm/build.sh \
     && ./kapitan/inputs/helm/build.sh
 
+COPY ./kapitan/dependency_manager/helm ./kapitan/dependency_manager/helm
 RUN chmod +x ./kapitan/dependency_manager/helm/build.sh \
     && ./kapitan/dependency_manager/helm/build.sh
+
+COPY ./kapitan ./kapitan
+COPY ./MANIFEST.in ./MANIFEST.in
+COPY ./requirements.txt ./requirements.txt
+COPY ./setup.py ./setup.py
+
 
 FROM python:3.7-slim-stretch
 


### PR DESCRIPTION
Speed up build time by only building golang binaries when the golang files change, leveraging docker caching.

## Proposed Changes

  - Each docker image has the golang binary materials added first and built.

