### PR TITLE
feat: add literal resolver to emit backslash dollar syntax in OmegaConf

### DIFF
--- a/docs/pages/inventory/omegaconf.md
+++ b/docs/pages/inventory/omegaconf.md
@@ -178,6 +178,7 @@ deployments:
 | Resolver | Description | Example |
 |----------|-------------|---------|
 | `escape` | Create an interpolation for next resolution pass | `${escape:some.path}` → `${some.path}` |
+| `literal` | Emit a literal `\${content}` string (never resolved) | `${literal:HOME}` → `\${HOME}` |
 | `default` | Chain of fallback values using oc.select | `${default:key1, key2, fallback}` |
 | `write` | Write resolved content to another inventory location | `${write:destination.path, source.path}` |
 | `from_file` | Read content from a file | `${from_file:path/to/file.txt}` |

--- a/docs/pages/inventory/omegaconf.md
+++ b/docs/pages/inventory/omegaconf.md
@@ -177,8 +177,7 @@ deployments:
 
 | Resolver | Description | Example |
 |----------|-------------|---------|
-| `escape` | Create an interpolation for next resolution pass | `${escape:some.path}` → `${some.path}` |
-| `literal` | Emit a literal `\${content}` string (never resolved) | `${literal:HOME}` → `\${HOME}` |
+| `escape` | Emit a literal `${content}` string (never resolved) | `${escape:HOME}` → `${HOME}` |
 | `default` | Chain of fallback values using oc.select | `${default:key1, key2, fallback}` |
 | `write` | Write resolved content to another inventory location | `${write:destination.path, source.path}` |
 | `from_file` | Read content from a file | `${from_file:path/to/file.txt}` |

--- a/kapitan/inventory/backends/omegaconf/resolvers.py
+++ b/kapitan/inventory/backends/omegaconf/resolvers.py
@@ -19,26 +19,53 @@ from omegaconf import Container, ListMergeMode, Node, OmegaConf
 
 logger = logging.getLogger(__name__)
 
-# Marker used by the literal resolver to protect interpolation syntax
+# Markers used by user-defined resolvers to emit ${content} in the final output
 LITERAL_MARKER_PREFIX = "__KAPITAN_LITERAL__"
 LITERAL_MARKER_SUFFIX = "__KAPITAN_LITERAL_END__"
+
+# Markers used by the built-in ${literal:} resolver to emit \${content} in the final output
+LITERAL_BACKSLASH_MARKER_PREFIX = "__KAPITAN_LITERAL_BACKSLASH__"
+LITERAL_BACKSLASH_MARKER_SUFFIX = "__KAPITAN_LITERAL_BACKSLASH_END__"
+
+# Combined pattern — single pass over strings in process_literals.
+# Named groups: `bs_content` captures the payload of a backslash-literal marker (\${...}),
+# `plain_content` captures the payload of a plain literal marker (${...}).
+_COMBINED_LITERAL_PATTERN = re.compile(
+    rf"(?:{re.escape(LITERAL_BACKSLASH_MARKER_PREFIX)}(?P<bs_content>.+?){re.escape(LITERAL_BACKSLASH_MARKER_SUFFIX)})"
+    rf"|(?:{re.escape(LITERAL_MARKER_PREFIX)}(?P<plain_content>.+?){re.escape(LITERAL_MARKER_SUFFIX)})"
+)
+
+# Keep individual compiled patterns for external callers that import them directly
 LITERAL_PATTERN = re.compile(
     rf"{re.escape(LITERAL_MARKER_PREFIX)}(.+?){re.escape(LITERAL_MARKER_SUFFIX)}"
 )
