### PR TITLE
Fixes issue with dynamically created array of pointers with cffi

### DIFF
--- a/kapitan/inputs/helm/__init__.py
+++ b/kapitan/inputs/helm/__init__.py
@@ -130,10 +130,18 @@ class Helm(InputType):
         char_dir_buf = ffi.new("char[]", chart_dir.encode("ascii"))
         output_path_buf = ffi.new("char[]", output_path.encode("ascii"))
 
+        # as noted in cffi documentation, once the reference to the pointer is out of scope, the data is freed.
+        # to prevent that from happening with these dynamic arrays, we create a 'keep_pointers_alive' dict
+        # https://cffi.readthedocs.io/en/latest/using.html#working-with-pointers-structures-and-arrays
         helm_values_files = []
+        keep_pointers_alive = dict()
         if kwargs.get("helm_values_files", []):
-            for file_name in kwargs["helm_values_files"]:
-                helm_values_files.append(ffi.new("char[]", file_name.encode("ascii")))
+            for i in range(len(kwargs["helm_values_files"])):
+                file_name = kwargs["helm_values_files"][i]
+
+                ptr_to_encoded_file_name = ffi.new("char[]", file_name.encode("ascii"))
+                keep_pointers_alive[file_name + str(i)] = ptr_to_encoded_file_name
+                helm_values_files.append(ptr_to_encoded_file_name)
 
         helm_values_files_len = ffi.cast("int", len(helm_values_files))
         helm_values_files = ffi.new("char *[]", helm_values_files)


### PR DESCRIPTION
The `helm_values_files` is meant to be an array of pointers. Those pointers are references to strings which are helm values files to use in the golang code. As of now, I've gotten lucky that the bytes weren't freed any faster. I noticed that once I hit a string over 96 bytes that I was getting errors in the golang code saying it couldn't find the file which seems to no longer be properly encoded.

```
valueFiles: [/tmp/tmps8j31sc8.helm_values.yml /tmp/tmp8lbavsth.kapitan/compiled/monitoring-prd/helm_values_files_prometheus_new_and_this/commo�]
From golang!!!!!
valueFiles: [/tmp/tmps8j31sc8.helm_values.yml /tmp/tmp8lbavsth.kapitan/compiled/monitoring-prd/helm_values_files_prometheus_new_and_this/commo� /tmp/tmp8lbavsth.kapitan/compiled/monitoring-prd/helm_values_files_prometheus_new_and_this/common.yml]
Compile pool terminated
Unknown (Non-Kapitan) Error occurred
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/multiprocessing/pool.py", line 121, in worker
    result = (True, func(*args, **kwds))
  File "/src/kapitan/targets.py", line 448, in compile_target
    input_compiler.compile_obj(comp_obj, ext_vars, **kwargs)
  File "/src/kapitan/inputs/base.py", line 53, in compile_obj
    self.compile_input_path(input_path, comp_obj, ext_vars, **kwargs)
  File "/src/kapitan/inputs/base.py", line 75, in compile_input_path
    **kwargs,
  File "/src/kapitan/inputs/helm/__init__.py", line 98, in compile_file
    **self.helm_params,
  File "/src/kapitan/inputs/helm/__init__.py", line 190, in render_chart
    return error_message.decode("utf-8")  # empty if no error
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 101: invalid start byte
"""
```

Because the array of pointers in being dynamically created, I used the [recommendation from the cffi docs](https://cffi.readthedocs.io/en/latest/using.html#working-with-pointers-structures-and-arrays) and created a dict to hold pointer references so the data is not prematurely garbage collected.