### PR TITLE
Reformat list of jinja2 filters in doc

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -64,24 +64,22 @@ java_opts for elasticsearch data role are: {{ inventory.parameters.elasticsearch
 
 We support the following custom filters for use in Jinja2 templates:
 
-```
-sha256 - SHA256 hashing of text e.g. {{ text | sha256 }}
-yaml - Dump text as YAML e.g. {{ text | yaml }}
-toml - Dump text as TOML e.g. {{ text | toml }}
-b64encode - base64 encode text e.g. {{ text | b64encode }}
-b64decode - base64 decode text e.g. {{ text | b64decode }}
-fileglob - return list of matched regular files for glob e.g. {{ ./path/file* | fileglob }}
-bool - return the bool for value e.g. {{ yes | bool }}
-to_datetime - return datetime object for string e.g. {{ "2019-03-07 13:37:00" | to_datetime }}
-strftime - return current date string for format e.g. {{ "%a, %d %b %Y %H:%M" | strftime }}
-regex_replace - perform a re.sub returning a string e.g. {{ hello world | regex_replace(pattern="world", replacement="kapitan") }}
-regex_escape - escape all regular expressions special characters from string e.g. {{ "+s[a-z].*" | regex_escape }}
-regex_search - perform re.search and return the list of matches or a backref e.g. {{ hello world | regex_search("world.*") }}
-regex_findall - perform re.findall and return the list of matches as array e.g. {{ hello world | regex_findall("world.*") }}
-ternary - value ? true_val : false_val e.g. {{ condition | ternary("yes", "no") }}
-shuffle - randomly shuffle elements of a list {{ [1, 2, 3, 4, 5] | shuffle }}
-reveal_maybe - reveal ref/secret tag only if `compile --reveal` flag is set e.g. {{ "?{base64:my_ref}" | reveal_maybe }}
-```
+- `sha256` - SHA256 hashing of text e.g. `{{ text | sha256 }}`
+- `yaml` - Dump text as YAML e.g. `{{ text | yaml }}`
+- `toml` - Dump text as TOML e.g. `{{ text | toml }}`
+- `b64encode` - base64 encode text e.g. `{{ text | b64encode }}`
+- `b64decode` - base64 decode text e.g. `{{ text | b64decode }}`
+- `fileglob` - return list of matched regular files for glob e.g. `{{ ./path/file* | fileglob }}`
+- `bool` - return the bool for value e.g. `{{ yes | bool }}`
+- `to_datetime` - return datetime object for string e.g. `{{ "2019-03-07 13:37:00" | to_datetime }}`
+- `strftime` - return current date string for format e.g. `{{ "%a, %d %b %Y %H:%M" | strftime }}`
+- `regex_replace` - perform a `re.sub` returning a string e.g. `{{ hello world | regex_replace(pattern="world", replacement="kapitan") }}`
+- `regex_escape` - escape all regular expressions special characters from string e.g. `{{ "+s[a-z].*" | regex_escape }}`
+- `regex_search` - perform `re.search` and return the list of matches or a backref e.g. `{{ hello world | regex_search("world.*") }}`
+- `regex_findall` - perform `re.findall` and return the list of matches as array e.g. `{{ hello world | regex_findall("world.*") }}`
+- `ternary` - `value ? true_val : false_val` e.g. `{{ condition | ternary("yes", "no") }}`
+- `shuffle` - randomly shuffle elements of a list `{{ [1, 2, 3, 4, 5] | shuffle }}`
+- `reveal_maybe` - reveal `ref/secret` tag only if `compile --reveal` flag is set e.g. `{{ "?{base64:my_ref}" | reveal_maybe }}`
 
 You can also provide path to your custom filter modules in CLI. By default, you can put your filters in `lib/jinja2_filters.py` and they will automatically get loaded.
 


### PR DESCRIPTION
Fixes issue #594 

## Proposed Changes

doc of jinja2 filters reformatted, codeblock turned into list of items
