### PR TITLE
add logging fix for python 3.8+ on macOS

### DIFF
--- a/kapitan/__init__.py
+++ b/kapitan/__init__.py
@@ -26,9 +26,10 @@ def setup_logging(name=None, level=logging.INFO, force=False):
     if sys.version_info < (3, 8) and force:
         logging.getLogger(name).setLevel(level)
 
+
 # XXX in MacOS, updating logging level in __main__ doesn't work for python3.8+
 # XXX this is a hack that seems to work
-if '-v' in sys.argv or '--verbose' in sys.argv:
+if "-v" in sys.argv or "--verbose" in sys.argv:
     setup_logging(level=logging.DEBUG)
 else:
     setup_logging()

--- a/kapitan/__init__.py
+++ b/kapitan/__init__.py
@@ -7,6 +7,31 @@
 
 import os
 import sys
+import logging
+
+
+def setup_logging(name=None, level=logging.INFO, force=False):
+    "setup logging and deal with logging behaviours in MacOS python 3.8 and below"
+    # default opts
+    kwopts = {"format": "%(message)s", "level": level}
+
+    if level == logging.DEBUG:
+        kwopts["format"] = "%(asctime)s %(name)-12s %(levelname)-8s %(message)s"
+
+    if sys.version_info >= (3, 8) and force:
+        kwopts["force"] = True
+
+    logging.basicConfig(**kwopts)
+
+    if sys.version_info < (3, 8) and force:
+        logging.getLogger(name).setLevel(level)
+
+# XXX in MacOS, updating logging level in __main__ doesn't work for python3.8+
+# XXX this is a hack that seems to work
+if '-v' in sys.argv or '--verbose' in sys.argv:
+    setup_logging(level=logging.DEBUG)
+else:
+    setup_logging()
 
 # Adding reclass to PYTHONPATH
 sys.path.insert(0, os.path.dirname(__file__) + "/reclass")

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -28,6 +28,7 @@ from kapitan.version import DESCRIPTION, PROJECT_NAME, VERSION
 
 logger = logging.getLogger(__name__)
 
+
 def print_deprecated_secrets_msg(args):
     logger.error("Secrets have been renamed to refs, please refer to: '$ kapitan refs --help'")
     sys.exit(1)

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -16,7 +16,7 @@ import os
 import sys
 
 import yaml
-from kapitan import cached, defaults
+from kapitan import cached, defaults, setup_logging
 from kapitan.initialiser import initialise_skeleton
 from kapitan.lint import start_lint
 from kapitan.refs.base import RefController, Revealer
@@ -27,7 +27,6 @@ from kapitan.utils import check_version, from_dot_kapitan, jsonnet_file, searchv
 from kapitan.version import DESCRIPTION, PROJECT_NAME, VERSION
 
 logger = logging.getLogger(__name__)
-
 
 def print_deprecated_secrets_msg(args):
     logger.error("Secrets have been renamed to refs, please refer to: '$ kapitan refs --help'")
@@ -529,11 +528,9 @@ def main():
     cached.args[sys.argv[1]] = args
 
     if hasattr(args, "verbose") and args.verbose:
-        logging.basicConfig(level=logging.DEBUG, format="%(asctime)s %(name)-12s %(levelname)-8s %(message)s")
+        setup_logging(level=logging.DEBUG, force=True)
     elif hasattr(args, "quiet") and args.quiet:
-        logging.basicConfig(level=logging.CRITICAL, format="%(message)s")
-    else:
-        logging.basicConfig(level=logging.INFO, format="%(message)s")
+        setup_logging(level=logging.CRITICAL, force=True)
 
     # call chosen command
     args.func(args)


### PR DESCRIPTION
Fixes issue #558 

Not an ideal fix, but I could not find a better way to fix. Python 3.8 logging on macOS seems to have changed behaviour / or is buggy, as updating logging levels at runtime does not seem to propagate to all loggers.