### PR TITLE
Bump cryptography to fix CVE-2020-25659

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Jinja2>=2.11.2
 jsonschema==3.2.0
 python-gnupg==0.4.6
 six>=1.15.0
-cryptography>=2.9.2
+cryptography>=3.2
 google-api-python-client==1.7.11
 boto3>=1.14.3
 requests==2.23.0


### PR DESCRIPTION
https://github.com/pyca/cryptography/commit/58494b41d6ecb0f56b7c5f05d5f5e3ca0320d494