### PR TITLE
Remove input type

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -441,3 +441,30 @@ This input type simply copies the input templates to the output directory withou
 For Copy, `input_paths` can be either a file or a directory: in case of a directory, all the templates in the directory will be copied and outputted to `output_path`.
 
 *Supported output types*: N/A (no need to specify `output_type`)
+
+### Remove
+
+This input type simply removes files or directories. This can be helpful if you can't control particular files
+generated during other compile inputs.
+
+For example, to remove a file named `copy_target`, specify an entry to `input_paths`, `compiled/${kapitan:vars:target}/copy_target`.
+
+```yaml
+parameters:
+  target_name: removal
+  kapitan:
+    vars:
+      target: ${target_name}
+    compile:
+      - input_type: copy
+        input_paths:
+          - copy_target
+        output_path: .
+      # test removal of a file
+      - input_type: remove
+        input_paths:
+          - compiled/${kapitan:vars:target}/copy_target
+        output_path: .
+```
+
+*Supported output types*: N/A (no need to specify `output_type`)

--- a/docs/compile.md
+++ b/docs/compile.md
@@ -467,4 +467,24 @@ parameters:
         output_path: .
 ```
 
+As a reminder, each input block within the compile array is run sequentially for a target in Kapitan. If we reversed the order of the inputs above like so:
+```yaml
+parameters:
+  target_name: removal
+  kapitan:
+    vars:
+      target: ${target_name}
+    compile:
+      - input_type: remove
+        input_paths:
+          - compiled/${kapitan:vars:target}/copy_target
+        output_path: .
+      - input_type: copy
+        input_paths:
+          - copy_target
+        output_path: .
+```
+
+The first input block would throw an error because the copy input command hasn't run yet to produce the file being removed by the remove input block.
+
 *Supported output types*: N/A (no need to specify `output_type`)

--- a/examples/kubernetes/inventory/targets/removal.yml
+++ b/examples/kubernetes/inventory/targets/removal.yml
@@ -1,0 +1,15 @@
+parameters:
+  target_name: removal
+  kapitan:
+    vars:
+      target: ${target_name}
+    compile:
+      - input_type: copy
+        input_paths:
+          - copy_target
+        output_path: .
+      # test removal of a file
+      - input_type: remove
+        input_paths:
+          - compiled/${kapitan:vars:target}/copy_target
+        output_path: .

--- a/kapitan/inputs/remove.py
+++ b/kapitan/inputs/remove.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import os
+import shutil
+from distutils.dir_util import copy_tree
+
+from kapitan.inputs.base import InputType
+
+logger = logging.getLogger(__name__)
+
+
+class Remove(InputType):
+    def __init__(self, compile_path, search_paths, ref_controller):
+        super().__init__("remove", compile_path, search_paths, ref_controller)
+
+    def compile_file(self, file_path, compile_path, ext_vars, **kwargs):
+        """
+        Write items in path as plain rendered files to compile_path.
+        path can be either a file or directory.
+        """
+
+        try:
+            logger.debug("Removing {}".format(file_path))
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+            else:
+                shutil.rmtree(file_path)
+        except OSError as e:
+            logger.exception(f"Input dir not removed. Error: {e}")
+
+    def default_output_type(self):
+        # no output_type options for remove
+        return None

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -445,7 +445,9 @@ def compile_target(target_obj, search_paths, compile_path, ref_controller, inven
         elif input_type == "remove":
             input_compiler = remove_compiler
         else:
-            err_msg = 'Invalid input_type: "{}". Supported input_types: jsonnet, jinja2, kadet, helm, copy, remove'
+            err_msg = (
+                'Invalid input_type: "{}". Supported input_types: jsonnet, jinja2, kadet, helm, copy, remove'
+            )
             raise CompileError(err_msg.format(input_type))
 
         input_compiler.make_compile_dirs(target_name, output_path)

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -64,7 +64,7 @@ class RemoveTest(unittest.TestCase):
     def test_remove_file_folder(self):
         test_dirs_bootstrap_helper()
         self.copy_compiler.compile_file(test_file_path, compile_path, None)
-        
+
         self.assertTrue(os.path.exists(test_file_compiled_path))
         self.remove_compiler.compile_file(test_file_compiled_path, compile_path, None)
         self.assertFalse(os.path.exists(test_file_compiled_path))
@@ -72,7 +72,7 @@ class RemoveTest(unittest.TestCase):
     def test_remove_folder_folder(self):
         test_dirs_bootstrap_helper()
         self.copy_compiler.compile_file(file_path, compile_path, None)
-        
+
         self.assertTrue(os.path.exists(compile_path))
         self.remove_compiler.compile_file(compile_path, compile_path, None)
         self.assertFalse(os.path.exists(compile_path))

--- a/tests/test_remove.py
+++ b/tests/test_remove.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"remove tests"
+import filecmp
+import hashlib
+import os
+import shutil
+import sys
+import unittest
+
+from kapitan.cli import main
+from kapitan.inputs.copy import Copy
+from kapitan.inputs.remove import Remove
+from kapitan.utils import directory_hash
+
+search_path = ""
+ref_controller = ""
+test_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_remove")
+compile_path = os.path.join(test_path, "output")
+file_path = os.path.join(test_path, "input")
+test_file_path = os.path.join(file_path, "test_copy_input")
+test_file_compiled_path = os.path.join(compile_path, "test_copy_input")
+test_file_content = """
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine
+  namespace: default
+spec:
+  containers:
+  - image: alpine:3.2
+    command:
+      - /bin/sh
+      - "-c"
+      - "sleep 60m"
+    imagePullPolicy: IfNotPresent
+    name: alpine
+  restartPolicy: Always
+"""
+
+
+def test_dirs_bootstrap_helper():
+    for folder in [file_path, compile_path]:
+        os.makedirs(folder, exist_ok=True)
+        with open(test_file_path, "w") as f:
+            f.write(test_file_content)
+
+
+class RemoveTest(unittest.TestCase):
+    def setUp(self):
+        try:
+            shutil.rmtree(test_path)
+        except FileNotFoundError:
+            pass
+
+        self.copy_compiler = Copy(compile_path, search_path, ref_controller)
+        self.remove_compiler = Remove(compile_path, search_path, ref_controller)
+
+    def test_remove_file_folder(self):
+        test_dirs_bootstrap_helper()
+        self.copy_compiler.compile_file(test_file_path, compile_path, None)
+        
+        self.assertTrue(os.path.exists(test_file_compiled_path))
+        self.remove_compiler.compile_file(test_file_compiled_path, compile_path, None)
+        self.assertFalse(os.path.exists(test_file_compiled_path))
+
+    def test_remove_folder_folder(self):
+        test_dirs_bootstrap_helper()
+        self.copy_compiler.compile_file(file_path, compile_path, None)
+        
+        self.assertTrue(os.path.exists(compile_path))
+        self.remove_compiler.compile_file(compile_path, compile_path, None)
+        self.assertFalse(os.path.exists(compile_path))
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(test_path)
+        except FileNotFoundError:
+            pass
+
+
+class CompileRemoveTest(unittest.TestCase):
+    def setUp(self):
+        os.chdir(os.path.join(os.getcwd(), "examples", "kubernetes"))
+
+    def validate_files_were_removed(self):
+        original_filepath = os.path.join("copy_target")
+        self.assertTrue(os.path.exists(original_filepath))
+        removed_file = os.path.join("compiled", "removal", "copy_target")
+        self.assertFalse(os.path.exists(removed_file))
+
+    def test_compiled_remove_target(self):
+        sys.argv = ["kapitan", "compile", "-t", "removal"]
+        main()
+        self.validate_files_were_removed()
+
+    def tearDown(self):
+        os.chdir(os.path.join(os.getcwd(), "..", ".."))


### PR DESCRIPTION
## Proposed Changes

  - Adds new input type `Remove`. This allows users to remove any compiled files.
  - Adds `temp_path` to `search_paths`. This allows users to reference files that have already been compiled for the `Remove` input to work but also opens up the ability to use the outputs of previous compile blocks to be the inputs for preceding compile blocks.
