### PR TITLE
Fix error for null inventory path in kadet

### DIFF
--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -89,6 +89,7 @@ class Kadet(InputType):
         prune = kwargs.get("prune", False)
         reveal = kwargs.get("reveal", False)
         target_name = kwargs.get("target_name", None)
+        inventory_path = kwargs.get("inventory_path", None)
         indent = kwargs.get("indent", 2)
 
         input_params = self.input_params
@@ -103,9 +104,9 @@ class Kadet(InputType):
         global search_paths
         search_paths = self.search_paths
         global inventory
-        inventory = lambda: Dict(inventory_func(self.search_paths, target_name))  # noqa E731
+        inventory = lambda: Dict(inventory_func(self.search_paths, target_name, inventory_path))  # noqa E731
         global inventory_global
-        inventory_global = lambda: Dict(inventory_func(self.search_paths, None))  # noqa E731
+        inventory_global = lambda: Dict(inventory_func(self.search_paths, None, inventory_path))  # noqa E731
 
         kadet_module, spec = module_from_path(file_path)
         sys.modules[spec.name] = kadet_module

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -257,7 +257,10 @@ def inventory(search_paths, target, inventory_path=None):
     if inventory_path is None:
         # grab inventory_path value from cli subcommand
         inventory_path_arg = cached.args.get("compile") or cached.args.get("inventory")
-        inventory_path = inventory_path_arg.inventory_path
+        if inventory_path_arg:
+            inventory_path = inventory_path_arg.inventory_path
+        else:
+            inventory_path = "./inventory"
 
     inv_path_exists = False
 

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -257,10 +257,7 @@ def inventory(search_paths, target, inventory_path=None):
     if inventory_path is None:
         # grab inventory_path value from cli subcommand
         inventory_path_arg = cached.args.get("compile") or cached.args.get("inventory")
-        if inventory_path_arg:
-            inventory_path = inventory_path_arg.inventory_path
-        else:
-            inventory_path = "./inventory"
+        inventory_path = inventory_path_arg.inventory_path
 
     inv_path_exists = False
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -408,7 +408,7 @@ def search_targets(inventory_path, targets, labels):
     return targets_found
 
 
-def compile_target(target_obj, search_paths, compile_path, ref_controller, inventory_path, **kwargs):
+def compile_target(target_obj, search_paths, compile_path, ref_controller, **kwargs):
     """Compiles target_obj and writes to compile_path"""
     start = time.time()
     compile_objs = target_obj["compile"]


### PR DESCRIPTION
Compile fails when inventory path is not set in kadet
```
$ kapitan compile
Unknown (Non-Kapitan) Error occurred
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/Users/adrianchifor/code/public/kapitan/kapitan/targets.py", line 453, in compile_target
    input_compiler.compile_obj(comp_obj, ext_vars, **kwargs)
  File "/Users/adrianchifor/code/public/kapitan/kapitan/inputs/base.py", line 54, in compile_obj
    self.compile_input_path(input_path, comp_obj, ext_vars, **kwargs)
  File "/Users/adrianchifor/code/public/kapitan/kapitan/inputs/base.py", line 69, in compile_input_path
    self.compile_file(
  File "/Users/adrianchifor/code/public/kapitan/kapitan/inputs/kadet.py", line 112, in compile_file
    spec.loader.exec_module(kadet_module)
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/adrianchifor/code/[redacted]/__init__.py", line 3, in <module>
    p = inventory().parameters
  File "/Users/adrianchifor/code/public/kapitan/kapitan/inputs/kadet.py", line 106, in <lambda>
    inventory = lambda: Dict(inventory_func(self.search_paths, target_name))  # noqa E731
  File "/Users/adrianchifor/code/public/kapitan/kapitan/resources.py", line 260, in inventory
    inventory_path = inventory_path_arg.inventory_path
AttributeError: 'NoneType' object has no attribute 'inventory_path'
```