### PR TITLE
VAULT_SKIP_VERIFY supports with yaml boolean defined in parameters

### DIFF
--- a/kapitan/refs/secrets/vaultkv.py
+++ b/kapitan/refs/secrets/vaultkv.py
@@ -58,7 +58,7 @@ def get_env(parameter):
         "VAULT_NAMESPACE", os.getenv("VAULT_NAMESPACE", default="")
     )
     # VERIFY VAULT SERVER TLS CERTIFICATE
-    skip_verify = parameter.get("VAULT_SKIP_VERIFY", os.getenv("VAULT_SKIP_VERIFY", default=""))
+    skip_verify = str(parameter.get("VAULT_SKIP_VERIFY", os.getenv("VAULT_SKIP_VERIFY", default="")))
 
     if skip_verify.lower() == "false":
         cert = parameter.get("VAULT_CACERT", os.getenv("VAULT_CACERT", default=""))


### PR DESCRIPTION
vaultkv `skip_verify` converges on str type to support subsequent `.lower()` string operation for determining `client_parameters["verify"]`.  as `skip_verify` can be sourced from yaml kapitan parameters or an environment variable, it is decidedly simpler to convert any python bool type to string (ie "True" or "False") rather than evaluate truthiness of a mixed bag of bool types and strings.

Fixes issue #622