### PR TITLE
Proposal to add support for Google Secret Manager backend

### DIFF
--- a/docs/kap_proposals/kap_8_google_secret_management.md
+++ b/docs/kap_proposals/kap_8_google_secret_management.md
@@ -1,6 +1,6 @@
-# Support for Google Secret Management
+# Support for [Google Secret Manager](https://cloud.google.com/secret-manager/)
 
-This feature will enable users to retrieve secrets from Google Secret Management API using the `gsm` keyword.
+This feature will enable users to retrieve secrets from Google Secret Manager API using the `gsm` keyword.
 
 ## Specification
 

--- a/docs/kap_proposals/kap_8_google_secret_management.md
+++ b/docs/kap_proposals/kap_8_google_secret_management.md
@@ -26,17 +26,18 @@ export PROJECT_ID=<Project_Id>
 ```
 
 ## Using a secret
+In GCP, a secret contains one or more secret versions, along with its metadata. The actual contents of a secret are stored in a secret version. Each secret is identified by a name. We call that variable `secret_id` e.g. _my\_treasured\_secret_.
+The URI of the secret becomes `projects/<Project_Id>/secrets/my_treasured_secret`
 
-`secret_id` is used to point to the secret data. The following command will be used to add a `secret_id` to kapitan.
-
+The following command will be used to add a `secret_id` to kapitan.
 ```shell
-$ echo "secret_id"  | kapitan refs --write gsm:path/to/secret_inside_kapitan -t <target_name> -f -
+$ echo "my_treasured_secret"  | kapitan refs --write gsm:path/to/secret_inside_kapitan -t <target_name> -f -
 ```
 The `-t <target_name>` is used to get the information about Project_ID.
 
-The _secret\_id_ is Base64 encoded and stored in `path/to/secret_inside_kapitan` as
+The `secret_id` is Base64 encoded and stored in `path/to/secret_inside_kapitan` as
 ```yaml
-data: aGVsbG8K
+data: bXlfdHJlYXN1cmVkX3NlY3JldAo=
 encoding: original
 type: gsm
 gsm_params:

--- a/docs/kap_proposals/kap_8_google_secret_management.md
+++ b/docs/kap_proposals/kap_8_google_secret_management.md
@@ -60,7 +60,7 @@ Here, `version_id` will be an optional argument. By default it will point to `la
 
 ## Revealing a secret
 
-After compilation, the secret reference will be prefixed with 8 characters from the sha256 hash of the retrieved password
+After compilation, the secret reference will be postfixed with 8 characters from the sha256 hash of the retrieved password
 ```yaml
 apiVersion: v1
 data:
@@ -80,4 +80,4 @@ To reveal the secret, the following command will be used
 
 * [google-cloud-secret-manager](https://github.com/googleapis/python-secret-manager)
 
-*note* Kapitan will not be responsible for authentication or access management
+*note* Kapitan will not be responsible for authentication or access management to GCP

--- a/docs/kap_proposals/kap_8_google_secret_management.md
+++ b/docs/kap_proposals/kap_8_google_secret_management.md
@@ -1,0 +1,83 @@
+# Support for Google Secret Management
+
+This feature will enable users to retrieve secrets from Google Secret Management API using the `gsm` keyword.
+
+## Specification
+
+`project_id` uniquely identifies GCP projects, and it needs to be made accessible to kapitan in one of the following ways:
+
+- As a part of target
+```yaml
+parameters:
+  kapitan:
+    secrets:
+      gsm:
+        project_id: Project_Id
+```
+
+- As a flag
+```shell
+$ kapitan refs --google-project-id=<Project_Id> --write gsm:/path/to/secret_id -f secret_id_file.txt
+```
+
+- As an environment variable
+```shell
+export PROJECT_ID=<Project_Id>
+```
+
+## Using a secret
+
+`secret_id` is used to point to the secret data. The following command will be used to add a `secret_id` to kapitan.
+
+```shell
+$ echo "secret_id"  | kapitan refs --write gsm:path/to/secret_inside_kapitan -t <target_name> -f -
+```
+The `-t <target_name>` is used to get the information about Project_ID.
+
+The _secret\_id_ is Base64 encoded and stored in `path/to/secret_inside_kapitan` as
+```yaml
+data: aGVsbG8K
+encoding: original
+type: gsm
+gsm_params:
+  project_id: Project_ID
+```
+
+## referencing a secret
+Secrets can be refered using `?{gsm:path/to/secret_id:version_id}`
+e.g.
+```yaml
+parameter:
+    mysql:
+        storage: 10G
+        storage_class: standard
+        image: mysql:latest
+        users:
+            root:
+                password: ?{gsm:path/to/secret_id:version_id}
+```
+Here, `version_id` will be an optional argument. By default it will point to `latest`.
+
+## Revealing a secret
+
+After compilation, the secret reference will be prefixed with 8 characters from the sha256 hash of the retrieved password
+```yaml
+apiVersion: v1
+data:
+  MYSQL_ROOT_PASSWORD: ?{gsm:path/to/secret_id:version_id:deadbeef}
+kind: Secret
+metadata:
+  labels:
+    name: example-mysql
+  name: example-mysql
+  namespace: minikube-mysql
+type: Opaque
+```
+To reveal the secret, the following command will be used
+`$ kapitan ref --reveal -f compiled/file/containing/secret`
+
+## Dependencies
+
+* [google-cloud-secret-manager](https://github.com/googleapis/python-secret-manager)
+
+*note* Kapitan will not be responsible for authentication or access management


### PR DESCRIPTION
With [Google Secret Manager](https://cloud.google.com/secret-manager/), Kapitan would be able to share secrets with scripts/processes
that do not have access to the Kapitan repository.

Related to issue #467 
