### PR TITLE
Note for jsonnet on arm. Skip import if not used

### DIFF
--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -39,6 +39,15 @@ from reclass.errors import NotFoundError, ReclassException
 logger = logging.getLogger(__name__)
 
 
+def check_jsonnet_import():
+    try:
+        import _jsonnet
+    except ImportError:
+        logger.info(
+            "Note: jsonnet is not yet supported on ARM/M1. You can still use kadet and jinja2 for templating"
+        )
+
+
 def compile_targets(
     inventory_path, search_paths, output_path, parallel, targets, labels, ref_controller, **kwargs
 ):
@@ -47,6 +56,7 @@ def compile_targets(
     multiprocessing pool with parallel number of processes.
     kwargs are passed to compile_target()
     """
+    check_jsonnet_import()
     # temp_path will hold compiled items
     temp_path = tempfile.mkdtemp(suffix=".kapitan")
     # enable previously compiled items to be reference in other compile inputs

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -21,7 +21,6 @@ from collections import Counter, defaultdict
 from functools import lru_cache, wraps
 from hashlib import sha256
 
-import _jsonnet as jsonnet
 import jinja2
 import requests
 import yaml
@@ -37,6 +36,12 @@ from distutils.dir_util import mkpath
 
 
 logger = logging.getLogger(__name__)
+
+try:
+    import _jsonnet as jsonnet
+except ImportError as e:
+    logger.debug(f"Could not import jsonnet: {e}")
+
 
 try:
     from yaml import CSafeLoader as YamlLoader


### PR DESCRIPTION
Jsonnet fails on arm / apple M1
```
$ kapitan compile
Traceback (most recent call last):
  File "/Users/adrianchifor/Library/Python/3.8/bin/kapitan", line 5, in <module>
    from kapitan.cli import main
  File "/Users/adrianchifor/Library/Python/3.8/lib/python/site-packages/kapitan/cli.py", line 21, in <module>
    from kapitan.lint import start_lint
  File "/Users/adrianchifor/Library/Python/3.8/lib/python/site-packages/kapitan/lint.py", line 16, in <module>
    from kapitan.utils import list_all_paths
  File "/Users/adrianchifor/Library/Python/3.8/lib/python/site-packages/kapitan/utils.py", line 24, in <module>
    import _jsonnet as jsonnet
ImportError: dlopen(/Users/adrianchifor/Library/Python/3.8/lib/python/site-packages/_jsonnet.cpython-38-darwin.so, 2): Symbol not found: _jsonnet_destroy
  Referenced from: /Users/adrianchifor/Library/Python/3.8/lib/python/site-packages/_jsonnet.cpython-38-darwin.so
  Expected in: flat namespace
 in /Users/adrianchifor/Library/Python/3.8/lib/python/site-packages/_jsonnet.cpython-38-darwin.so
```

This change will print a note when failing to import jsonnet and will continue to compile
```
$ kapitan compile
Note: jsonnet is not yet supported on ARM/M1. You can still use kadet and jinja2 for templating
Compiled target (0.50s)
```