### PR TITLE
fix: replace bare except with except Exception

### DIFF
--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -81,7 +81,7 @@ def trigger_compile(args):
             ref_controller=ref_controller,
             args=args,
         )
-    except:
+    except Exception:
         sys.exit(1)
 
 

--- a/kapitan/refs/base64.py
+++ b/kapitan/refs/base64.py
@@ -45,7 +45,7 @@ class Base64Ref(PlainRef):
         decoded = base64.b64decode(self.data)
         try:
             return decoded.decode()
-        except:
+        except Exception:
             return self.data
 
     def compile_embedded(self):


### PR DESCRIPTION
## Summary

Replace bare `except:` clauses with `except Exception:` in `base64.py` and `cli.py`.

Bare `except:` catches all exceptions including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit`, which is almost never intended. Using `except Exception:` follows PEP 8 best practices.

**Changes:**
```python
# Before (kapitan/refs/base64.py:48)
except:
    return self.data

# After
except Exception:
    return self.data

# Before (kapitan/cli.py:84)
except:
    sys.exit(1)

# After
except Exception:
    sys.exit(1)
```

## Testing
No behavior change for normal exceptions — style/correctness fix only.