+LITERAL_BACKSLASH_PATTERN = re.compile(
+    rf"{re.escape(LITERAL_BACKSLASH_MARKER_PREFIX)}(.+?){re.escape(LITERAL_BACKSLASH_MARKER_SUFFIX)}"
+)
+
+
+def _replace_literal(m: re.Match) -> str:
+    """Replace a matched literal marker with its final interpolation syntax.
+
+    Backslash-literal markers become \\${content}; plain markers become ${content}.
+    """
+    if m.group("bs_content") is not None:
+        return r"\${" + m.group("bs_content") + "}"
+    return "${" + m.group("plain_content") + "}"
 
 
 def process_literals(obj):
     """Recursively process literal markers in the resolved config.
 
     Converts __KAPITAN_LITERAL__content__KAPITAN_LITERAL_END__ back to ${content}.
+    Converts __KAPITAN_LITERAL_BACKSLASH__content__KAPITAN_LITERAL_BACKSLASH_END__ back to \\${content}.
     """
     if isinstance(obj, dict):
         return {k: process_literals(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [process_literals(item) for item in obj]
     if isinstance(obj, str):
-        # Replace all literal markers with actual interpolation syntax
-        return LITERAL_PATTERN.sub(r"${\1}", obj)
+        return _COMBINED_LITERAL_PATTERN.sub(_replace_literal, obj)
     return obj
 
 
@@ -69,6 +96,13 @@ def access_key_with_dots(*key: str, _root_: Container):
 def escape_interpolation(content: str):
     """resolver function that escapes an interpolation for the next resolving step"""
     return f"${{{content}}}"
+
+
+def literal_interpolation(content: str):
+    """resolver function that emits \\${content} as a literal string in the final output"""
+    return (
+        f"{LITERAL_BACKSLASH_MARKER_PREFIX}{content}{LITERAL_BACKSLASH_MARKER_SUFFIX}"
+    )
 
 
 def merge(*args):
@@ -250,6 +284,7 @@ def register_resolvers(inventory_path: str = None) -> None:
     # yaml object utility functions
     OmegaConf.register_new_resolver("access", access_key_with_dots, replace=replace)
     OmegaConf.register_new_resolver("escape", escape_interpolation, replace=replace)
+    OmegaConf.register_new_resolver("literal", literal_interpolation, replace=replace)
     OmegaConf.register_new_resolver("merge", merge, replace=replace)
     OmegaConf.register_new_resolver("dict", to_dict, replace=replace)
     OmegaConf.register_new_resolver("list", to_list, replace=replace)

--- a/kapitan/inventory/backends/omegaconf/resolvers.py
+++ b/kapitan/inventory/backends/omegaconf/resolvers.py
@@ -19,53 +19,26 @@ from omegaconf import Container, ListMergeMode, Node, OmegaConf
 
 logger = logging.getLogger(__name__)
 
-# Markers used by user-defined resolvers to emit ${content} in the final output
+# Markers used by ${escape:} to emit ${content} as a literal string in the final output
 LITERAL_MARKER_PREFIX = "__KAPITAN_LITERAL__"
 LITERAL_MARKER_SUFFIX = "__KAPITAN_LITERAL_END__"
 
-# Markers used by the built-in ${literal:} resolver to emit \${content} in the final output
-LITERAL_BACKSLASH_MARKER_PREFIX = "__KAPITAN_LITERAL_BACKSLASH__"
-LITERAL_BACKSLASH_MARKER_SUFFIX = "__KAPITAN_LITERAL_BACKSLASH_END__"
-
-# Combined pattern — single pass over strings in process_literals.
-# Named groups: `bs_content` captures the payload of a backslash-literal marker (\${...}),
-# `plain_content` captures the payload of a plain literal marker (${...}).
-_COMBINED_LITERAL_PATTERN = re.compile(
-    rf"(?:{re.escape(LITERAL_BACKSLASH_MARKER_PREFIX)}(?P<bs_content>.+?){re.escape(LITERAL_BACKSLASH_MARKER_SUFFIX)})"
-    rf"|(?:{re.escape(LITERAL_MARKER_PREFIX)}(?P<plain_content>.+?){re.escape(LITERAL_MARKER_SUFFIX)})"
-)
-
-# Keep individual compiled patterns for external callers that import them directly
 LITERAL_PATTERN = re.compile(
     rf"{re.escape(LITERAL_MARKER_PREFIX)}(.+?){re.escape(LITERAL_MARKER_SUFFIX)}"
 )
-LITERAL_BACKSLASH_PATTERN = re.compile(
-    rf"{re.escape(LITERAL_BACKSLASH_MARKER_PREFIX)}(.+?){re.escape(LITERAL_BACKSLASH_MARKER_SUFFIX)}"
-)
-
-
-def _replace_literal(m: re.Match) -> str:
-    """Replace a matched literal marker with its final interpolation syntax.
-
-    Backslash-literal markers become \\${content}; plain markers become ${content}.
-    """
-    if m.group("bs_content") is not None:
-        return r"\${" + m.group("bs_content") + "}"
-    return "${" + m.group("plain_content") + "}"
 
 
 def process_literals(obj):
     """Recursively process literal markers in the resolved config.
 
     Converts __KAPITAN_LITERAL__content__KAPITAN_LITERAL_END__ back to ${content}.
-    Converts __KAPITAN_LITERAL_BACKSLASH__content__KAPITAN_LITERAL_BACKSLASH_END__ back to \\${content}.
     """
     if isinstance(obj, dict):
         return {k: process_literals(v) for k, v in obj.items()}
     if isinstance(obj, list):
         return [process_literals(item) for item in obj]
     if isinstance(obj, str):
-        return _COMBINED_LITERAL_PATTERN.sub(_replace_literal, obj)
+        return LITERAL_PATTERN.sub(r"${\1}", obj)
     return obj
 
 
@@ -94,15 +67,8 @@ def access_key_with_dots(*key: str, _root_: Container):
 
 
 def escape_interpolation(content: str):
-    """resolver function that escapes an interpolation for the next resolving step"""
-    return f"${{{content}}}"
-
-
-def literal_interpolation(content: str):
-    """resolver function that emits \\${content} as a literal string in the final output"""
-    return (
-        f"{LITERAL_BACKSLASH_MARKER_PREFIX}{content}{LITERAL_BACKSLASH_MARKER_SUFFIX}"
-    )
+    """resolver function that emits ${content} as a literal string in the final output"""
+    return f"{LITERAL_MARKER_PREFIX}{content}{LITERAL_MARKER_SUFFIX}"
 
 
 def merge(*args):
@@ -284,7 +250,6 @@ def register_resolvers(inventory_path: str = None) -> None:
     # yaml object utility functions
     OmegaConf.register_new_resolver("access", access_key_with_dots, replace=replace)
     OmegaConf.register_new_resolver("escape", escape_interpolation, replace=replace)
-    OmegaConf.register_new_resolver("literal", literal_interpolation, replace=replace)
     OmegaConf.register_new_resolver("merge", merge, replace=replace)
     OmegaConf.register_new_resolver("dict", to_dict, replace=replace)
     OmegaConf.register_new_resolver("list", to_list, replace=replace)

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -297,16 +297,37 @@ class InventoryTestOmegaConfOC(unittest.TestCase):
         inventory.load_target(target)
 
         params = target.parameters.model_dump(by_alias=True)
+        escape_test = params["escape_test"]
 
+        # Standalone values become ${content}
         self.assertEqual(
-            params["escape_test"]["terraform_ref"],
+            escape_test["terraform_ref"],
             "${google_service_account.cluster.email}",
             "${escape:} should produce ${content} without omegaconf resolving it",
         )
         self.assertEqual(
-            params["escape_test"]["shell_var"],
+            escape_test["shell_var"],
             "${HOME}",
             "${escape:} should preserve shell variable syntax literally",
+        )
+
+        # Embedded mid-string: surrounding text and other interpolations are unaffected
+        self.assertEqual(
+            escape_test["greeting"],
+            "Hello ${USER}, welcome to resolvers-test",
+            "${escape:} embedded in a string should only escape its own content",
+        )
+
+        # Content that matches a real inventory key must NOT be resolved
+        self.assertNotEqual(
+            escape_test["escaped_key"],
+            escape_test["real_key"],
+            "${escape:environment} must not resolve the 'environment' key",
+        )
+        self.assertEqual(
+            escape_test["escaped_key"],
+            "${environment}",
+            "${escape:environment} should produce the literal string '${environment}'",
         )
 
 

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -286,6 +286,29 @@ class InventoryTestOmegaConfOC(unittest.TestCase):
             "omegaconf.remove should contain base_component for removal during compile",
         )
 
+    def test_literal_resolver_produces_backslash_dollar_syntax(self):
+        """Test that ${literal:content} produces \\${content} as a literal string."""
+        target_name = "test-resolvers"
+        target_path = "test-resolvers.yml"
+
+        inventory = self.inventory_backend
+        target = inventory.target_class(name=target_name, path=target_path)
+        inventory.targets.update({target_name: target})
+        inventory.load_target(target)
+
+        params = target.parameters.model_dump(by_alias=True)
+
+        self.assertEqual(
+            params["literal_test"]["terraform_ref"],
+            r"\${google_service_account.cluster.email}",
+            "${literal:} should produce \\${content} without omegaconf resolving it",
+        )
+        self.assertEqual(
+            params["literal_test"]["shell_var"],
+            r"\${HOME}",
+            "${literal:} should preserve shell variable syntax literally",
+        )
+
 
 class InventoryTestOmegaConfMergeResolver(unittest.TestCase):
     """Test OmegaConf merge resolver functionality"""

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -286,8 +286,8 @@ class InventoryTestOmegaConfOC(unittest.TestCase):
             "omegaconf.remove should contain base_component for removal during compile",
         )
 
