### PR TITLE
Adds kadet_params for compile time parameter injection into kadet modules

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -261,7 +261,7 @@ For a deeper understanding of this input type please review the proposal documen
 - yaml (default)
 - json
 
-#### using kadet for "post processing" or "overlaying" manifests
+#### using kadet for "post processing" or "overlaying" manifests (alpha/experimental)
 
 Sometimes you need to add a little something extra to manifests that you can't do within the original compile block.
 
@@ -277,7 +277,8 @@ parameters:
     output_path: test-1
   kapitan:
     compile:
-    - input_type: helm
+    - name: template-helm-chart
+      input_type: helm
       output_path: ${test_1:output_path}
       input_paths:
       	- <chart_path>
@@ -289,19 +290,20 @@ parameters:
       	namespace: <substitutes_.Release.Namespace>
       	name_template: <namespace_template>
       	release_name: <chart_release_name>
-    - input_type: kadet
+    - name: add-metadata-test-1
+      input_type: kadet
       output_path: ${test_1:output_path}
       input_paths:
         - <path_to_kadet_module>
-      kadet_params:
+      input_params:
         team_name: ops
-        input_paths: [${test_1:output_path}]
+        post_process_inputs: [template-helm-chart]
 ```
 Here you can clearly define the order in which your manifests are compiled and ensure that the helm
-chart is templated before your kadet module is run. The `kadet_params` injected are available in
-the main function as an object. `kadet_params` will always have the `compile_path` which is the absolute
+chart is templated before your kadet module is run. The `input_params` injected are available in
+the main function as an object. `input_params` will always have the `compile_path` which is the absolute
 path to the compile directory where manifests are compiled on the current run. Any additional keys 
-placed on the `kadet_params` in the compile block can be accessed in the kadet module for that specific
+placed on the `input_params` in the compile block can be accessed in the kadet module for that specific
 compile run.
 
 ```python
@@ -309,11 +311,11 @@ from kapitan.inputs import kadet
 
 inventory = kadet.inventory()
 
-def main(kadet_params):
-    team_name = kadet_params.get("team_name", "no-owner")
+def main(input_params):
+    team_name = input_params.get("team_name", "no-owner")
 ...
     target_name = inventory.parameters.kapitan.vars.target
