### PR TITLE
Pin urllib3 to fix kapitan crash on newest boto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ six>=1.15.0
 cryptography>=2.9.2
 google-api-python-client==1.7.11
 boto3>=1.14.3
+# Can be removed once https://github.com/boto/botocore/issues/2187 is resolved
+urllib3==1.25.10
 requests==2.23.0
 addict==2.2.1
 yamllint>=1.23.0


### PR DESCRIPTION
With boto3 1.19.6
```
$ kapitan --version
Traceback (most recent call last):
  File "/Users/adrianchifor/Library/Python/3.7/bin/kapitan", line 6, in <module>
    from kapitan.cli import main
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/kapitan/cli.py", line 23, in <module>
    from kapitan.refs.cmd_parser import handle_refs_command
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/kapitan/refs/cmd_parser.py", line 12, in <module>
    from kapitan.refs.secrets.awskms import AWSKMSSecret
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/kapitan/refs/secrets/awskms.py", line 9, in <module>
    import boto3
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/botocore/session.py", line 30, in <module>
    import botocore.credentials
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/botocore/credentials.py", line 34, in <module>
    from botocore.config import Config
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/botocore/config.py", line 16, in <module>
    from botocore.endpoint import DEFAULT_TIMEOUT, MAX_POOL_CONNECTIONS
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/botocore/endpoint.py", line 22, in <module>
    from botocore.awsrequest import create_request_object
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/botocore/awsrequest.py", line 25, in <module>
    import botocore.utils
  File "/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/botocore/utils.py", line 30, in <module>
    from urllib3.util.url import IPV6_ADDRZ_RE
ImportError: cannot import name 'IPV6_ADDRZ_RE' from 'urllib3.util.url' (/Users/adrianchifor/Library/Python/3.7/lib/python/site-packages/urllib3/util/url.py)
```

Post-fix
```
$ kapitan --version
0.29.3
```

botocore bug https://github.com/boto/botocore/issues/2187