-    def test_literal_resolver_produces_backslash_dollar_syntax(self):
-        """Test that ${literal:content} produces \\${content} as a literal string."""
+    def test_escape_resolver_produces_dollar_syntax(self):
+        """Test that ${escape:content} produces ${content} as a literal string."""
         target_name = "test-resolvers"
         target_path = "test-resolvers.yml"
 
@@ -299,14 +299,14 @@ class InventoryTestOmegaConfOC(unittest.TestCase):
         params = target.parameters.model_dump(by_alias=True)
 
         self.assertEqual(
-            params["literal_test"]["terraform_ref"],
-            r"\${google_service_account.cluster.email}",
-            "${literal:} should produce \\${content} without omegaconf resolving it",
+            params["escape_test"]["terraform_ref"],
+            "${google_service_account.cluster.email}",
+            "${escape:} should produce ${content} without omegaconf resolving it",
         )
         self.assertEqual(
-            params["literal_test"]["shell_var"],
-            r"\${HOME}",
-            "${literal:} should preserve shell variable syntax literally",
+            params["escape_test"]["shell_var"],
+            "${HOME}",
+            "${escape:} should preserve shell variable syntax literally",
         )
 
 

--- a/tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml
+++ b/tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml
@@ -78,11 +78,11 @@ parameters:
         memory: 1Gi
 
   # -----------------------------------------------
