### PR TITLE
Add staticx and patchelf to pyinstaller.sh to build a Linux static binary

### DIFF
--- a/Dockerfile.pyinstaller
+++ b/Dockerfile.pyinstaller
@@ -33,10 +33,11 @@ ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y \
-        build-essential \
+        build-essential patchelf \
     && python -m venv /opt/venv \
     && pip install --upgrade pip wheel \
     && pip install pyinstaller==$PYINSTALLER_VERSION \
+    && pip install staticx \
     && pip install -r requirements.txt \
     && ./kapitan/inputs/helm/build.sh \
     && ./kapitan/dependency_manager/helm/build.sh \

--- a/scripts/pyinstaller.sh
+++ b/scripts/pyinstaller.sh
@@ -5,6 +5,9 @@
 
 set -e
 
+#CC='gcc -pthread -static'
+#CONFIG_ARGS='--disable-shared'
+
 entry='__main__'
 output_name='kapitan-linux-amd64'
 pyi-makespec kapitan/"$entry".py --onefile \
@@ -17,7 +20,7 @@ pyi-makespec kapitan/"$entry".py --onefile \
     --hidden-import 'pkg_resources.py2_warn' \
     --exclude-module doctest --exclude-module pydoc
 pyinstaller "$entry".spec --clean
-mv dist/$entry dist/$output_name
+staticx --strip dist/$entry dist/$output_name
 # Open permissions so that when this binary
 # is used outside of docker (on the volume mount) it
 # also can be deleted by Travis CI


### PR DESCRIPTION
Currently the linux binary is not statically linked as pyinstaller does not support this. Patchelf and staticx allow converting a Linux dynamically linked binary into a static binary.