### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/compile.md
+++ b/docs/compile.md
@@ -8,6 +8,7 @@
 Now that we have a basic understanding of Kapitan `inventory`, we can talk about the `kapitan compile` command. 
 
 The command has five distinct `phases`:
+
 - Reclass: this takes all the target and class definitions and runs reclass to determine what kapitan needs to do during the compile command.
 - Fetch: this is an optional phase that happens before the compilation actions, if there are dependencies defined in any classes under `parameters.kapitan.dependencies`. This is triggered through the `--fetch` option on the `kapitan compile` command.
 - Compilation: the Reclass phase has determined a sequential list of actions to run specified in the `parameters.kapitan.compile` for each target.  The actions can be defined using jinja2, jsonnet, kadet, helm, and copy. These actions define any transpilation steps you want to take to get a desired manifest output, or simply put, your inputs and outputs.

--- a/docs/inventory.md
+++ b/docs/inventory.md
@@ -263,7 +263,7 @@ parameters:
   kapitan:
     inventory:
     - type: <inventory_type>
-      output_path: path/to/file/or/dir # releative to inventory
+      output_path: path/to/file/or/dir # relative to inventory
       source: <source_of_inventory>
       # other type-specific parameters, if any
 ```


### PR DESCRIPTION
Summary:
  - fix generated documentation formatting for docs/compile.md
  - fix typo in docs/inventory.md