-  # Test literal resolver - produces \${content} without resolving
+  # Test escape resolver - produces ${content} without resolving
   # -----------------------------------------------
-  literal_test:
-    terraform_ref: ${literal:google_service_account.cluster.email}
-    shell_var: ${literal:HOME}
+  escape_test:
+    terraform_ref: ${escape:google_service_account.cluster.email}
+    shell_var: ${escape:HOME}
 
   # -----------------------------------------------
   # KAPITAN COMPILE (minimal, just to validate inventory)

--- a/tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml
+++ b/tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml
@@ -78,6 +78,13 @@ parameters:
         memory: 1Gi
 
   # -----------------------------------------------
+  # Test literal resolver - produces \${content} without resolving
+  # -----------------------------------------------
+  literal_test:
+    terraform_ref: ${literal:google_service_account.cluster.email}
+    shell_var: ${literal:HOME}
+
+  # -----------------------------------------------
   # KAPITAN COMPILE (minimal, just to validate inventory)
   # -----------------------------------------------
   kapitan:

--- a/tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml
+++ b/tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml
@@ -83,6 +83,11 @@ parameters:
   escape_test:
     terraform_ref: ${escape:google_service_account.cluster.email}
     shell_var: ${escape:HOME}
+    # ${escape:} mid-string: surrounding text must be preserved
+    greeting: "Hello ${escape:USER}, welcome to ${cluster}"
+    # ${escape:} content matches a real inventory key — must NOT be re-resolved
+    real_key: ${environment}
+    escaped_key: ${escape:environment}
 
   # -----------------------------------------------
   # KAPITAN COMPILE (minimal, just to validate inventory)


