### PR TITLE
Fix small bug in github docker action for master branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -32,7 +32,6 @@ jobs:
           dockerfile: Dockerfile
       - name: "Build PR/latest/versioned ci tags"
         uses: docker/build-push-action@v1
-        if: github.ref != 'refs/heads/master'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -42,7 +41,8 @@ jobs:
           dockerfile: Dockerfile.ci
       - name: "Test both Dockerfile and Dockerfile.ci in current ref"
         run: |
-            docker run -t --rm deepmind/kapitan:${{ env.REF_NAME }} --version
+            [ ${{ env.REF_NAME }} == "master" ] && tagname="latest" || tagname=${{ env.REF_NAME }}
+            docker run -t --rm deepmind/kapitan:${tagname} --version
             docker run -t --rm deepmind/kapitan:${{ env.REF_NAME }}-ci kapitan --version
       - name: "Build major version tag"
         uses: docker/build-push-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.28.1-rc.2:
+## 0.28.1-rc.3:
 - Enable helm values files to be injected for input type "helm" (#545)
 - Fix issue #500: Add --ref-file or --tag to refs --reveal option. (#548)
 


### PR DESCRIPTION
```
Run docker run -t --rm deepmind/kapitan:master --version
Unable to find image 'deepmind/kapitan:master' locally
docker: Error response from daemon: manifest for deepmind/kapitan:master not found: manifest unknown: manifest unknown.
See 'docker run --help'.
##[error]Process completed with exit code 125.
```
This fixes the master branch edge case where the docker push action translates ("master" <> ref name) to ("latest" <> docker tag).