-    compile_path = kadet_params.get("compile_path")
+    compile_path = input_params.get("compile_path")
 ...
 ```
 

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -211,7 +211,7 @@ Method functions:
 
 A class can be a resource such as a kubernetes Deployment as shown here:
 
-```
+```python
 class Deployment(BaseObj):
     def new(self):
         self.need("name", "name string needed")
@@ -232,7 +232,7 @@ We have established that you may define a library which holds information on cla
 
 Here we import `kubelib` using `load_from_search_paths()`. We then use kubelib to access the defined object classes. In this instance the Deployment & Service resource class.
 
-```
+```python
 ...
 kubelib = kadet.load_from_search_paths("kubelib")
 ...
@@ -260,6 +260,65 @@ For a deeper understanding of this input type please review the proposal documen
 
 - yaml (default)
 - json
+
+#### using kadet for "post processing" or "overlaying" manifests
+
+Sometimes you need to add a little something extra to manifests that you can't do within the original compile block.
+
+For instance, you might use an open source helm chart that doesn't have a specific parameter that is
+configurable. You could download the helm chart locally, amend the chart to take a new parameter, and
+check it into your repository. This could make it harder to upgrade chart versions in the future, and
+understand the motivation behind changes in the chart itself.
+
+Instead, you could create a kadet module that compiles after the helm input has compiled.
+```yaml
+parameters:
+  test_1:
+    output_path: test-1
+  kapitan:
+    compile:
+    - input_type: helm
+      output_path: ${test_1:output_path}
+      input_paths:
+      	- <chart_path>
+      helm_values:
+        <object_with_values_to_override>
+      helm_values_files:
+        - <values_file_path>
+      helm_params:
+      	namespace: <substitutes_.Release.Namespace>
+      	name_template: <namespace_template>
+      	release_name: <chart_release_name>
+    - input_type: kadet
+      output_path: ${test_1:output_path}
+      input_paths:
+        - <path_to_kadet_module>
+      kadet_params:
+        team_name: ops
+        input_paths: [${test_1:output_path}]
+```
+Here you can clearly define the order in which your manifests are compiled and ensure that the helm
+chart is templated before your kadet module is run. The `kadet_params` injected are available in
+the main function as an object. `kadet_params` will always have the `compile_path` which is the absolute
+path to the compile directory where manifests are compiled on the current run. Any additional keys 
+placed on the `kadet_params` in the compile block can be accessed in the kadet module for that specific
+compile run.
+
+```python
+from kapitan.inputs import kadet
+
+inventory = kadet.inventory()
+
+def main(kadet_params):
+    team_name = kadet_params.get("team_name", "no-owner")
+...
+    target_name = inventory.parameters.kapitan.vars.target
+    compile_path = kadet_params.get("compile_path")
+...
+```
+
+For an in depth example, look at the `kadet-test` target under `tests/test_resources/inventory`. There is an
+example of adding labels to every kubernetes object a specific compiled folder.
 
 ### helm
 

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -69,10 +69,10 @@ def load_from_search_paths(module_name):
 class Kadet(InputType):
     def __init__(self, compile_path, search_paths, ref_controller):
         super().__init__("kadet", compile_path, search_paths, ref_controller)
-        self.kadet_params = {}
+        self.input_params = {}
 
-    def set_kadet_params(self, kadet_params):
-        self.kadet_params = kadet_params
+    def set_input_params(self, input_params):
+        self.input_params = input_params
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
         """
@@ -91,12 +91,12 @@ class Kadet(InputType):
         target_name = kwargs.get("target_name", None)
         indent = kwargs.get("indent", 2)
 
-        kadet_params = self.kadet_params
+        input_params = self.input_params
         # set compile_path allowing kadet functions to have context on where files
         # are being compiled on the current kapitan run
-        kadet_params["compile_path"] = compile_path
+        input_params["compile_path"] = compile_path
         # reset between each compile if kadet component is used multiple times
-        self.kadet_params = {}
+        self.input_params = {}
 
         # These will be updated per target
         # XXX At the moment we have no other way of setting externals for modules...
@@ -116,7 +116,7 @@ class Kadet(InputType):
         logger.debug("Kadet main args: {}".format(kadet_arg_spec.args))
 
         if len(kadet_arg_spec.args) == 1:
-            output_obj = kadet_module.main(kadet_params).to_dict()
+            output_obj = kadet_module.main(input_params).to_dict()
         elif len(kadet_arg_spec.args) == 0:
             output_obj = kadet_module.main().to_dict()
         else:

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -11,6 +11,7 @@ import os
 import sys
 from importlib.util import module_from_spec, spec_from_file_location
 
+import inspect
 import yaml
 from addict import Dict
 from kapitan.errors import CompileError
@@ -68,6 +69,10 @@ def load_from_search_paths(module_name):
 class Kadet(InputType):
     def __init__(self, compile_path, search_paths, ref_controller):
         super().__init__("kadet", compile_path, search_paths, ref_controller)
+        self.kadet_params = {}
+    
+    def set_kadet_params(self, kadet_params):
+        self.kadet_params = kadet_params
 
     def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
         """
@@ -86,6 +91,14 @@ class Kadet(InputType):
         target_name = kwargs.get("target_name", None)
         indent = kwargs.get("indent", 2)
 
+
+        kadet_params = self.kadet_params
+        # set compile_path allowing kadet functions to have context on where files
+        # are being compiled on the current kapitan run
+        kadet_params['compile_path'] = compile_path
+        # reset between each compile if kadet component is used multiple times
+        self.kadet_params = {}
+
         # These will be updated per target
         # XXX At the moment we have no other way of setting externals for modules...
         global search_paths
@@ -100,7 +113,18 @@ class Kadet(InputType):
         spec.loader.exec_module(kadet_module)
         logger.debug("Kadet.compile_file: spec.name: %s", spec.name)
 
-        output_obj = kadet_module.main().to_dict()
+        kadet_arg_spec = inspect.getfullargspec(kadet_module.main)
+        logger.debug("Kadet main args: {}".format(kadet_arg_spec.args))
+
+        if len(kadet_arg_spec.args) == 1:
+            output_obj = kadet_module.main(kadet_params).to_dict()
+        elif len(kadet_arg_spec.args) == 0:
+            output_obj = kadet_module.main().to_dict()
+        else:
+            raise ValueError(
+                f"Kadet {spec.name} main parameters not equal to 1 or 0"
+            )
+        
         if prune:
             output_obj = prune_empty(output_obj)
 

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -70,7 +70,7 @@ class Kadet(InputType):
     def __init__(self, compile_path, search_paths, ref_controller):
         super().__init__("kadet", compile_path, search_paths, ref_controller)
         self.kadet_params = {}
-    
+
     def set_kadet_params(self, kadet_params):
         self.kadet_params = kadet_params
 
@@ -91,11 +91,10 @@ class Kadet(InputType):
         target_name = kwargs.get("target_name", None)
         indent = kwargs.get("indent", 2)
 
-
         kadet_params = self.kadet_params
         # set compile_path allowing kadet functions to have context on where files
         # are being compiled on the current kapitan run
-        kadet_params['compile_path'] = compile_path
+        kadet_params["compile_path"] = compile_path
         # reset between each compile if kadet component is used multiple times
         self.kadet_params = {}
 
@@ -121,10 +120,8 @@ class Kadet(InputType):
         elif len(kadet_arg_spec.args) == 0:
             output_obj = kadet_module.main().to_dict()
         else:
-            raise ValueError(
-                f"Kadet {spec.name} main parameters not equal to 1 or 0"
-            )
-        
+            raise ValueError(f"Kadet {spec.name} main parameters not equal to 1 or 0")
+
         if prune:
             output_obj = prune_empty(output_obj)
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -435,6 +435,7 @@ def valid_target_obj(target_obj):
                 "items": {
                     "type": "object",
                     "properties": {
+                        "name": {"type": "string"},
                         "input_paths": {"type": "array"},
                         "input_type": {"type": "string"},
                         "output_path": {"type": "string"},

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -395,6 +395,8 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, **kwa
             input_compiler = jsonnet_compiler
         elif input_type == "kadet":
             input_compiler = kadet_compiler
+            if "kadet_params" in comp_obj:
+                kadet_compiler.set_kadet_params(comp_obj["kadet_params"])
         elif input_type == "helm":
             if "helm_values" in comp_obj:
                 helm_compiler.dump_helm_values(comp_obj["helm_values"])
@@ -448,6 +450,7 @@ def valid_target_obj(target_obj):
                             },
                             "additionalProperties": False,
                         },
+                        "kadet_params": {"type": "object"},
                     },
                     "required": ["input_type", "input_paths", "output_path"],
                     "minItems": 1,

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -395,8 +395,8 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, **kwa
             input_compiler = jsonnet_compiler
         elif input_type == "kadet":
             input_compiler = kadet_compiler
-            if "kadet_params" in comp_obj:
-                kadet_compiler.set_kadet_params(comp_obj["kadet_params"])
+            if "input_params" in comp_obj:
+                kadet_compiler.set_input_params(comp_obj["input_params"])
         elif input_type == "helm":
             if "helm_values" in comp_obj:
                 helm_compiler.dump_helm_values(comp_obj["helm_values"])
@@ -451,7 +451,7 @@ def valid_target_obj(target_obj):
                             },
                             "additionalProperties": False,
                         },
-                        "kadet_params": {"type": "object"},
+                        "input_params": {"type": "object"},
                     },
                     "required": ["input_type", "input_paths", "output_path"],
                     "minItems": 1,

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -42,14 +42,15 @@ class CompileTestResourcesTestObjs(unittest.TestCase):
         reset_cache()
 
 
-class CompileKadetTest(unittest.TestCase):
+class CompileTestResourcesTestKadet(unittest.TestCase):
     def setUp(self):
         os.chdir(os.getcwd() + "/tests/test_resources/")
 
-    def test_compile_with_kadet_params(self):
+    def test_compile(self):
         sys.argv = ["kapitan", "compile", "-t", "kadet-test"]
         main()
 
+    def test_compile_with_kadet_params(self):
         # kadet_params propagate through and written out to file
         for g in glob.glob("compiled/kadet-test/test-1/*.yaml"):
             with open(g, "r") as fp:

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -41,6 +41,7 @@ class CompileTestResourcesTestObjs(unittest.TestCase):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()
 
+
 class CompileKadetTest(unittest.TestCase):
     def setUp(self):
         os.chdir(os.getcwd() + "/tests/test_resources/")
@@ -54,7 +55,7 @@ class CompileKadetTest(unittest.TestCase):
             with open(g, "r") as fp:
                 manifest = yaml.safe_load(fp.read())
                 namespace = manifest["metadata"]["namespace"]
-                team_name =  manifest["metadata"]["labels"]["team_name"]
+                team_name = manifest["metadata"]["labels"]["team_name"]
                 self.assertEqual(namespace, "ops")
                 self.assertEqual(team_name, "client-operations")
         # same kadet function was called with new params should have
@@ -63,14 +64,14 @@ class CompileKadetTest(unittest.TestCase):
             with open(g, "r") as fp:
                 manifest = yaml.safe_load(fp.read())
                 namespace = manifest["metadata"]["namespace"]
-                team_name =  manifest["metadata"]["labels"]["team_name"]
+                team_name = manifest["metadata"]["labels"]["team_name"]
                 self.assertEqual(namespace, "team-2")
                 self.assertEqual(team_name, "SRE")
 
-    
     def tearDown(self):
         os.chdir(os.getcwd() + "/../../")
         reset_cache()
+
 
 class CompileKubernetesTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -50,8 +50,8 @@ class CompileTestResourcesTestKadet(unittest.TestCase):
         sys.argv = ["kapitan", "compile", "-t", "kadet-test"]
         main()
 
-    def test_compile_with_kadet_params(self):
-        # kadet_params propagate through and written out to file
+    def test_compile_with_input_params(self):
+        # input_params propagate through and written out to file
         for g in glob.glob("compiled/kadet-test/test-1/*.yaml"):
             with open(g, "r") as fp:
                 manifest = yaml.safe_load(fp.read())

--- a/tests/test_resources/inventory/targets/kadet-test.yml
+++ b/tests/test_resources/inventory/targets/kadet-test.yml
@@ -1,0 +1,30 @@
+parameters:
+  kapitan:
+    vars:
+      target: kadet-test
+    compile:
+      - input_type: copy # setup for remaining kadet compiles
+        output_path: test-1
+        input_paths:
+          - templates/test_deployment.yaml
+      - input_type: kadet
+        output_path: test-1
+        input_paths:
+          - kadet_functions/add_team_label
+        kadet_params:
+          team_name: 'client-operations'
+          input_paths: ['test-1']
+          namespace: 'ops'
+      - input_type: copy # setup for remaining kadet compiles
+        output_path: test-2
+        input_paths:
+          - templates/test_deployment.yaml
+      - input_type: kadet
+        output_path: test-2
+        input_paths:
+          - kadet_functions/add_team_label
+        kadet_params:
+          team_name: 'SRE'
+          input_paths: ['test-2']
+          namespace: 'team-2'
+        

--- a/tests/test_resources/inventory/targets/kadet-test.yml
+++ b/tests/test_resources/inventory/targets/kadet-test.yml
@@ -3,28 +3,33 @@ parameters:
     vars:
       target: kadet-test
     compile:
-      - input_type: copy # setup for remaining kadet compiles
+      - name: gen-test-1
+        input_type: copy # setup for remaining kadet compiles
         output_path: test-1
         input_paths:
           - templates/test_deployment.yaml
-      - input_type: kadet
+      - name: add-metadata-test-1
+        input_type: kadet
         output_path: test-1
         input_paths:
           - kadet_functions/add_team_label
-        kadet_params:
+        input_params:
           team_name: 'client-operations'
-          input_paths: ['test-1']
           namespace: 'ops'
-      - input_type: copy # setup for remaining kadet compiles
+          post_process_inputs: [gen-test-1]
+      - name: gen-test-2
+        input_type: copy # setup for remaining kadet compiles
         output_path: test-2
         input_paths:
           - templates/test_deployment.yaml
-      - input_type: kadet
+      - name: add-metadata-test-2
+        input_type: kadet
         output_path: test-2
         input_paths:
           - kadet_functions/add_team_label
-        kadet_params:
+        input_params:
           team_name: 'SRE'
-          input_paths: ['test-2']
           namespace: 'team-2'
+          post_process_inputs: [gen-test-2]
+
         

--- a/tests/test_resources/kadet_functions/add_team_label/__init__.py
+++ b/tests/test_resources/kadet_functions/add_team_label/__init__.py
@@ -18,12 +18,14 @@ def set_namespace(obj, namespace):
     obj.root.metadata["namespace"] = namespace
     return obj
 
+
 def get_root_path(path, target_name):
     drive, tail = os.path.split(path)
     if tail == target_name:
         return drive
     else:
         return get_root_path(drive, target_name)
+
 
 def main(kadet_params):
     team_name = kadet_params.get("team_name", "no-owner")

--- a/tests/test_resources/kadet_functions/add_team_label/__init__.py
+++ b/tests/test_resources/kadet_functions/add_team_label/__init__.py
@@ -1,0 +1,68 @@
+import os
+import json
+from kapitan.resources import jinja2_render_file, yaml_load
+from kapitan.inputs import kadet
+import glob
+import yaml
+import time
+
+inventory = kadet.inventory()
+
+def set_team_name(obj, team_name):
+    obj.root.metadata["labels"]["team_name"] = team_name
+    return obj
+
+def set_namespace(obj, namespace):
+    obj.root.metadata["namespace"] = namespace
+    return obj
+
+def main(kadet_params):
+    team_name = kadet_params.get("team_name", "no-owner")
+    if "namespace" in kadet_params:
+        namespace = kadet_params.get("namespace")
+    else:
+        raise ValueError("'namespace' key not found in 'kadet_params'")
+
+    if "input_paths" in kadet_params:
+        input_paths = kadet_params.get("input_paths")
+    else:
+        raise ValueError("'input_paths' key not found in 'kadet_params'")
+    
+    # get path where files have been compiled on this run
+    target_name = inventory.parameters.kapitan.vars.target
+    compile_path = kadet_params.get("compile_path")
+    root_path = ""
+    for s in compile_path.split("/"):
+        if len(s) == 0:
+            continue
+        if s == target_name:
+            break
+        else:
+            root_path += "/" + s
+
+    target_compiled_dir = root_path + "/" + target_name
+
+    all_objects = {}
+    for ip in input_paths:
+        output = kadet.BaseObj()
+
+        ip_file_path = os.path.abspath(target_compiled_dir + "/" + ip)
+
+        for file in glob.glob(ip_file_path + "/*.yaml", recursive=True):
+            # remove file extension
+            file_name = os.path.basename(file).replace(".yaml", "")
+            with open(file) as fp:
+                yaml_stream = yaml.safe_load_all(fp)
+                objects_for_file = []
+                for obj in yaml_stream:
+                    o = kadet.BaseObj.from_dict(obj)
+                    o = set_team_name(o, team_name)
+                    o = set_namespace(o, namespace)
+                    objects_for_file.append(o)
+                all_objects.update({ file_name: objects_for_file })
+            fp.close()
+
+    output = kadet.BaseObj()
+    for file_name, obj in all_objects.items():
+        output.root[file_name] = obj
+    return output

--- a/tests/test_resources/kadet_functions/add_team_label/__init__.py
+++ b/tests/test_resources/kadet_functions/add_team_label/__init__.py
@@ -27,29 +27,36 @@ def get_root_path(path, target_name):
         return get_root_path(drive, target_name)
 
 
-def main(kadet_params):
-    team_name = kadet_params.get("team_name", "no-owner")
-    if "namespace" in kadet_params:
-        namespace = kadet_params.get("namespace")
-    else:
-        raise ValueError("'namespace' key not found in 'kadet_params'")
+def get_post_process_input_output_path(post_process_input):
+    for i in inventory.parameters.kapitan.compile:
+        if i.name == post_process_input:
+            return i.output_path
+    raise ValueError("'post_process_input' {post_process_input} not found")
 
-    if "input_paths" in kadet_params:
-        input_paths = kadet_params.get("input_paths")
+
+def main(input_params):
+    team_name = input_params.get("team_name", "no-owner")
+    if "namespace" in input_params:
+        namespace = input_params.get("namespace")
     else:
-        raise ValueError("'input_paths' key not found in 'kadet_params'")
+        raise ValueError("'namespace' key not found in 'input_params'")
+
+    if "post_process_inputs" in input_params:
+        post_process_inputs = input_params.get("post_process_inputs")
+    else:
+        raise ValueError("'post_process_inputs' key not found in 'input_params'")
 
     # get path where files have been compiled on this run
     target_name = inventory.parameters.kapitan.vars.target
-    compile_path = kadet_params.get("compile_path")
+    compile_path = input_params.get("compile_path")
     root_path = get_root_path(compile_path, target_name)
 
     all_objects = {}
-    for ip in input_paths:
+    for post_process_input in post_process_inputs:
         output = kadet.BaseObj()
-
-        ip_file_path = os.path.join(root_path, target_name, ip)
-        for file in glob.glob(ip_file_path + "/*.yaml", recursive=True):
+        p = get_post_process_input_output_path(post_process_input)
+        dir_file_path = os.path.join(root_path, target_name, p)
+        for file in glob.glob(dir_file_path + "/*.yaml", recursive=True):
             # remove file extension
             file_name = os.path.basename(file).replace(".yaml", "")
             with open(file) as fp:

--- a/tests/test_resources/kadet_functions/add_team_label/__init__.py
+++ b/tests/test_resources/kadet_functions/add_team_label/__init__.py
@@ -18,6 +18,12 @@ def set_namespace(obj, namespace):
     obj.root.metadata["namespace"] = namespace
     return obj
 
+def get_root_path(path, target_name):
+    drive, tail = os.path.split(path)
+    if tail == target_name:
+        return drive
+    else:
+        return get_root_path(drive, target_name)
 
 def main(kadet_params):
     team_name = kadet_params.get("team_name", "no-owner")
@@ -34,23 +40,13 @@ def main(kadet_params):
     # get path where files have been compiled on this run
     target_name = inventory.parameters.kapitan.vars.target
     compile_path = kadet_params.get("compile_path")
-    root_path = ""
-    for s in compile_path.split("/"):
-        if len(s) == 0:
-            continue
-        if s == target_name:
-            break
-        else:
-            root_path += "/" + s
-
-    target_compiled_dir = root_path + "/" + target_name
+    root_path = get_root_path(compile_path, target_name)
 
     all_objects = {}
     for ip in input_paths:
         output = kadet.BaseObj()
 
-        ip_file_path = os.path.abspath(target_compiled_dir + "/" + ip)
-
+        ip_file_path = os.path.join(root_path, target_name, ip)
         for file in glob.glob(ip_file_path + "/*.yaml", recursive=True):
             # remove file extension
             file_name = os.path.basename(file).replace(".yaml", "")

--- a/tests/test_resources/kadet_functions/add_team_label/__init__.py
+++ b/tests/test_resources/kadet_functions/add_team_label/__init__.py
@@ -8,13 +8,16 @@ import time
 
 inventory = kadet.inventory()
 
+
 def set_team_name(obj, team_name):
     obj.root.metadata["labels"]["team_name"] = team_name
     return obj
 
+
 def set_namespace(obj, namespace):
     obj.root.metadata["namespace"] = namespace
     return obj
+
 
 def main(kadet_params):
     team_name = kadet_params.get("team_name", "no-owner")
@@ -27,7 +30,7 @@ def main(kadet_params):
         input_paths = kadet_params.get("input_paths")
     else:
         raise ValueError("'input_paths' key not found in 'kadet_params'")
-    
+
     # get path where files have been compiled on this run
     target_name = inventory.parameters.kapitan.vars.target
     compile_path = kadet_params.get("compile_path")
@@ -59,7 +62,7 @@ def main(kadet_params):
                     o = set_team_name(o, team_name)
                     o = set_namespace(o, namespace)
                     objects_for_file.append(o)
-                all_objects.update({ file_name: objects_for_file })
+                all_objects.update({file_name: objects_for_file})
             fp.close()
 
     output = kadet.BaseObj()

--- a/tests/test_resources/templates/test_deployment.yaml
+++ b/tests/test_resources/templates/test_deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-name
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: app-name
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: app-name
+    spec:
+      containers:
+      - name: hello
+        image: hello-word
+        imagePullPolicy: Always


### PR DESCRIPTION
Adds kadet_params as a way to create compile time parameters for kadet modules. This should enable a reusable plugin like system within a single target, that shows the contract cleary through injection rather than relying on the 'parameters' concept in inventory.

The compile process currently works in a blocking sequential manner. Only targets are multi threaded. This enables a the concept of "post processing" or "overlays" as mentioned in #527 and #365.

## Proposed Changes

  - 'kadet_params' as attribute for kadet input type