### PR DESCRIPTION
## [feat]: Repurpose `escape` resolver to emit literal `${content}` in OmegaConf

---

### Summary

Repurposes the existing `${escape:content}` resolver in the OmegaConf inventory backend to emit
`${content}` as a verbatim string in the final compiled output — bypassing both OmegaConf
resolution passes entirely.

This is useful when a target needs to produce a literal `${...}` expression in its output (e.g.
a Terraform resource reference or a shell variable) without Kapitan attempting to resolve it as
an inventory interpolation.

```yaml
parameters:
  google_sa_email: ${escape:google_service_account.cluster.email}
  # compiled value: ${google_service_account.cluster.email}

  shell_home: ${escape:HOME}
  # compiled value: ${HOME}

  # Works embedded in a larger string too
  greeting: "Hello ${escape:USER}, welcome to ${cluster}"
  # compiled value: Hello ${USER}, welcome to my-cluster
```

---

### Proposed Changes

#### Implementation

- **`kapitan/inventory/backends/omegaconf/resolvers.py`**
  - `escape_interpolation(content)` now returns content wrapped in opaque `LITERAL_MARKER_*`
    markers instead of a raw `${content}` string — this ensures the value is never picked up and
    re-resolved during the second OmegaConf pass, even when `content` matches a real inventory key
  - `process_literals()` already handled these markers; no change needed there
  - Removed the now-superseded `literal_interpolation` function and its `LITERAL_BACKSLASH_MARKER_*`
    constants and `_COMBINED_LITERAL_PATTERN` / `_replace_literal` helpers
  - Removed the `literal` resolver registration from `register_resolvers()`

#### How it works

The OmegaConf backend uses a two-pass resolution strategy. To produce a final value that contains
`${...}`, a resolver must return a string that:

1. Is not itself an OmegaConf interpolation (so it survives both passes unchanged)
2. Can be post-processed after resolution is complete

`escape_interpolation` wraps `content` in opaque marker strings. After both OmegaConf passes run,
`process_literals()` substitutes the markers for the final `${content}` value.

---

### Docs and Tests

- [x] **Test updated** — `test_escape_resolver_produces_dollar_syntax` in `tests/test_omegaconf.py` covers:
  - Standalone values (`${escape:HOME}` → `${HOME}`)
  - Embedded mid-string use (`Hello ${escape:USER}, welcome to ${cluster}` resolves surrounding interpolations but not the escaped one)
  - Key-collision protection — `${escape:environment}` produces `${environment}` even though `environment` is a real inventory key that would otherwise resolve to `dev`
- [x] **Test inventory updated** — `tests/test_resources/omegaconf/inventory/classes/components/test-resolvers.yml`
  `escape_test` section extended with the mid-string and key-collision cases
- [x] **Docs updated** — `docs/pages/inventory/omegaconf.md` Utility Resolvers table entry for
  `escape` updated to reflect the new behaviour
