### PR TITLE
Allow reclass override none feature

### DIFF
--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -307,6 +307,7 @@ def inventory_reclass(inventory_path):
             "nodes_uri": os.path.join(inventory_path, "targets"),
             "classes_uri": os.path.join(inventory_path, "classes"),
             "compose_node_name": False,
+            "allow_none_override": True,
         }
 
         try:


### PR DESCRIPTION
Enable the reclass `allow_none_override` feature [1] to be able to
remove dicts and lists further down in the hierarchy.

[1] https://github.com/salt-formulas/reclass/blob/develop/README-extensions.rst#allow-override-list-and-dicts-by-empty-entitynone-instead-of-merge

## Proposed Changes

Set `allow_none_override=true` in reclass config.
