### PR TITLE
Apply simple code simplifications

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -8,6 +8,7 @@
 "command line module"
 
 import argparse
+import contextlib
 import json
 import logging
 import multiprocessing
@@ -659,12 +660,10 @@ def main():
     parser = build_parser()
     args = parser.parse_args()
 
-    try:
-        multiprocessing.set_start_method(args.mp_method)
-    # main() is explicitly multiple times in tests
+    # main() is explicitly called multiple times in tests
     # and will raise RuntimeError
-    except RuntimeError:
-        pass
+    with contextlib.suppress(RuntimeError):
+        multiprocessing.set_start_method(args.mp_method)
 
     if (
         getattr(args, "func", None) == generate_inventory

--- a/kapitan/defaults.py
+++ b/kapitan/defaults.py
@@ -15,7 +15,7 @@ DEFAULT_KUBERNETES_VERSION = "1.14.0"
 # strict is used as it behaves similarly to kubectl
 # see https://github.com/garethr/kubernetes-json-schema#kubernetes-json-schemas for more info
 SCHEMA_TYPE = "standalone-strict"
-FILE_PATH_FORMAT = "v{}-%s/{}.json" % SCHEMA_TYPE
+FILE_PATH_FORMAT = f"v{{}}-{SCHEMA_TYPE}/{{}}.json"
 
 # default path from where user defined custom filters are read
 DEFAULT_JINJA2_FILTERS_PATH = os.path.join("lib", "jinja2_filters.py")

--- a/kapitan/lint.py
+++ b/kapitan/lint.py
@@ -151,7 +151,7 @@ def lint_unused_classes(inventory_path):
     logger.debug("Find unused classes from %s", classes_dir)
     class_paths = set()
     for path in list_all_paths(classes_dir):
-        if os.path.isfile(path) and (path.endswith(".yml") or path.endswith(".yaml")):
+        if os.path.isfile(path) and path.endswith((".yml", ".yaml")):
             path = path[len(classes_dir) :]
             path = path.replace(".yml", "").replace(".yaml", "").replace("/", ".")
             class_paths.add(path)
@@ -208,7 +208,7 @@ def lint_yamllint(inventory_path):
 
     checks_sum = 0
     for path in list_all_paths(inventory_path):
-        if os.path.isfile(path) and (path.endswith(".yml") or path.endswith(".yaml")):
+        if os.path.isfile(path) and path.endswith((".yml", ".yaml")):
             with open(path) as yaml_file:
                 file_contents = yaml_file.read()
 

--- a/kapitan/refs/base.py
+++ b/kapitan/refs/base.py
@@ -241,7 +241,7 @@ class Revealer:
         detects filename by extension (.yml/.yaml, .json or otherwise raw)
         reveals secrets in content
         """
-        if filename.endswith(".yml") or filename.endswith(".yaml"):
+        if filename.endswith((".yml", ".yaml")):
             logger.debug("Revealer: revealing yml file: %s", filename)
             with open(filename) as fp:
                 obj = [o for o in yaml.load_all(fp, Loader=YamlLoader)]
@@ -278,7 +278,7 @@ class Revealer:
         for fpath in list_all_paths(dirname):
             if not os.path.isfile(fpath):
                 continue
-            if fpath.endswith(".yml") or fpath.endswith(".yaml"):
+            if fpath.endswith((".yml", ".yaml")):
                 out, _ = self._reveal_file(fpath)
                 out_yaml += out
             elif fpath.endswith(".json"):

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -138,9 +138,7 @@ def yaml_load(search_paths, name):
     for path in search_paths:
         _full_path = os.path.join(path, name)
         logger.debug("yaml_load trying file %s", _full_path)
-        if os.path.exists(_full_path) and (
-            name.endswith(".yml") or name.endswith(".yaml")
-        ):
+        if os.path.exists(_full_path) and name.endswith((".yml", ".yaml")):
             logger.debug("yaml_load found file at %s", _full_path)
             try:
                 with open(_full_path) as f:
@@ -156,9 +154,7 @@ def yaml_load_stream(search_paths, name):
     for path in search_paths:
         _full_path = os.path.join(path, name)
         logger.debug("yaml_load_stream trying file %s", _full_path)
-        if os.path.exists(_full_path) and (
-            name.endswith(".yml") or name.endswith(".yaml")
-        ):
+        if os.path.exists(_full_path) and name.endswith((".yml", ".yaml")):
             logger.debug("yaml_load_stream found file at %s", _full_path)
             try:
                 with open(_full_path) as f:

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -191,7 +191,7 @@ def deep_get(dictionary, keys, previousKey=None):
             # If we find nothing, check for globbing, loop and match with dict keys
             if "*" in keys[0]:
                 key_lower = keys[0].replace("*", "").lower()
-                for dict_key in dictionary.keys():
+                for dict_key in dictionary:
                     if key_lower in dict_key.lower():
                         # If we're at the last key in the chain, return matched value
                         if len(keys) == 1:
@@ -224,7 +224,7 @@ def searchvar(args):
     maxlength = 0
     keys = args.searchvar.split(".")
     for full_path in list_all_paths(args.inventory_path):
-        if full_path.endswith(".yml") or full_path.endswith(".yaml"):
+        if full_path.endswith((".yml", ".yaml")):
             with open(full_path) as fd:
                 data = yaml.load(fd, Loader=YamlLoader)
                 value = deep_get(data, keys)


### PR DESCRIPTION
## Summary

This PR applies four simple code simplifications to improve readability and modernize Python idioms. All changes are syntactic with no functional impact.

## Changes

### 1. Use tuple syntax for `.endswith()` checks (7 locations)
**Before:**
```python
if path.endswith('.yml') or path.endswith('.yaml'):
```
**After:**
```python
if path.endswith(('.yml', '.yaml')):
```
- More Pythonic and cleaner
- Slightly more efficient (single method call)

### 2. Remove redundant `.keys()` call (1 location)
**Before:**
```python
for key in dictionary.keys():
```
**After:**
```python
for key in dictionary:
```
- Follows Python best practices
- Cleaner and more idiomatic

### 3. Use `contextlib.suppress` instead of try-except-pass (1 location)
**Before:**
```python
try:
    multiprocessing.set_start_method(args.mp_method)
except RuntimeError:
    pass
```
**After:**
```python
with contextlib.suppress(RuntimeError):
    multiprocessing.set_start_method(args.mp_method)
```
- More explicit intent
- Modern Pythonic error suppression

### 4. Convert % formatting to f-string (1 location)
**Before:**
```python
FILE_PATH_FORMAT = "v{}-%s/{}.json" % SCHEMA_TYPE
```
**After:**
```python
FILE_PATH_FORMAT = f"v{{}}-{SCHEMA_TYPE}/{{}}.json"
```
- Modern Python string formatting
- Better readability

## Files Modified

- `kapitan/cli.py` (contextlib.suppress)
- `kapitan/defaults.py` (f-string)
- `kapitan/lint.py` (endswith tuple × 2)
- `kapitan/refs/base.py` (endswith tuple × 2)
- `kapitan/resources.py` (endswith tuple × 2)
- `kapitan/utils.py` (endswith tuple, redundant .keys())

## Testing

- ✅ All existing tests pass (221 passed, 2 skipped)
- ✅ No functional changes - purely syntactic improvements
- ✅ Verified behavior unchanged
