### PR TITLE
Fix FileExistsError when fetching multiple dependencies with unpack=True

### DIFF
--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -4,6 +4,7 @@
 
 import hashlib
 import logging
+import multiprocessing
 import os
 from collections import defaultdict
 from distutils.dir_util import copy_tree
@@ -172,7 +173,9 @@ def fetch_http_dependency(dep_mapping, save_dir, force, item_type="Dependency"):
             if force:
                 is_unpacked = unpack_downloaded_file(cached_source_path, output_path, content_type)
             else:
-                unpack_output = os.path.join(save_dir, "extracted")
+                unpack_output = os.path.join(
+                    save_dir, "extracted-" + str(multiprocessing.current_process().name)
+                )
                 os.makedirs(unpack_output)
                 is_unpacked = unpack_downloaded_file(cached_source_path, unpack_output, content_type)
                 safe_copy_tree(unpack_output, output_path)


### PR DESCRIPTION
## Proposed Changes

  - Add test for parallel http(s) dependency fetching with unpack=True
  - Make temporary directory for unpacking http(s) dependencies unique

## Background & Explanation
We've observed that dependency fetching with the default parallelism setting of 4 and with multiple http(s) dependencies with `unpack=True` sometimes fails with:

```
Unknown (Non-Kapitan) Error occurred
multiprocessing.pool.RemoteTraceback:
"""
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/path/to/venv/lib/python3.8/site-packages/kapitan/dependency_manager/base.py", line 176, in fetch_http_dependency
    os.makedirs(unpack_output)
  File "/usr/lib/python3.8/os.py", line 221, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/tmp/tmpj3f3nldp.kapitan/extracted'
"""
```

This error happens because the current implementation use the same temporary directory `{save_dir}/extracted` to unpack all http(s) dependencies which have `unpack=True`. With parallelism > 1, this can lead to interleaved unpacking operations where multiple multiprocessing worker processes try to create the directory in parallel, at which point one of them fails to do so with the error reproduced above.

This commit makes the temporary directory unique by appending the multiprocessing worker process name to the directory name. Since the temporary directory for unpacking the tarball is deleted after a single dependency is fetched, using the worker process name is unique enough to avoid the FileExistsError which we've previously sometimes observed when two or more dependencies with unpack=True are fetched simultaneously.

