### PR TITLE
Fix ModuleNotFoundError in cache usage with kapicorp/generators

### DIFF
--- a/kapitan/defaults.py
+++ b/kapitan/defaults.py
@@ -24,3 +24,6 @@ DEFAULT_JINJA2_FILTERS_PATH: str = os.path.join("lib", "jinja2_filters.py")
 # Copier template defaults
 COPIER_TEMPLATE_REPOSITORY: str = "https://github.com/kapicorp/kapitan-reference.git"
 COPIER_TEMPLATE_REF: str = "copier"
+
+# kadet component prefix for kadet modules loaded at runtime
+KADET_COMPONENT_MODULE_PREFIX = "kadet_component_"

--- a/kapitan/inputs/cache.py
+++ b/kapitan/inputs/cache.py
@@ -5,6 +5,7 @@ import pickle
 from pathlib import Path
 from typing import Tuple
 
+from kapitan.defaults import KADET_COMPONENT_MODULE_PREFIX
 from kapitan.errors import CompileError
 
 
@@ -97,4 +98,13 @@ class InputCache:
         return pickle.dump(output_obj, fp)
 
     def load_output(self, fp):
-        return pickle.load(fp)
+        try:
+            return pickle.load(fp)
+        except ModuleNotFoundError as e:
+            # It is safe to ignore exception for kadet modules (prefixed with KADET_COMPONENT_MODULE_PREFIX)
+            # since they are lazy loaded at runtime.
+            # This is most likely to happen when using kapicorp/generators
+            if e.name.startswith(KADET_COMPONENT_MODULE_PREFIX):
+                pass
+            else:
+                raise

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -19,6 +19,7 @@ import kadet
 from kadet import BaseModel, BaseObj, Dict
 
 from kapitan import cached
+from kapitan.defaults import KADET_COMPONENT_MODULE_PREFIX
 from kapitan.errors import CompileError
 from kapitan.inputs.base import InputType
 from kapitan.inputs.cache import InputCache
@@ -71,7 +72,9 @@ def module_from_path(path, check_name=None):
 
     module_name = os.path.basename(os.path.normpath(path))
     init_path = os.path.join(path, "__init__.py")
-    spec = spec_from_file_location(f"kadet_component_{module_name}", init_path)
+    spec = spec_from_file_location(
+        f"{KADET_COMPONENT_MODULE_PREFIX}{module_name}", init_path
+    )
     mod = module_from_spec(spec)
 
     if spec is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     "regex>=2024.5.10,<2025",
     "strenum>=0.4.15,<0.5 ; python_version ~= '3.10'",
     "typing-extensions>=4.0.0,<5",
+    "cachetools (>=7.0.1,<8.0.0)",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -130,11 +130,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "6.2.4"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/1d/ede8680603f6016887c062a2cf4fc8fdba905866a3ab8831aa8aa651320c/cachetools-6.2.4.tar.gz", hash = "sha256:82c5c05585e70b6ba2d3ae09ea60b79548872185d2f24ae1f2709d37299fd607", size = 31731, upload-time = "2025-12-15T18:24:53.744Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/07/56595285564e90777d758ebd383d6b0b971b87729bbe2184a849932a3736/cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341", size = 36126, upload-time = "2026-02-10T22:24:05.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/fc/1d7b80d0eb7b714984ce40efc78859c022cd930e402f599d8ca9e39c78a4/cachetools-6.2.4-py3-none-any.whl", hash = "sha256:69a7a52634fed8b8bf6e24a050fb60bff1c9bd8f6d24572b99c32d4e71e62a51", size = 11551, upload-time = "2025-12-15T18:24:52.332Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9e/5faefbf9db1db466d633735faceda1f94aa99ce506ac450d232536266b32/cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf", size = 13484, upload-time = "2026-02-10T22:24:03.741Z" },
 ]
 
 [[package]]
@@ -700,16 +700,16 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.45.0"
+version = "2.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cachetools" },
+    { name = "cryptography" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/00/3c794502a8b892c404b2dea5b3650eb21bfc7069612fbfd15c7f17c1cb0d/google_auth-2.45.0.tar.gz", hash = "sha256:90d3f41b6b72ea72dd9811e765699ee491ab24139f34ebf1ca2b9cc0c38708f3", size = 320708, upload-time = "2025-12-15T22:58:42.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/41/242044323fbd746615884b1c16639749e73665b718209946ebad7ba8a813/google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce", size = 326522, upload-time = "2026-01-26T19:22:47.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/97/451d55e05487a5cd6279a01a7e34921858b16f7dc8aa38a2c684743cd2b3/google_auth-2.45.0-py2.py3-none-any.whl", hash = "sha256:82344e86dc00410ef5382d99be677c6043d72e502b625aa4f4afa0bdacca0f36", size = 233312, upload-time = "2025-12-15T22:58:40.777Z" },
+    { url = "https://files.pythonhosted.org/packages/83/1d/d6466de3a5249d35e832a52834115ca9d1d0de6abc22065f049707516d47/google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f", size = 236499, upload-time = "2026-01-26T19:22:45.099Z" },
 ]
 
 [[package]]
@@ -958,6 +958,7 @@ dependencies = [
     { name = "azure-identity" },
     { name = "azure-keyvault-keys" },
     { name = "boto3" },
+    { name = "cachetools" },
     { name = "certifi" },
     { name = "copier" },
     { name = "cryptography" },
@@ -1032,6 +1033,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.12.0,<2" },
     { name = "azure-keyvault-keys", specifier = ">=4.7.0,<5" },
     { name = "boto3", specifier = ">=1.18.17,<2" },
+    { name = "cachetools", specifier = ">=7.0.1,<8.0.0" },
     { name = "certifi" },
     { name = "copier", specifier = ">=9.3.1,<10" },
     { name = "cryptography", specifier = ">=3.4.7,<44.0.0" },


### PR DESCRIPTION
Fixes #1405

## Proposed Changes

* Catches and ignores ModuleNotFoundError exceptions only when loading kadet modules dynamically via kapicorp generators when kadet cache is unpickled.
* Additionally, adds the missing cachetools to pyproject.toml
