### PR TITLE
Fix CI docker push and refactor workflow

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -146,46 +146,7 @@ jobs:
 
   build:
     name: build ${{ matrix.platform.platform }} image using python ${{ matrix.python-version }}
-    needs: [setup]
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: ${{ fromJson(needs.setup.outputs.platforms) }}
-        python-version: ${{ fromJson(needs.setup.outputs.python-versions) }}
-    steps:
-      - name: Checkout kapitan recursively
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          submodules: recursive
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
-
-      # Builds docker image and allow scoped caching
-      - name: build Kapitan Image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
-        with:
-          push: False
-          platforms: ${{ matrix.platform.platform }}
-          load: True
-          file: Dockerfile
-          tags: local-test-${{ matrix.platform.platform }}
-          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.platform.platform }}-py${{ matrix.python-version }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.platform.platform }}-py${{ matrix.python-version }}
-          build-args: |
-            PYTHON_VERSION=${{ matrix.python-version }}
-
-      - name: Test Kapitan for ${{ matrix.platform.platform }}
-        run: |
-          docker run -t --rm local-test-${{ matrix.platform.platform }} --version
-
-
-  publish:
-    name: publish platform images
-    # Only starts if everything else is successful
-    needs: [setup, precommit, test, build]
-    if: github.event_name != 'pull_request'
+    needs: [setup, precommit, test]
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       fail-fast: false
@@ -205,7 +166,7 @@ jobs:
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -230,10 +191,8 @@ jobs:
         id: meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          # list of Docker images to use as base name for tags
           images: |
             name=${{ vars.DOCKERHUB_REPOSITORY }}/${{ needs.setup.outputs.default-image-name }}
-          # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=branch,suffix=${{ steps.suffix.outputs.python-suffix }}${{ steps.suffix.outputs.platform-suffix }}
             type=semver,pattern={{version}},suffix=${{ steps.suffix.outputs.python-suffix }}${{ steps.suffix.outputs.platform-suffix }}
@@ -269,11 +228,28 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push by digest
-        id: push-digest
+      # Build, test locally, then push if not a PR
+      - name: Build Kapitan image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          platforms: ${{ matrix.platform.platform }}
+          push: false
+          load: true
+          file: Dockerfile
+          tags: local-test
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.platform.platform }}-py${{ matrix.python-version }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.platform.platform }}-py${{ matrix.python-version }}
+          build-args: |
+            PYTHON_VERSION=${{ matrix.python-version }}
+
+      - name: Test Kapitan image
+        run: |
+          docker run -t --rm local-test --version
+
+      - name: Push image to DockerHub
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        if: env.DOCKERHUB_USERNAME != ''
+        if: env.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           platforms: ${{ matrix.platform.platform }}
@@ -281,7 +257,6 @@ jobs:
           tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=${{ github.ref_name }}-${{ matrix.platform.platform }}-py${{ matrix.python-version }}
-          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ matrix.platform.platform }}-py${{ matrix.python-version }}
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
 
@@ -289,7 +264,8 @@ jobs:
     name: combine platform images for python ${{ matrix.python-version }}
     needs:
       - setup
-      - publish
+      - build
+    if: github.event_name != 'pull_request'
     runs-on: ${{ needs.setup.outputs.runner }}
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
## Summary

This PR fixes a CI failure where Docker image push was broken due to invalid GitHub Actions expression syntax, and includes several workflow improvements.

### Bug Fix
- **Fixed broken Docker image name**: Commit `f1c91c24` introduced a bug where the Python version (`3.10`) was being used as the image name instead of the proper repository name. The conditional expression was incorrectly placed outside `${{ }}`.

### Improvements
- **Tag-based Python versions**: Switched from separate image names (`kapitan`, `kapitan-py3.12`) to a single image with Python version in tags (`kapitan:master`, `kapitan:master-py3.12`). The default Python version gets both tagged and untagged variants for compatibility.
- **Centralized configuration**: All version lists and settings are now defined once in `env` block at the top of the workflow
- **Native ARM runners**: Replaced QEMU emulation with GitHub's native `ubuntu-24.04-arm` runners for faster ARM builds
- **Dynamic matrix generation**: Setup job outputs all matrix values, eliminating hardcoded duplicates
- **Dynamic platform suffixes**: Manifest creation suffixes are now generated from the platforms list via jq
- **Better cache keys**: Added Python version to Docker cache scope keys to prevent cache collisions
- **Fixed secrets in conditionals**: Use `env:` pattern since `secrets` context can't be used directly in `if` expressions
- **Updated Python versions**: Now testing 3.11, 3.12, 3.13, and 3.14 (dropped 3.10)

### New Tag Structure
For Python 3.11 (default):
- `kapitan:master` - convenience tag
- `kapitan:master-py3.11` - explicit version tag

For other Python versions:
- `kapitan:master-py3.12`
- `kapitan:master-py3.13`
- `kapitan:master-py3.14`

## Test plan
- [ ] Verify CI passes on this branch
- [ ] Verify Docker images are built for all Python versions
- [ ] Verify multi-architecture manifests are created correctly
- [ ] Verify ARM builds complete without QEMU
- [ ] Verify both `kapitan:master` and `kapitan:master-py3.11` tags exist for default version

🤖 Generated with [Claude Code](https://claude.com/claude-code)