### PR TITLE
fix for reveal of secret for dir with json

### DIFF
--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -224,7 +224,7 @@ class Revealer(object):
                 out_yaml += out
             elif fpath.endswith(".json"):
                 out, _ = self._reveal_file(fpath)
-                out_json += self._reveal_file(fpath)
+                out_json += out
             else:
                 out, _ = self._reveal_file(fpath)
                 out_raw += out


### PR DESCRIPTION
currently the reveal of refs for full directory fails if it has json in it with msg,

```
2020-09-21 13:47:50,282 kapitan.refs.base DEBUG    Revealer: revealing json file: compiled/wallet/gcp/terraform/provider.tf.json
2020-09-21 13:47:50,283 kapitan.refs.base DEBUG    Revealer: revealing json file: compiled/wallet/gcp/terraform/provider.tf.json
Traceback (most recent call last):
  File "/home/nashaikh/.local/bin/kapitan", line 11, in <module>
    sys.exit(main())
  File "/home/nashaikh/.local/lib/python3.6/site-packages/kapitan/cli.py", line 561, in main
    ref_reveal(args, ref_controller)
  File "/home/nashaikh/.local/lib/python3.6/site-packages/kapitan/cli.py", line 798, in ref_reveal
    for rev_obj in revealer.reveal_path(file_name):
  File "/home/nashaikh/.local/lib/python3.6/site-packages/kapitan/refs/base.py", line 161, in reveal_path
    content_yaml, content_json, content_raw = self._reveal_dir(path)
  File "/home/nashaikh/.local/lib/python3.6/site-packages/kapitan/refs/base.py", line 217, in _reveal_dir
    out_json += self._reveal_file(fpath)
TypeError: must be str, not tuple
```
