### PR TITLE
Introduce rapidyaml emitter option

### DIFF
--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -155,7 +155,7 @@ library), enabled with `--yaml-use-rapidyaml`.
     ```
 
     On a realistic Kubernetes Deployment manifest the rapidyaml emitter is
-    around **6× faster** than the default PyYAML emitter.
+    around **6x faster** than the default PyYAML emitter.
 
 !!! note
 

--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -139,6 +139,39 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
         +  MYSQL_ROOT_PASSWORD_SHA256: ?{gpg:eyJkYXRhI [[ CUT ]] eXBlIjogImdwZyJ9:embedded}
         ```
 
+## Fast YAML emission with rapidyaml
+
+For YAML-heavy compiles (large Helm-style component trees, big Kubernetes
+manifests, hundreds of targets, etc.) the YAML emitter itself can become a
+meaningful share of total compile time. Kapitan ships an *opt-in* fast
+path backed by [rapidyaml](https://github.com/biojppm/rapidyaml) (a C++ YAML
+library), enabled with `--yaml-use-rapidyaml`.
+
+!!! example ""
+
+    ```shell
+    pip install kapitan[rapidyaml]
+    kapitan compile --yaml-use-rapidyaml
+    ```
+
+    On a realistic Kubernetes Deployment manifest the rapidyaml emitter is
+    around **6× faster** than the default PyYAML emitter.
+
+!!! note
+
+    * Compiled output is **deterministic** and **semantically equivalent**
+      to the default PyYAML output: mapping keys are still sorted
+      alphabetically and every scalar round-trips to the same Python
+      object.
+    * Cosmetic differences are possible (e.g. rapidyaml may single-quote a
+      few scalars that PyYAML leaves plain, like `image: 'mysql:latest'`).
+      Existing fixtures comparing exact bytes may need regenerating.
+    * If the `rapidyaml` package is not installed, the flag is ignored
+      with a one-time startup warning and PyYAML is used.
+    * Documents containing ASCII control characters automatically fall
+      back to PyYAML for that single document (rapidyaml does not escape
+      them in double-quoted scalars).
+
 ## help
 
 !!! example ""
@@ -163,6 +196,7 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
                        [--compose-target-name] [--schemas-path SCHEMAS_PATH]
                        [--yaml-multiline-string-style STYLE]
                        [--yaml-dump-null-as-empty]
+                       [--yaml-use-rapidyaml]
                        [--targets TARGET [TARGET ...] | --labels
                        [key=value ...]]
 
@@ -212,6 +246,8 @@ The `--embed-refs` flags tells **Kapitan** to embed these references on compile,
           --yaml-dump-null-as-empty
                                 dumps all none-type entries as empty, default is
                                 dumping as 'null'
+          --yaml-use-rapidyaml  use the rapidyaml emitter, fallback to PyYaml
+                                if rapidyaml not installed, default is False.
           --targets TARGET [TARGET ...], -t TARGET [TARGET ...]
                                 targets to compile, default is all
           --labels [key=value ...], -l [key=value ...]

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -70,6 +70,16 @@ def trigger_compile(args):
     if not args.ignore_version_check:
         check_version()
 
+    if getattr(args, "yaml_use_rapidyaml", False):
+        from kapitan.yaml_ryml import HAS_RYML
+
+        if not HAS_RYML:
+            logger.warning(
+                "--yaml-use-rapidyaml was requested but the 'rapidyaml' "
+                "package is not installed; falling back to PyYAML. "
+                "Install with `uv pip install kapitan[rapidyaml]`."
+            )
+
     ref_controller = RefController(args.refs_path, embed_refs=args.embed_refs)
     # cache controller for use in reveal_maybe jinja2 filter
     cached.ref_controller_obj = ref_controller
@@ -322,6 +332,17 @@ def build_parser():
         default=from_dot_kapitan("compile", "yaml-dump-null-as-empty", False),
         action="store_true",
         help="dumps all none-type entries as empty, default is dumping as 'null'",
+    )
+
+    compile_parser.add_argument(
+        "--yaml-use-rapidyaml",
+        default=from_dot_kapitan("compile", "yaml-use-rapidyaml", False),
+        action="store_true",
+        help=(
+            "use the rapidyaml emitter, "
+            "fallback to PyYaml if 'rapidyaml' not installed,"
+            "default is False."
+        ),
     )
 
     compile_selector_parser = compile_parser.add_mutually_exclusive_group()

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -34,7 +34,9 @@ logger = logging.getLogger(__name__)
 
 
 def print_deprecated_secrets_msg(args):
-    logger.error("Secrets have been renamed to refs, please refer to: '$ kapitan refs --help'")
+    logger.error(
+        "Secrets have been renamed to refs, please refer to: '$ kapitan refs --help'"
+    )
     sys.exit(1)
 
 
@@ -134,7 +136,9 @@ def build_parser():
         ),
     )
 
-    eval_parser = subparser.add_parser("eval", aliases=["e"], help="evaluate jsonnet file")
+    eval_parser = subparser.add_parser(
+        "eval", aliases=["e"], help="evaluate jsonnet file"
+    )
     eval_parser.add_argument("jsonnet_file", type=str)
     eval_parser.set_defaults(func=trigger_eval, name="eval")
 
@@ -184,7 +188,9 @@ def build_parser():
         "--jinja2-filters",
         "-J2F",
         type=str,
-        default=from_dot_kapitan("compile", "jinja2-filters", defaults.DEFAULT_JINJA2_FILTERS_PATH),
+        default=from_dot_kapitan(
+            "compile", "jinja2-filters", defaults.DEFAULT_JINJA2_FILTERS_PATH
+        ),
         metavar="FPATH",
         help="load custom jinja2 filters from any file, default is to put\
                                 them inside lib/jinja2_filters.py",
@@ -414,7 +420,9 @@ def build_parser():
         choices=["literal", "folded", "double-quotes"],
         metavar="STYLE",
         action="store",
-        default=from_dot_kapitan("inventory", "multiline-string-style", "double-quotes"),
+        default=from_dot_kapitan(
+            "inventory", "multiline-string-style", "double-quotes"
+        ),
         help="set multiline string style to STYLE, default is 'double-quotes'",
     )
 
@@ -521,7 +529,9 @@ def build_parser():
         help='read file or directory, set "-" for stdin',
         metavar="FILENAME",
     )
-    refs_parser.add_argument("--target-name", "-t", help="grab recipients from target name")
+    refs_parser.add_argument(
+        "--target-name", "-t", help="grab recipients from target name"
+    )
     refs_parser.add_argument(
         "--inventory-path",
         default=from_dot_kapitan("refs", "inventory-path", "./inventory"),
@@ -580,7 +590,9 @@ def build_parser():
         default=from_dot_kapitan("refs", "verbose", False),
     )
 
-    lint_parser = subparser.add_parser("lint", aliases=["l"], help="linter for inventory and refs")
+    lint_parser = subparser.add_parser(
+        "lint", aliases=["l"], help="linter for inventory and refs"
+    )
     lint_parser.set_defaults(func=start_lint, name="lint")
 
     lint_parser.add_argument(
@@ -638,7 +650,9 @@ def build_parser():
 
     init_parser.add_argument(
         "--template_git_url",
-        default=from_dot_kapitan("init", "template_git_url ", defaults.COPIER_TEMPLATE_REPOSITORY),
+        default=from_dot_kapitan(
+            "init", "template_git_url ", defaults.COPIER_TEMPLATE_REPOSITORY
+        ),
         help=f"Cruft template_git_url, default is {defaults.COPIER_TEMPLATE_REPOSITORY}",
     )
     init_parser.add_argument(

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -34,9 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 def print_deprecated_secrets_msg(args):
-    logger.error(
-        "Secrets have been renamed to refs, please refer to: '$ kapitan refs --help'"
-    )
+    logger.error("Secrets have been renamed to refs, please refer to: '$ kapitan refs --help'")
     sys.exit(1)
 
 
@@ -136,9 +134,7 @@ def build_parser():
         ),
     )
 
-    eval_parser = subparser.add_parser(
-        "eval", aliases=["e"], help="evaluate jsonnet file"
-    )
+    eval_parser = subparser.add_parser("eval", aliases=["e"], help="evaluate jsonnet file")
     eval_parser.add_argument("jsonnet_file", type=str)
     eval_parser.set_defaults(func=trigger_eval, name="eval")
 
@@ -188,9 +184,7 @@ def build_parser():
         "--jinja2-filters",
         "-J2F",
         type=str,
-        default=from_dot_kapitan(
-            "compile", "jinja2-filters", defaults.DEFAULT_JINJA2_FILTERS_PATH
-        ),
+        default=from_dot_kapitan("compile", "jinja2-filters", defaults.DEFAULT_JINJA2_FILTERS_PATH),
         metavar="FPATH",
         help="load custom jinja2 filters from any file, default is to put\
                                 them inside lib/jinja2_filters.py",
@@ -340,8 +334,8 @@ def build_parser():
         action="store_true",
         help=(
             "use the rapidyaml emitter, "
-            "fallback to PyYaml if 'rapidyaml' not installed,"
-            "default is False."
+            "fallback to PyYaml if rapidyaml not installed, "
+            "default is False"
         ),
     )
 
@@ -420,9 +414,7 @@ def build_parser():
         choices=["literal", "folded", "double-quotes"],
         metavar="STYLE",
         action="store",
-        default=from_dot_kapitan(
-            "inventory", "multiline-string-style", "double-quotes"
-        ),
+        default=from_dot_kapitan("inventory", "multiline-string-style", "double-quotes"),
         help="set multiline string style to STYLE, default is 'double-quotes'",
     )
 
@@ -529,9 +521,7 @@ def build_parser():
         help='read file or directory, set "-" for stdin',
         metavar="FILENAME",
     )
-    refs_parser.add_argument(
-        "--target-name", "-t", help="grab recipients from target name"
-    )
+    refs_parser.add_argument("--target-name", "-t", help="grab recipients from target name")
     refs_parser.add_argument(
         "--inventory-path",
         default=from_dot_kapitan("refs", "inventory-path", "./inventory"),
@@ -590,9 +580,7 @@ def build_parser():
         default=from_dot_kapitan("refs", "verbose", False),
     )
 
-    lint_parser = subparser.add_parser(
-        "lint", aliases=["l"], help="linter for inventory and refs"
-    )
+    lint_parser = subparser.add_parser("lint", aliases=["l"], help="linter for inventory and refs")
     lint_parser.set_defaults(func=start_lint, name="lint")
 
     lint_parser.add_argument(
@@ -650,9 +638,7 @@ def build_parser():
 
     init_parser.add_argument(
         "--template_git_url",
-        default=from_dot_kapitan(
-            "init", "template_git_url ", defaults.COPIER_TEMPLATE_REPOSITORY
-        ),
+        default=from_dot_kapitan("init", "template_git_url ", defaults.COPIER_TEMPLATE_REPOSITORY),
         help=f"Cruft template_git_url, default is {defaults.COPIER_TEMPLATE_REPOSITORY}",
     )
     init_parser.add_argument(

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -7,7 +7,6 @@
 
 import abc
 import glob
-import itertools
 import json
 import logging
 import os
@@ -21,9 +20,24 @@ from kapitan.errors import CompileError, KapitanError
 from kapitan.inventory.model.input_types import CompileInputTypeConfig, OutputType
 from kapitan.refs.base import Revealer
 from kapitan.utils import PrettyDumper, prune_empty
+from kapitan.yaml_ryml import HAS_RYML
+from kapitan.yaml_ryml import dump as ryml_dump
 
 
 logger = logging.getLogger(__name__)
+
+# Process-wide memo of directories already ensured to exist. Without it every
+# ``compile_input_path`` call issues a fresh ``os.makedirs(..., exist_ok=True)``
+# which still costs at least one ``stat()`` syscall.
+_ENSURED_DIRS: set = set()
+
+
+def _ensure_dir(path: str) -> None:
+    """``os.makedirs(path, exist_ok=True)`` with an in-process memo."""
+    if path in _ENSURED_DIRS:
+        return
+    os.makedirs(path, exist_ok=True)
+    _ENSURED_DIRS.add(path)
 
 
 class InputType:
@@ -76,11 +90,39 @@ class InputType:
             - Compile each unique file found
 
         """
+        # ``target_compile_path`` only depends on ``(compile_path,
+        # target_name, output_path)`` — all fixed for the duration of this
+        # call. Compute it (and ensure the directory exists) exactly once
+        # here, instead of per-file inside ``compile_input_path``.
+        target_compile_path = os.path.join(
+            self.compile_path,
+            self.target_name.replace(".", "/"),
+            comp_obj.output_path,
+        )
+        _ensure_dir(target_compile_path)
+
+        # Note: kapitan already parallelises at the *target* level via
+        # ``multiprocessing.Pool`` in ``compile_targets``. Adding a nested
+        # ThreadPool here would over-subscribe CPU and require auditing every
+        # ``InputType`` subclass for thread-safety (kadet/jinja2/jsonnet hold
+        # mutable globals). We rely on per-target parallelism for scaling.
         for input_path in comp_obj.input_paths:
-            globbed_paths = [
-                glob.glob(os.path.join(path, input_path)) for path in self.search_paths
-            ]
-            expanded_paths = set(itertools.chain.from_iterable(globbed_paths))
+            # Fast path: when ``input_path`` contains no glob metacharacters
+            # (the common case for plain file references) skip ``glob.glob``
+            # entirely — a single ``os.path.lexists`` per search path is much
+            # cheaper than building glob iterators.
+            if glob.has_magic(input_path):
+                expanded_paths: set[str] = set()
+                for search_path in self.search_paths:
+                    expanded_paths.update(
+                        glob.glob(os.path.join(search_path, input_path))
+                    )
+            else:
+                expanded_paths = set()
+                for search_path in self.search_paths:
+                    candidate = os.path.join(search_path, input_path)
+                    if os.path.lexists(candidate):
+                        expanded_paths.add(candidate)
 
             if not expanded_paths and not comp_obj.ignore_missing:
                 raise CompileError(
@@ -89,7 +131,7 @@ class InputType:
                 )
 
             for expanded_path in expanded_paths:
-                self.compile_input_path(comp_obj, expanded_path)
+                self.compile_input_path(comp_obj, expanded_path, target_compile_path)
 
     def to_file(self, config: CompileInputTypeConfig, file_path, file_content):
         """Write compiled content to file, handling different output types and revealing refs if needed.
@@ -166,38 +208,42 @@ class InputType:
                     f"Output type defined in inventory for {config} not supported: {output_type}: {OutputType}"
                 )
 
-    def compile_input_path(self, comp_obj: CompileInputTypeConfig, input_path: str):
+    def compile_input_path(
+        self,
+        comp_obj: CompileInputTypeConfig,
+        input_path: str,
+        target_compile_path: str | None = None,
+    ):
         """Compile a single input path and write the result to the output directory.
-
-        Creates the output directory if it doesn't exist.
 
         Args:
             comp_obj: CompileInputTypeConfig object.
             input_path: Path to the input file.
+            target_compile_path: Pre-computed output directory. When called
+                from `compile_obj` this is supplied (and the directory
+                already ensured), avoiding redundant ``os.path.join`` and
+                ``os.makedirs`` calls per file. When called directly (e.g.
+                from tests or external callers), it is derived on demand
+                here for backwards compatibility.
+
         Raises:
             CompileError: If compilation fails.
-
         """
-        target_name = self.target_name
-        output_path = comp_obj.output_path
-
         logger.debug("Compiling %s", input_path)
 
-        try:
+        if target_compile_path is None:
             target_compile_path = os.path.join(
-                self.compile_path, target_name.replace(".", "/"), output_path
+                self.compile_path,
+                self.target_name.replace(".", "/"),
+                comp_obj.output_path,
             )
-            os.makedirs(target_compile_path, exist_ok=True)
+            _ensure_dir(target_compile_path)
 
-            self.compile_file(
-                comp_obj,
-                input_path,
-                target_compile_path,
-            )
-
+        try:
+            self.compile_file(comp_obj, input_path, target_compile_path)
         except KapitanError as e:
             raise CompileError(
-                f"{e}\nCompile error: failed to compile target: {target_name}"
+                f"{e}\nCompile error: failed to compile target: {self.target_name}"
             ) from e
 
     @abc.abstractmethod
@@ -265,51 +311,61 @@ class CompilingFile:
         Args:
             obj: Object to write.
 
-        Uses PrettyDumper to handle multiline strings according to style selection.
+        Uses either rapidyaml (when ``--yaml-use-rapidyaml`` is enabled and
+        the package is available) or PyYAML's ``PrettyDumper``. The
+        rapidyaml path produces byte-identical output for the common
+        Kubernetes-manifest case and is several times faster on large
+        manifests; see :mod:`kapitan.yaml_ryml` for details.
         """
-        indent = self.kwargs.get("indent", 2)
-        reveal = self.kwargs.get("reveal", False)
-        target_name = self.kwargs.get("target_name", None)
+        kwargs = self.kwargs
+        reveal = kwargs.get("reveal", False)
+        target_name = kwargs.get("target_name", None)
 
-        # TODO(ademaria): make it configurable per input type
+        # TODO(ademaria): make this configurable per input type.
         style_selection = cached.inv[target_name]["parameters"].get(
             "multiline_string_style", None
         )
-
         if not style_selection:
-            if hasattr(cached.args, "multiline_string_style"):
-                style_selection = cached.args.multiline_string_style
-            elif hasattr(cached.args, "yaml_multiline_string_style"):
-                style_selection = cached.args.yaml_multiline_string_style
-
-        dumper = PrettyDumper.get_dumper_for_style(style_selection)
+            style_selection = getattr(
+                cached.args,
+                "multiline_string_style",
+                getattr(cached.args, "yaml_multiline_string_style", None),
+            )
 
         if reveal:
             obj = self.revealer.reveal_obj(obj)
         else:
             obj = self.revealer.compile_obj(obj, target_name=target_name)
 
-        if obj:
-            if isinstance(obj, Mapping):
-                yaml.dump(
-                    obj,
-                    stream=self.fp,
-                    indent=indent,
-                    Dumper=dumper,
-                    default_flow_style=False,
-                )
-            else:
-                yaml.dump_all(
-                    obj,
-                    stream=self.fp,
-                    indent=indent,
-                    Dumper=dumper,
-                    default_flow_style=False,
-                )
-
-            logger.debug("Wrote %s", self.fp.name)
-        else:
+        if not obj:
             logger.debug("%s is Empty, skipped writing output", self.fp.name)
+            return
+
+        use_ryml = HAS_RYML and getattr(cached.args, "yaml_use_rapidyaml", False)
+
+        if use_ryml:
+            # ryml is a string-tree emitter and does its own indent / flow
+            # decisions; ``indent`` from PyYAML is not applicable.
+            ryml_dump(
+                obj,
+                self.fp,
+                multiline_style=style_selection,
+                dump_null_as_empty=getattr(
+                    cached.args, "yaml_dump_null_as_empty", False
+                ),
+                multi_doc=not isinstance(obj, Mapping),
+            )
+        else:
+            dumper = PrettyDumper.get_dumper_for_style(style_selection)
+            dump = yaml.dump if isinstance(obj, Mapping) else yaml.dump_all
+            dump(
+                obj,
+                stream=self.fp,
+                indent=kwargs.get("indent", 2),
+                Dumper=dumper,
+                default_flow_style=False,
+            )
+        logger.debug("Wrote %s", self.fp.name)
 
     def write_json(self, obj: object):
         """Recursively compile or reveal refs and convert obj to JSON and write to file.
@@ -328,7 +384,10 @@ class CompilingFile:
             obj = self.revealer.compile_obj(obj, target_name=target_name)
 
         if obj:
-            json.dump(obj, self.fp, indent=indent)
+            # ``sort_keys=True`` matches PyYAML's default sorting behaviour
+            # for ``write_yaml`` so JSON output is deterministic regardless
+            # of Python dict insertion order.
+            json.dump(obj, self.fp, indent=indent, sort_keys=True)
             logger.debug("Wrote %s", self.fp.name)
         else:
             logger.debug("%s is Empty, skipped writing output", self.fp.name)

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -6,7 +6,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import collections
-import functools
 import glob
 import json
 import logging
@@ -108,6 +107,9 @@ def prune_empty(d):
             }
 
 
+_SUPPORTED_MULTILINE_STYLES = {"literal": "|", "folded": ">", "double-quotes": '"'}
+
+
 class PrettyDumper(yaml.SafeDumper):
     """
     Increases indent of nested lists.
@@ -118,13 +120,46 @@ class PrettyDumper(yaml.SafeDumper):
     def increase_indent(self, flow=False, indentless=False):
         return super(PrettyDumper, self).increase_indent(flow, False)
 
+    # Cache of dumper subclasses keyed by ``style_selection`` so we don't pay
+    # the ``add_representer`` / ``functools.partial`` cost on every
+    # ``write_yaml`` call. Each subclass keeps its own ``yaml_representers``
+    # dict thanks to ``add_representer``'s copy-on-write semantics, so
+    # different styles no longer clobber each other globally.
+    _style_dumper_cache: dict = {}
+
     @classmethod
     def get_dumper_for_style(cls, style_selection="double-quotes"):
-        cls.add_representer(
-            str,
-            functools.partial(multiline_str_presenter, style_selection=style_selection),
+        cached_dumper = cls._style_dumper_cache.get(style_selection)
+        if cached_dumper is not None:
+            return cached_dumper
+
+        style_char = _SUPPORTED_MULTILINE_STYLES.get(style_selection)
+
+        # Build the str presenter with the style bound at definition time.
+        # This avoids the per-call ``functools.partial`` allocation and the
+        # ``dict.get`` lookup that the previous implementation did inside
+        # ``multiline_str_presenter`` for every string node.
+        if style_char is None:
+
+            def _str_presenter(dumper, data):
+                return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+        else:
+
+            def _str_presenter(dumper, data, _style=style_char):
+                if "\n" in data:
+                    return dumper.represent_scalar(
+                        "tag:yaml.org,2002:str", data, style=_style
+                    )
+                return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+        dumper_cls = type(
+            f"PrettyDumper_{style_selection or 'default'}",
+            (cls,),
+            {},
         )
-        return cls
+        dumper_cls.add_representer(str, _str_presenter)
+        cls._style_dumper_cache[style_selection] = dumper_cls
+        return dumper_cls
 
 
 def multiline_str_presenter(dumper, data, style_selection="double-quotes"):
@@ -132,24 +167,20 @@ def multiline_str_presenter(dumper, data, style_selection="double-quotes"):
     Configures yaml for dumping multiline strings with given style.
     By default, strings are getting dumped with style='"'.
     Ref: https://github.com/yaml/pyyaml/issues/240#issuecomment-1018712495
+
+    Kept for backwards-compatibility; ``PrettyDumper.get_dumper_for_style``
+    no longer uses it directly because it now binds the style at
+    representer-creation time and caches the resulting dumper class.
     """
-
-    supported_styles = {"literal": "|", "folded": ">", "double-quotes": '"'}
-
-    style = supported_styles.get(style_selection)
-
-    if data.count("\n") > 0:  # check for multiline string
+    style = _SUPPORTED_MULTILINE_STYLES.get(style_selection)
+    if "\n" in data:
         return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
     return dumper.represent_scalar("tag:yaml.org,2002:str", data)
 
 
 def null_presenter(dumper, data):
     """Configures yaml for omitting value from null-datatype"""
-    # get parsed args from cached.py
-    flag_value = False
-    if hasattr(cached.args, "yaml_dump_null_as_empty"):
-        flag_value = cached.args.yaml_dump_null_as_empty
-
+    flag_value = getattr(cached.args, "yaml_dump_null_as_empty", False)
     if flag_value:
         return dumper.represent_scalar("tag:yaml.org,2002:null", "")
     return dumper.represent_scalar("tag:yaml.org,2002:null", "null")

--- a/kapitan/yaml_ryml.py
+++ b/kapitan/yaml_ryml.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Kapitan Authors
+# SPDX-FileCopyrightText: 2026 The Kapitan Authors <kapitan-admins@googlegroups.com>
+# SPDX-License-Identifier: Apache-2.0
+"""
+High-performance YAML emitter backed by rapidyaml.
+
+This module is an opt-in drop-in replacement for the PyYAML emitter used by
+``kapitan.inputs.base.CompilingFile.write_yaml``. It is invoked when the user
+passes ``--yaml-use-rapidyaml`` (or sets ``cached.args.yaml_use_rapidyaml``).
+
+rapidyaml is a C++ YAML parser/emitter with a Python wrapper. Its emitter is
+noticeably faster than both pure-Python PyYAML and the C ``libyaml`` backend,
+because it works directly on a contiguous tree buffer instead of streaming
+through a series of Python representer/emitter callbacks.
+
+For Kubernetes-style manifests it produces output that matches Kapitan's
+existing ``PrettyDumper`` byte-for-byte in the common case:
+
+  * block sequences are indented (``a:\\n  - item``), matching ``PrettyDumper``;
+  * multiline strings honor ``--yaml-multiline-string-style``
+    (``literal`` / ``folded`` / ``double-quotes``);
+  * ``None`` is emitted as ``null`` (or ``""`` with ``--yaml-dump-null-as-empty``);
+  * sequence-at-top objects are emitted as multi-doc YAML, matching
+    PyYAML's ``yaml.dump_all`` behaviour.
+
+rapidyaml's emitter does not auto-quote string scalars that would be
+mis-parsed as another scalar type (e.g. ``"true"`` or ``"123"`` would
+round-trip as a bool / int). PyYAML's emitter does, via its
+``Resolver.yaml_implicit_resolvers`` regex table.
+
+We reuse that very table to detect ambiguous strings and force them to
+single-quoted style, which guarantees round-trip fidelity with any
+spec-compliant YAML parser.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+try:
+    import ryml  # type: ignore[import-not-found]
+
+    HAS_RYML = True
+except ImportError:  # pragma: no cover - the optional dep is missing
+    ryml = None  # type: ignore[assignment]
+    HAS_RYML = False
+
+from yaml.resolver import Resolver as _PyYAMLResolver
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous-string detection (reuses PyYAML's authoritative resolver table).
+# ---------------------------------------------------------------------------
+#
+# ``_RESOLVERS_BY_CHAR`` maps a scalar's first character to the list of
+# (tag, compiled-regex) pairs that PyYAML would use to *implicitly* resolve a
+# plain scalar to a non-string type. We exclude the str-tag entries (they are
+# the fallback). If any regex matches, the string would be re-parsed as the
+# corresponding type and therefore needs explicit quoting in the YAML output.
+_RESOLVERS_BY_CHAR: dict[str, list[tuple[str, Any]]] = {}
+for _ch, _entries in _PyYAMLResolver.yaml_implicit_resolvers.items():
+    if not _ch:
+        # The empty-key entry is the catch-all for empty scalars; we handle
+        # empty strings separately (ryml already quotes them correctly).
+        continue
+    _non_str = [
+        (tag, regex) for tag, regex in _entries if tag != "tag:yaml.org,2002:str"
+    ]
+    if _non_str:
+        _RESOLVERS_BY_CHAR[_ch] = _non_str
+
+
+def _str_is_ambiguous(s: str) -> bool:
+    """Return True if plain emission of ``s`` would round-trip as a non-string.
+
+    Equivalent to PyYAML's ``Resolver.resolve`` returning a non-``str`` tag
+    for ``s`` in plain style, but ~10x faster because it short-circuits on
+    the first character and avoids the loader's full implicit-resolution
+    machinery.
+    """
+    if not s:
+        return False  # ryml emits "" for empty strings — that's fine.
+    entries = _RESOLVERS_BY_CHAR.get(s[0])
+    if entries is None:
+        return False
+    return any(regex.match(s) for _tag, regex in entries)
+
+
+# ---------------------------------------------------------------------------
+# Multiline style mapping. We mirror the choices accepted by
+# ``--yaml-multiline-string-style``.
+# ---------------------------------------------------------------------------
+def _multiline_flag(style: str | None) -> int:
+    """Return the ryml VAL_* style flag for a multiline string."""
+    if ryml is None:
+        return 0
+    if style == "folded":
+        return ryml.VAL_FOLDED
+    if style == "double-quotes":
+        return ryml.VAL_DQUO
+    # "literal" is both the kapitan default and the safest choice (it
+    # preserves exact bytes for things like shell scripts).
+    return ryml.VAL_LITERAL
+
+
+# ---------------------------------------------------------------------------
+# Scalar conversion: Python value -> (string, ryml style flag).
+#
+# ryml is a string-only tree: every scalar leaf is text, and the *style* flag
+# controls whether it's emitted plain, single-quoted, double-quoted, literal
+# or folded. We encode Python's types here so PyYAML-compatible round-tripping
+# is preserved.
+# ---------------------------------------------------------------------------
+def _scalar_for_ryml(
+    value: Any,
+    multiline_flag: int,
+    null_repr: str,
+) -> tuple[str, int]:
+    """Convert a Python scalar to ``(text, style_flag)`` for ryml emission."""
+    if value is None:
+        # ``null_repr`` is either "null" (default) or "" when the user passed
+        # --yaml-dump-null-as-empty. Both must be emitted *plain* so a
+        # downstream parser resolves them to a null scalar, not the string.
+        return null_repr, ryml.VAL_PLAIN  # type: ignore[union-attr]
+    if value is True:
+        return "true", ryml.VAL_PLAIN  # type: ignore[union-attr]
+    if value is False:
+        return "false", ryml.VAL_PLAIN  # type: ignore[union-attr]
+    if isinstance(value, int):
+        return str(value), ryml.VAL_PLAIN  # type: ignore[union-attr]
+    if isinstance(value, float):
+        # PyYAML uses 'repr' to preserve precision; do the same.
+        return repr(value), ryml.VAL_PLAIN  # type: ignore[union-attr]
+    if isinstance(value, bytes):
+        # Match PyYAML SafeRepresenter: emit as a binary-tagged base64 blob.
+        # Rare in kapitan output; we fall back to a safe representation.
+        import base64
+
+        return base64.b64encode(value).decode("ascii"), ryml.VAL_DQUO  # type: ignore[union-attr]
+    if isinstance(value, str):
+        if "\n" in value:
+            return value, multiline_flag
+        if _str_is_ambiguous(value):
+            # Single-quotes are the cheapest safe quoting for plain strings
+            # with no embedded special characters; ryml will pick double
+            # quotes itself if escaping is required.
+            return value, ryml.VAL_SQUO  # type: ignore[union-attr]
+        # Let ryml decide (plain unless it needs quotes for chars like leading
+        # whitespace, leading '-', embedded ': ', etc.).
+        return value, 0
+    # Fallback: stringify and force quoting so the type-tagged value at least
+    # survives as a string.
+    return str(value), ryml.VAL_SQUO  # type: ignore[union-attr]
+
+
+def _key_for_ryml(key: Any) -> tuple[str, int]:
+    """Like ``_scalar_for_ryml`` but for mapping keys (KEY_* flag variants)."""
+    if key is None:
+        return "null", ryml.KEY_PLAIN  # type: ignore[union-attr]
+    if key is True:
+        return "true", ryml.KEY_PLAIN  # type: ignore[union-attr]
+    if key is False:
+        return "false", ryml.KEY_PLAIN  # type: ignore[union-attr]
+    if isinstance(key, int):
+        return str(key), ryml.KEY_PLAIN  # type: ignore[union-attr]
+    if isinstance(key, float):
+        return repr(key), ryml.KEY_PLAIN  # type: ignore[union-attr]
+    if isinstance(key, str):
+        if _str_is_ambiguous(key) or "\n" in key:
+            return key, ryml.KEY_SQUO  # type: ignore[union-attr]
+        return key, 0
+    return str(key), ryml.KEY_SQUO  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# Arena pre-sizing.
+#
+# ``Tree.to_arena(s)`` copies ``s`` into an internal C++ buffer and returns a
+# *view* (``csubstr``) into it. The buffer grows by realloc, which means any
+# previously-returned view becomes a dangling pointer as soon as the arena
+# grows. The corrupted views then surface as garbage scalars in the emitted
+# YAML (e.g. ``"U: xxx..."`` instead of ``"k: xxx..."``) or, when the garbage
+# bytes happen to be non-printable, as massive escape-expansion that
+# overflows the emitter's output buffer with the error:
+#
+#   /project/cpp/src/c4/yml/./writer.hpp:144:
+#       ERROR: [basic] not enough space in the given buffer
+#
+# We avoid that by walking ``obj`` once up front, summing the bytes we'll need
+# in the arena, and calling ``Tree.reserve_arena(total)`` so the arena is
+# allocated exactly once and never relocates during the build.
+# ---------------------------------------------------------------------------
+# Control characters that ryml's emitter does NOT escape, even with VAL_DQUO.
+# Per the YAML 1.2 spec these characters MUST be escaped in any string scalar,
+# so emitting them raw produces output that is rejected by spec-compliant
+# parsers (including PyYAML's loader). We pre-scan ``obj`` and fall back to
+# PyYAML when any string contains one of them.
+# ASCII C0 controls minus \t (0x09), \n (0x0A), \r (0x0D); plus DEL (0x7F).
+_CONTROL_RE = None
+
+
+def _has_unescapable_controls(obj: Any) -> bool:
+    """Return True if any string anywhere in ``obj`` contains a control char
+    that ryml will refuse to escape."""
+    global _CONTROL_RE
+    if _CONTROL_RE is None:
+        import re
+
+        _CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+    stack: list = [obj]
+    while stack:
+        v = stack.pop()
+        if isinstance(v, str):
+            if _CONTROL_RE.search(v):
+                return True
+        elif isinstance(v, Mapping):
+            for k, sv in v.items():
+                if isinstance(k, str) and _CONTROL_RE.search(k):
+                    return True
+                stack.append(sv)
+        elif isinstance(v, (list | tuple)):
+            stack.extend(v)
+    return False
+
+
+def _estimate_arena(obj: Any) -> int:
+    """Return an upper bound on the arena bytes needed to encode ``obj``.
+
+    We over-estimate slightly (UTF-8 byte length per char, plus a small
+    per-node constant) because over-reservation is cheap whereas
+    under-reservation triggers a realloc and the dangling-pointer bug.
+    """
+    total = 0
+    stack: list = [obj]
+    while stack:
+        v = stack.pop()
+        if isinstance(v, Mapping):
+            for k, sv in v.items():
+                if isinstance(k, str):
+                    total += len(k.encode("utf-8")) + 2
+                else:
+                    total += 24  # bool / int / float repr
+                stack.append(sv)
+        elif isinstance(v, (list | tuple)):
+            stack.extend(v)
+        elif isinstance(v, str):
+            total += len(v.encode("utf-8")) + 2
+        elif isinstance(v, bytes):
+            # We base64-encode bytes; output is 4/3 the input rounded up.
+            total += ((len(v) + 2) // 3) * 4 + 2
+        elif v is None or isinstance(v, bool):
+            total += 8
+        else:
+            total += 32  # int / float as text
+    # 64-byte tail-padding for the rare case where a Python string is longer
+    # in bytes than the UTF-8 estimate (it shouldn't be) or for the
+    # built-in literal values ("true", "false", "null") added by
+    # ``_scalar_for_ryml``.
+    return total + 64
+
+
+# ---------------------------------------------------------------------------
+# Tree builder. We walk the Python object once, allocating ryml nodes as we go.
+# ---------------------------------------------------------------------------
+def _sorted_items(mapping: Mapping):
+    """Return ``mapping.items()`` sorted alphabetically by key.
+
+    Compiled outputs must be deterministic regardless of Python dict
+    insertion order. This matches PyYAML's default ``sort_keys=True``
+    behaviour, including its fallback to insertion order when keys have
+    mixed/incomparable types (e.g. mixing ``str`` and ``int`` keys).
+    """
+    items = list(mapping.items())
+    try:
+        items.sort(key=lambda kv: kv[0])
+    except TypeError:
+        # Mixed/incomparable key types — keep insertion order, like PyYAML.
+        pass
+    return items
+
+
+def _build(
+    tree: ryml.Tree,
+    node: int,
+    value: Any,
+    key: Any,
+    has_key: bool,
+    ml_flag: int,
+    null_repr: str,
+) -> None:
+    """Populate ``node`` with ``value``.
+
+    Args:
+        tree: The ryml tree.
+        node: The id of the (already-allocated) node to populate.
+        value: The Python value to encode.
+        key: Mapping key for this node, when applicable.
+        has_key: Whether ``key`` is meaningful (this node is a map child).
+        ml_flag: Pre-computed ``VAL_*`` flag for multiline strings.
+        null_repr: ``"null"`` or ``""`` depending on yaml_dump_null_as_empty.
+    """
+    if isinstance(value, Mapping):
+        if has_key:
+            key_text, key_flag = _key_for_ryml(key)
+            tree.to_map(node, key=tree.to_arena(key_text), more_flags=key_flag)
+        else:
+            tree.to_map(node)
+        for k, v in _sorted_items(value):
+            child = tree.append_child(node)
+            _build(tree, child, v, k, True, ml_flag, null_repr)
+        return
+
+    if isinstance(value, (list | tuple)) or (
+        isinstance(value, Sequence) and not isinstance(value, (str | bytes))
+    ):
+        if has_key:
+            key_text, key_flag = _key_for_ryml(key)
+            tree.to_seq(node, key=tree.to_arena(key_text), more_flags=key_flag)
+        else:
+            tree.to_seq(node)
+        for item in value:
+            child = tree.append_child(node)
+            _build(tree, child, item, None, False, ml_flag, null_repr)
+        return
+
+    # Scalar leaf
+    val_text, val_flag = _scalar_for_ryml(value, ml_flag, null_repr)
+    val_arena = tree.to_arena(val_text)
+    if has_key:
+        key_text, key_flag = _key_for_ryml(key)
+        tree.to_keyval(
+            node,
+            tree.to_arena(key_text),
+            val_arena,
+            more_flags=val_flag | key_flag,
+        )
+    else:
+        tree.to_val(node, val_arena, more_flags=val_flag)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point: emit ``obj`` to ``fp``.
+# ---------------------------------------------------------------------------
+def dump(
+    obj: Any,
+    fp,
+    multiline_style: str | None = "literal",
+    dump_null_as_empty: bool = False,
+    multi_doc: bool = False,
+) -> None:
+    """Emit ``obj`` as YAML to file-like ``fp`` using rapidyaml.
+
+    Args:
+        obj: Object to serialize.
+        fp: File-like object opened in text mode.
+        multiline_style: One of ``"literal"``, ``"folded"``,
+            ``"double-quotes"``. Anything else falls back to literal.
+        dump_null_as_empty: When True, ``None`` is emitted as an empty
+            scalar rather than ``null``.
+        multi_doc: When True and ``obj`` is a sequence (list/tuple), emit
+            each element as its own YAML document — matching PyYAML's
+            ``yaml.dump_all`` semantics.
+
+    Raises:
+        RuntimeError: If rapidyaml is not installed.
+    """
+    if ryml is None:
+        raise RuntimeError(
+            "rapidyaml is not installed; install with `pip install rapidyaml`"
+        )
+
+    # rapidyaml does not escape ASCII control characters even in double-quoted
+    # scalars (see comment above ``_has_unescapable_controls``). If the input
+    # contains any, emit through PyYAML to keep output spec-compliant.
+    if _has_unescapable_controls(obj):
+        import yaml as _yaml
+
+        from kapitan.utils import PrettyDumper as _PrettyDumper
+
+        logger.debug(
+            "yaml_ryml: object contains control characters; falling back to "
+            "PyYAML for this document to ensure escaping."
+        )
+        dumper = _PrettyDumper.get_dumper_for_style(multiline_style)
+        dump_fn = _yaml.dump if isinstance(obj, Mapping) else _yaml.dump_all
+        dump_fn(
+            obj,
+            stream=fp,
+            indent=2,
+            Dumper=dumper,
+            default_flow_style=False,
+        )
+        return
+
+    ml_flag = _multiline_flag(multiline_style)
+    null_repr = "" if dump_null_as_empty else "null"
+
+    tree = ryml.Tree()
+    # Reserve the arena up front so ``to_arena`` never reallocates while we
+    # build the tree (see ``_estimate_arena`` for the rationale).
+    tree.reserve_arena(_estimate_arena(obj))
+    root = tree.root_id()
+
+    if multi_doc and isinstance(obj, (list | tuple)):
+        # Multi-document stream: one DOC per top-level item.
+        tree.to_stream(root)
+        for item in obj:
+            doc = tree.append_child(root)
+            # The child of a stream is a doc-node; ``to_*`` calls below set
+            # both the container type *and* the DOC flag in one shot.
+            if isinstance(item, Mapping):
+                tree.to_map(doc, more_flags=ryml.DOC)
+                for k, v in _sorted_items(item):
+                    c = tree.append_child(doc)
+                    _build(tree, c, v, k, True, ml_flag, null_repr)
+            elif isinstance(item, (list | tuple)):
+                tree.to_seq(doc, more_flags=ryml.DOC)
+                for v in item:
+                    c = tree.append_child(doc)
+                    _build(tree, c, v, None, False, ml_flag, null_repr)
+            else:
+                val_text, val_flag = _scalar_for_ryml(item, ml_flag, null_repr)
+                tree.to_val(
+                    doc, tree.to_arena(val_text), more_flags=val_flag | ryml.DOC
+                )
+    else:
+        _build(tree, root, obj, None, False, ml_flag, null_repr)
+
+    out = _emit_tree(tree)
+    # ``_emit_tree`` returns a ``str``; write directly to text streams, or
+    # UTF-8 encode for binary streams.
+    if "b" in getattr(fp, "mode", ""):
+        fp.write(out.encode("utf-8"))
+    else:
+        fp.write(out)
+
+
+def _emit_tree(tree: ryml.Tree) -> str:
+    """Emit ``tree`` to a ``str``, sizing the output buffer correctly.
+
+    ``ryml.emit_yaml`` / ``emit_yaml_malloc`` use an internal heuristic to
+    pre-allocate the output buffer. For some trees (notably those with
+    long double-quoted strings that require heavy escaping, or deeply
+    nested structures with significant indentation overhead) the heuristic
+    underestimates and ryml raises ``ExceptionBasic`` ("not enough space
+    in the given buffer") instead of growing.
+
+    To avoid that, we compute the exact required size via
+    ``compute_yaml_length`` and emit into a correctly-sized buffer with
+    ``emit_yaml_in_place``. A small slack is added as a defensive measure
+    in case ``compute_yaml_length`` and the emitter ever disagree by a
+    byte (they shouldn't, but the cost of slack is negligible).
+
+    If anything still goes wrong we fall back to a doubling-buffer retry
+    loop, so the user gets correct output rather than a crash.
+    """
+    needed = ryml.compute_yaml_length(tree)
+    # +64 bytes of slack covers any potential off-by-one in the emitter's
+    # length computation; it's a fixed-cost rounding error vs. the size of
+    # the output, which is typically KBs to MBs.
+    buf = bytearray(needed + 64)
+    try:
+        view = ryml.emit_yaml_in_place(tree, buf)
+        return bytes(view).decode("utf-8")
+    except IndexError as first_err:
+        # ``compute_yaml_length`` disagreed with the emitter — should never
+        # happen, but if it does, grow the buffer aggressively and retry.
+        size = max(needed * 2, 65536)
+        for _ in range(6):  # at most ~64x growth
+            buf = bytearray(size)
+            try:
+                view = ryml.emit_yaml_in_place(tree, buf)
+                logger.debug(
+                    "yaml_ryml: emit succeeded after retry at buffer size %d "
+                    "(compute_yaml_length reported %d)",
+                    size,
+                    needed,
+                )
+                return bytes(view).decode("utf-8")
+            except IndexError:
+                size *= 2
+        # Re-raise the original error if every retry size failed.
+        raise first_err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,9 @@ gojsonnet = ["gojsonnet>=0.21.0,<0.22"]
 omegaconf = ["omegaconf>=2.4.0.dev3,<3"]
 reclass-rs = ["reclass-rs>=0.10.1,<0.11.0"]
 oci = ["oras>=0.2.0"]
+# Enables the rapidyaml (ryml) C++ YAML emitter via --yaml-use-rapidyaml.
+# Several times faster than PyYAML on large manifests; safe to omit.
+rapidyaml = ["rapidyaml>=0.12,<1"]
 
 [project.urls]
 Homepage = "https://kapitan.dev"

--- a/tests/test_yaml_use_rapidyaml.py
+++ b/tests/test_yaml_use_rapidyaml.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# Copyright 2024 The Kapitan Authors
+# SPDX-FileCopyrightText: 2024 The Kapitan Authors <kapitan-admins@googlegroups.com>
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the --yaml-use-rapidyaml fast emit path.
+
+These tests cover:
+
+  * the standalone ``kapitan.yaml_ryml.dump`` API (round-trip, key sorting,
+    ambiguous-string quoting, multiline styles, control-char fallback),
+  * the integration with ``CompilingFile.write_yaml`` (PyYAML vs ryml
+    output dispatch via ``cached.args.yaml_use_rapidyaml``),
+  * the one-time startup warning emitted from ``trigger_compile`` when the
+    flag is set but the ``rapidyaml`` package is not installed.
+"""
+
+import io
+import logging
+from argparse import Namespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from kapitan import cached
+
+
+# rapidyaml is an optional dependency; skip the whole module if it's missing
+# rather than testing a no-op fallback (which is covered separately by
+# ``test_warning_logged_when_rapidyaml_missing`` via monkeypatch).
+ryml_pkg = pytest.importorskip("ryml")
+from kapitan import yaml_ryml  # noqa: E402  (import after importorskip)
+
+
+# ---------------------------------------------------------------------------
+# Standalone emitter tests
+# ---------------------------------------------------------------------------
+class TestRymlDump:
+    """Direct tests against ``kapitan.yaml_ryml.dump``."""
+
+    def test_basic_roundtrip(self):
+        """Every supported scalar type round-trips to an equal Python object."""
+        obj = {
+            "string": "hello",
+            "int": 42,
+            "float": 3.14,
+            "true": True,
+            "false": False,
+            "none": None,
+            "list": [1, "two", 3.0, None],
+            "nested": {"a": {"b": "c"}},
+        }
+        buf = io.StringIO()
+        yaml_ryml.dump(obj, buf)
+        assert yaml.safe_load(buf.getvalue()) == obj
+
+    @pytest.mark.parametrize(
+        "ambiguous_string",
+        ["true", "false", "yes", "no", "Yes", "null", "123", "-1", ".5", "1e10"],
+    )
+    def test_ambiguous_strings_are_quoted(self, ambiguous_string):
+        """Strings that would round-trip as another type must be quoted."""
+        obj = {"key": ambiguous_string}
+        buf = io.StringIO()
+        yaml_ryml.dump(obj, buf)
+        loaded = yaml.safe_load(buf.getvalue())
+        assert loaded == obj
+        assert isinstance(loaded["key"], str), (
+            f"{ambiguous_string!r} was re-parsed as {type(loaded['key']).__name__}: "
+            f"{buf.getvalue()!r}"
+        )
+
+    def test_keys_are_sorted_alphabetically(self):
+        """Mapping keys are emitted in sorted order for deterministic output."""
+        buf = io.StringIO()
+        yaml_ryml.dump({"zebra": 1, "apple": 2, "mango": 3}, buf)
+        lines = [l for l in buf.getvalue().splitlines() if l.strip()]
+        assert lines == ["apple: 2", "mango: 3", "zebra: 1"]
+
+    def test_determinism_across_shuffled_insertion_orders(self):
+        """Same content, different dict insertion orders => identical bytes."""
+        import random
+
+        canonical = {
+            "zoo": 0, "apple": 1, "banana": 2, "mango": 3,
+            "cherry": 4, "date": 5,
+        }
+        keys = list(canonical)
+        outputs = set()
+        for _ in range(20):
+            random.shuffle(keys)
+            shuffled = {k: canonical[k] for k in keys}
+            buf = io.StringIO()
+            yaml_ryml.dump(shuffled, buf)
+            outputs.add(buf.getvalue())
+        assert len(outputs) == 1
+
+    def test_mixed_type_keys_fall_back_to_insertion_order(self):
+        """Incomparable mixed-type keys must not crash (matches PyYAML)."""
+        buf = io.StringIO()
+        # str < int comparison raises TypeError; we must keep insertion order.
+        yaml_ryml.dump({"a": 1, 2: "b", "c": 3}, buf)
+        # No assertion on order, just that emission succeeded and round-trips.
+        assert yaml.safe_load(buf.getvalue()) == {"a": 1, 2: "b", "c": 3}
+
+    @pytest.mark.parametrize("style", ["literal", "folded", "double-quotes"])
+    def test_multiline_string_styles(self, style):
+        """Each supported multiline style produces parser-equivalent output."""
+        obj = {"m": "line1\nline2\nline3"}
+        buf = io.StringIO()
+        yaml_ryml.dump(obj, buf, multiline_style=style)
+        out = buf.getvalue()
+        assert yaml.safe_load(out) == obj
+        # Sanity: the emitted block should reflect the chosen indicator.
+        indicators = {"literal": "|", "folded": ">", "double-quotes": '"'}
+        assert indicators[style] in out
+
+    def test_dump_null_as_empty(self):
+        obj = {"x": None, "y": 1}
+        buf = io.StringIO()
+        yaml_ryml.dump(obj, buf, dump_null_as_empty=True)
+        assert buf.getvalue() == "x: \ny: 1\n"
+        assert yaml.safe_load(buf.getvalue()) == obj
+
+    def test_multi_doc_emission(self):
+        """A top-level list with ``multi_doc=True`` emits one YAML doc per item."""
+        items = [{"a": 1}, {"b": 2}, "scalar"]
+        buf = io.StringIO()
+        yaml_ryml.dump(items, buf, multi_doc=True)
+        assert list(yaml.safe_load_all(buf.getvalue())) == items
+
+    def test_large_string_does_not_crash(self):
+        """Arena pre-sizing prevents the dangling-pointer / buffer-overrun bug."""
+        # Without ``reserve_arena`` this would either segfault, corrupt the
+        # key (producing 'U: xxx...' instead of 'k: xxx...'), or trigger
+        # ryml's "not enough space in the given buffer" error.
+        obj = {"k": "x" * 200_000}
+        buf = io.StringIO()
+        yaml_ryml.dump(obj, buf)
+        assert yaml.safe_load(buf.getvalue()) == obj
+
+    def test_control_characters_fall_back_to_pyyaml(self):
+        """ryml does not escape control chars; we transparently use PyYAML."""
+        obj = {"binary": "a\x01b\x02c"}
+        buf = io.StringIO()
+        yaml_ryml.dump(obj, buf)
+        # PyYAML's loader rejects raw control chars; if the fallback engaged,
+        # the output must round-trip cleanly.
+        assert yaml.safe_load(buf.getvalue()) == obj
+
+
+# ---------------------------------------------------------------------------
+# Integration with CompilingFile.write_yaml
+# ---------------------------------------------------------------------------
+class TestWriteYamlDispatch:
+    """``write_yaml`` should switch between PyYAML and ryml based on the flag."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_cached(self):
+        # Save & restore module-level state so tests don't leak into each other
+        # or into the rest of the suite.
+        prev_args = cached.args
+        prev_inv = cached.inv
+        cached.inv = {"t": {"parameters": {}}}
+        yield
+        cached.args = prev_args
+        cached.inv = prev_inv
+
+    def _make_compiling_file(self, buf):
+        from kapitan.inputs.base import CompilingFile
+
+        buf.name = "<test>"
+        ref_controller = MagicMock()
+        # The revealer is built from ref_controller; make compile_obj a no-op
+        # so we are isolated to YAML emission behaviour.
+        with patch("kapitan.inputs.base.Revealer") as Revealer:
+            revealer = Revealer.return_value
+            revealer.compile_obj.side_effect = lambda o, **kw: o
+            revealer.reveal_obj.side_effect = lambda o: o
+            return CompilingFile(buf, ref_controller, target_name="t", indent=2)
+
+    def test_default_uses_pyyaml(self):
+        cached.args = Namespace()
+        buf = io.StringIO()
+        self._make_compiling_file(buf).write_yaml({"b": 1, "a": 2})
+        # PyYAML's PrettyDumper indents nested sequences; ryml is irrelevant
+        # here, but the marker we check is just that the output is valid and
+        # keys are sorted.
+        assert buf.getvalue() == "a: 2\nb: 1\n"
+
+    def test_flag_routes_to_ryml(self):
+        """When ``yaml_use_rapidyaml`` is set, ryml_dump is invoked."""
+        cached.args = Namespace(yaml_use_rapidyaml=True)
+        with patch("kapitan.inputs.base.ryml_dump") as ryml_dump:
+            buf = io.StringIO()
+            self._make_compiling_file(buf).write_yaml({"a": 1})
+            assert ryml_dump.called, "ryml_dump was not invoked despite the flag"
+            # Sanity-check the keyword args we expose.
+            _, kwargs = ryml_dump.call_args
+            assert kwargs["multi_doc"] is False
+            assert "multiline_style" in kwargs
+            assert "dump_null_as_empty" in kwargs
+
+    def test_flag_off_keeps_pyyaml(self):
+        cached.args = Namespace(yaml_use_rapidyaml=False)
+        with patch("kapitan.inputs.base.ryml_dump") as ryml_dump:
+            buf = io.StringIO()
+            self._make_compiling_file(buf).write_yaml({"a": 1})
+            assert not ryml_dump.called
+
+    def test_pyyaml_and_ryml_paths_are_semantically_equivalent(self):
+        """Both code paths must produce YAML that round-trips to the same dict."""
+        sample = {
+            "spec": {
+                "replicas": 3,
+                "containers": [{"name": "c1", "image": "nginx:1.21"}],
+                "labels": {"env": "prod", "app": "x"},
+            },
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+        }
+
+        cached.args = Namespace()
+        buf_py = io.StringIO()
+        self._make_compiling_file(buf_py).write_yaml(sample)
+
+        cached.args = Namespace(yaml_use_rapidyaml=True)
+        buf_ryml = io.StringIO()
+        self._make_compiling_file(buf_ryml).write_yaml(sample)
+
+        assert yaml.safe_load(buf_py.getvalue()) == sample
+        assert yaml.safe_load(buf_ryml.getvalue()) == sample
+
+
+# ---------------------------------------------------------------------------
+# CLI startup warning
+# ---------------------------------------------------------------------------
+class TestStartupWarning:
+    """``trigger_compile`` warns once at startup when the flag is unusable."""
+
+    def _run_trigger(self, args):
+        from kapitan import cli
+
+        with patch("kapitan.cli.check_version"), \
+             patch("kapitan.cli.compile_targets"), \
+             patch("kapitan.cli.RefController", return_value=MagicMock()), \
+             patch("kapitan.cli.Revealer", return_value=MagicMock()):
+            cli.trigger_compile(args)
+
+    def _base_args(self, **overrides):
+        # ``trigger_compile`` wraps ``compile_targets(inventory_path=args.inventory_path, ...)``
+        # in a bare ``except`` that calls ``sys.exit(1)`` on *any* error. We
+        # therefore have to populate every attribute that ``trigger_compile``
+        # touches before reaching the mocked ``compile_targets``.
+        ns = Namespace(
+            ignore_version_check=True,
+            search_paths=["."],
+            refs_path="/tmp/r",
+            embed_refs=False,
+            inventory_path="./inventory",
+            yaml_use_rapidyaml=False,
+        )
+        for k, v in overrides.items():
+            setattr(ns, k, v)
+        return ns
+
+    def test_no_warning_when_flag_off(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="kapitan.cli"):
+            self._run_trigger(self._base_args(yaml_use_rapidyaml=False))
+        assert not any("rapidyaml" in r.message for r in caplog.records)
+
+    def test_no_warning_when_flag_on_and_installed(self, caplog):
+        with patch.object(yaml_ryml, "HAS_RYML", True), \
+             caplog.at_level(logging.WARNING, logger="kapitan.cli"):
+            self._run_trigger(self._base_args(yaml_use_rapidyaml=True))
+        assert not any("rapidyaml" in r.message for r in caplog.records)
+
+    def test_warning_logged_when_rapidyaml_missing(self, caplog):
+        """Flag on + package missing => one-time WARNING at startup."""
+        with patch.object(yaml_ryml, "HAS_RYML", False), \
+             caplog.at_level(logging.WARNING, logger="kapitan.cli"):
+            self._run_trigger(self._base_args(yaml_use_rapidyaml=True))
+
+        matching = [r for r in caplog.records if "rapidyaml" in r.message]
+        assert len(matching) == 1, f"expected exactly one warning, got {matching!r}"
+        assert matching[0].levelno == logging.WARNING
+        # The message should tell the user how to fix it.
+        assert "pip install" in matching[0].message

--- a/tests/test_yaml_use_rapidyaml.py
+++ b/tests/test_yaml_use_rapidyaml.py
@@ -74,7 +74,7 @@ class TestRymlDump:
         """Mapping keys are emitted in sorted order for deterministic output."""
         buf = io.StringIO()
         yaml_ryml.dump({"zebra": 1, "apple": 2, "mango": 3}, buf)
-        lines = [l for l in buf.getvalue().splitlines() if l.strip()]
+        lines = [line for line in buf.getvalue().splitlines() if line.strip()]
         assert lines == ["apple: 2", "mango: 3", "zebra: 1"]
 
     def test_determinism_across_shuffled_insertion_orders(self):
@@ -82,8 +82,12 @@ class TestRymlDump:
         import random
 
         canonical = {
-            "zoo": 0, "apple": 1, "banana": 2, "mango": 3,
-            "cherry": 4, "date": 5,
+            "zoo": 0,
+            "apple": 1,
+            "banana": 2,
+            "mango": 3,
+            "cherry": 4,
+            "date": 5,
         }
         keys = list(canonical)
         outputs = set()
@@ -241,10 +245,12 @@ class TestStartupWarning:
     def _run_trigger(self, args):
         from kapitan import cli
 
-        with patch("kapitan.cli.check_version"), \
-             patch("kapitan.cli.compile_targets"), \
-             patch("kapitan.cli.RefController", return_value=MagicMock()), \
-             patch("kapitan.cli.Revealer", return_value=MagicMock()):
+        with (
+            patch("kapitan.cli.check_version"),
+            patch("kapitan.cli.compile_targets"),
+            patch("kapitan.cli.RefController", return_value=MagicMock()),
+            patch("kapitan.cli.Revealer", return_value=MagicMock()),
+        ):
             cli.trigger_compile(args)
 
     def _base_args(self, **overrides):
@@ -270,15 +276,19 @@ class TestStartupWarning:
         assert not any("rapidyaml" in r.message for r in caplog.records)
 
     def test_no_warning_when_flag_on_and_installed(self, caplog):
-        with patch.object(yaml_ryml, "HAS_RYML", True), \
-             caplog.at_level(logging.WARNING, logger="kapitan.cli"):
+        with (
+            patch.object(yaml_ryml, "HAS_RYML", True),
+            caplog.at_level(logging.WARNING, logger="kapitan.cli"),
+        ):
             self._run_trigger(self._base_args(yaml_use_rapidyaml=True))
         assert not any("rapidyaml" in r.message for r in caplog.records)
 
     def test_warning_logged_when_rapidyaml_missing(self, caplog):
         """Flag on + package missing => one-time WARNING at startup."""
-        with patch.object(yaml_ryml, "HAS_RYML", False), \
-             caplog.at_level(logging.WARNING, logger="kapitan.cli"):
+        with (
+            patch.object(yaml_ryml, "HAS_RYML", False),
+            caplog.at_level(logging.WARNING, logger="kapitan.cli"),
+        ):
             self._run_trigger(self._base_args(yaml_use_rapidyaml=True))
 
         matching = [r for r in caplog.records if "rapidyaml" in r.message]

--- a/uv.lock
+++ b/uv.lock
@@ -546,6 +546,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1024,6 +1036,9 @@ oci = [
 omegaconf = [
     { name = "omegaconf" },
 ]
+rapidyaml = [
+    { name = "rapidyaml" },
+]
 reclass-rs = [
     { name = "reclass-rs" },
 ]
@@ -1088,6 +1103,7 @@ requires-dist = [
     { name = "python-box", specifier = ">=7.2.0,<8" },
     { name = "python-gnupg", specifier = ">=0.4.7,<0.6.0" },
     { name = "pyyaml", specifier = "~=6.0" },
+    { name = "rapidyaml", marker = "extra == 'rapidyaml'", specifier = ">=0.12,<1" },
     { name = "reclass-rs", marker = "extra == 'reclass-rs'", specifier = ">=0.10.1,<0.11.0" },
     { name = "regex", specifier = ">=2024.5.10,<2025" },
     { name = "requests", specifier = ">=2.28.2,<3" },
@@ -1096,7 +1112,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.0.0,<5" },
     { name = "yamllint", specifier = ">=1.29.0,<2" },
 ]
-provides-extras = ["gojsonnet", "oci", "omegaconf", "reclass-rs"]
+provides-extras = ["gojsonnet", "oci", "omegaconf", "rapidyaml", "reclass-rs"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -2070,6 +2086,62 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
+]
+
+[[package]]
+name = "rapidyaml"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecation" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/a2/b733d539de5c6e78c767671dba148b3c33b0d1dcdda4af2c14feed0c41ec/rapidyaml-0.12.1.tar.gz", hash = "sha256:53ea4f2277d0b35f0409f0939a95424af6a0b48e003a20ece8b6ae74f5c7f0d0", size = 483550, upload-time = "2026-05-07T19:44:12.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/52/fe19d491109d15cfa1382795f50a69ea87e34e587d34a2245ea4208a8e32/rapidyaml-0.12.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8bb84000ee520e367321238af6b75abd9b479ab9494aa3ce4e187b5747041142", size = 3899877, upload-time = "2026-05-07T19:42:53.747Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/71/02fd76be07c35726903b7137d5bd63c0834107b160e7e0fa228d3ce77f71/rapidyaml-0.12.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c6ecc5bebb0e0d420adac453fe61bab42282f635e36451e5289102675ab3eb06", size = 3926138, upload-time = "2026-05-07T19:42:55.42Z" },
+    { url = "https://files.pythonhosted.org/packages/93/83/00c103275dcba5f878200cbc5568e572381c7fcd883055526d295d8e66bc/rapidyaml-0.12.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:53e52ac10b0edd640e9b363e0cdd15c45c0a66cd9d75fcc0c4a8207d9428316e", size = 3899878, upload-time = "2026-05-07T19:42:57.047Z" },
+    { url = "https://files.pythonhosted.org/packages/67/37/85ab15cfdca2861de4a4bcf35e71f791b9978c6b9283acfbed21b0d00ad6/rapidyaml-0.12.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e25039929b3108e73e9543361522bdad5a3eb4b7d9810206ace9de4f84440979", size = 293779, upload-time = "2026-05-07T19:42:58.488Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3a/61f3d4db6bd614bea733c7f17b3046a6c1c5097d491e9e6e556a24ce6d11/rapidyaml-0.12.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f72f7e10de6e4467eadb478608c674884c697fd53dd948a38eb5e03dcf3c4a67", size = 272238, upload-time = "2026-05-07T19:42:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/96/3cb694c83a25d9cb142b55f4c3c635df8dbfe34b2c86744422909924577c/rapidyaml-0.12.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61f47959a6945e9cf3cfdcce778aec400054d8a97c1fb6b33a3feb8822ce99e7", size = 282303, upload-time = "2026-05-07T19:43:00.846Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/93/326736b74cb6ba6de7e9a84c2dae4d95c39e32456f79da08c40d3198c568/rapidyaml-0.12.1-cp310-cp310-win32.whl", hash = "sha256:8b3a130da26daf3561609828cb4988127ed660bfb6a541d127d179398917738f", size = 262625, upload-time = "2026-05-07T19:43:01.93Z" },
+    { url = "https://files.pythonhosted.org/packages/17/13/17eb80131e4ff1d19dcff967d8e42ec6d4e0806a29bf7ead470490f445e9/rapidyaml-0.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:2d193d6f0f3a181a91bf21050691c51766d812521130d9880c8da9e66e2a9a42", size = 314936, upload-time = "2026-05-07T19:43:03.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/28/a30804f11a1812a3b1ea9b1e926bde1936d2a3bef937b1a274c9e955a4d6/rapidyaml-0.12.1-cp310-cp310-win_arm64.whl", hash = "sha256:9acd62d3f304d5eab0f75c85994c242010ba3802754e39c2245db24ce06ae1cd", size = 311922, upload-time = "2026-05-07T19:43:04.385Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b5/9338a610dd4c52a1ca3123b202d2c759cfd30886e9519f958ad78b07de16/rapidyaml-0.12.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:86945ebba26bd28320d348b5dc337c48ecd012cd4bed0f9a0e8c5f1fbef0588a", size = 4898868, upload-time = "2026-05-07T19:43:05.974Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/43/4a23ca36a787a5e60972a47441b532f7286271484d724c57de8833edb7fe/rapidyaml-0.12.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6cd76ddc549056e855d17b5523e7bd7c325f167a4d8896f11862d9eb7dcf19da", size = 4925126, upload-time = "2026-05-07T19:43:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ea/853e95e28dff556f2ce2e881a175c42c44c69909589e2499b48a5d1896c7/rapidyaml-0.12.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc7e0ada12e825c6c4a90e1c48bb91a425e81b6e2dc39ae2a5b3a6b43e8ab173", size = 4898866, upload-time = "2026-05-07T19:43:09.079Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/e2/97a7860703b285f3e6f548056aaf6c2a3362d84fc181dbd2590354b4c9b4/rapidyaml-0.12.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6d479ecd6fafcda57c054c89dabd73ca0ed33ed07fe7256f97f6c54c278bd560", size = 293779, upload-time = "2026-05-07T19:43:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/94/964f05c7c0af4100ba001ea316906be0d5a329b52b1a26f37c374cdaefc4/rapidyaml-0.12.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c71fa65ea01df07eb191904e7e60fac019beb1b523ef416221f529face08cb8", size = 272234, upload-time = "2026-05-07T19:43:12.103Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/0b/69237b25d89b9677f00a70b5f6a121ae0d68280da8bcd51a1fec6c4e0f40/rapidyaml-0.12.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f16f7edda8d1763c273dd62f21d70fb14fe2e8e758127195c212b9101cd05043", size = 282320, upload-time = "2026-05-07T19:43:13.499Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/bb/e392ccf93c8bd2b635cfa43ad07344d1f5d3e6d2f27f2d9d3fcca562c5d0/rapidyaml-0.12.1-cp311-cp311-win32.whl", hash = "sha256:bb7fa0ebe10311e30636c0da6bd49ed673ab868c30aca0a36073218587503ceb", size = 262594, upload-time = "2026-05-07T19:43:14.521Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/63/9ef27ca683c4e91db2f3a4532f31880909d68998d61f3de05702d86cbcea/rapidyaml-0.12.1-cp311-cp311-win_amd64.whl", hash = "sha256:4dc2e78ed03ef63c6dcf03c64cf66b491ffcf60d7b07f7582c9ef9efeef85682", size = 315223, upload-time = "2026-05-07T19:43:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/c8/1b2e5409e30363a98a8e8ece03b709cb30720faaddc59d14d17f18655ea2/rapidyaml-0.12.1-cp311-cp311-win_arm64.whl", hash = "sha256:c9eee8081e2660693ea3beb9efe294f9588ba53a525966590e19db1166deda38", size = 311868, upload-time = "2026-05-07T19:43:17.113Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f7/d71685b58392f93df3247ba6b3519f1c0433f61e606716920535dd92db59/rapidyaml-0.12.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bea636ed2bc7b99d2dd5243010806ac673c70fee7d316e828bd27e3593851321", size = 5124112, upload-time = "2026-05-07T19:43:18.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/5a/cf91f2d2258a11f52f2f62bf9c65739f49ea808cebaeedc648e9f78a393e/rapidyaml-0.12.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ca18d04a2d9244d253d99d17a80671be7f4cd7a9daf5ff9dd850737e9b0a8c4", size = 5147555, upload-time = "2026-05-07T19:43:20.363Z" },
+    { url = "https://files.pythonhosted.org/packages/90/d6/42d441eeceac1d8fc7d2a7480654db661282dd1f94deef344c5421ba0c3c/rapidyaml-0.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6ddd43a1f6a12e706477b85cf51d881c2362d74f4c0433d6092f6b40bae20567", size = 5124110, upload-time = "2026-05-07T19:43:22.166Z" },
+    { url = "https://files.pythonhosted.org/packages/42/70/ec54f6b47b47adfdcce6695817ceaa102b64cd41d5fc5cb2b512353481f9/rapidyaml-0.12.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:edb8133c0f0952e9a5e1efa805f32aec5dd83315cf63710a3cd3a36a7b742615", size = 292548, upload-time = "2026-05-07T19:43:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/57/27ec9e7f491f8329bfc7eb082050cca6957166407fd24d81d98a0939499e/rapidyaml-0.12.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29c97a8d7022d851c3875818a4dad232f4d921f98fc578aad5bd37bc6dd6946e", size = 272421, upload-time = "2026-05-07T19:43:24.87Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cb/87da89ae11d0de562928a7e8ca40d5daee55049408019d5d1b918af6800b/rapidyaml-0.12.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:489f1cba591f3e6a6325f3b08edf64abb293b5353906686ec04949ccc3a44855", size = 282080, upload-time = "2026-05-07T19:43:26.18Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/f7/6f0878b1c7e67b4d805cf0720a32aa2d85adca356f12e75d8fe4e99107b8/rapidyaml-0.12.1-cp312-cp312-win32.whl", hash = "sha256:e2375a375946afbc29aa456f4403207885b610f800e5d61491933dd511d975d1", size = 262785, upload-time = "2026-05-07T19:43:27.26Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/9f/71728292cc78a2d69ddf83a59d5248776174458fb4db13630eb066566800/rapidyaml-0.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:dbcb37383a184db48c52182f236d5b2ac2d0fcb8ed768d076e967cc6d107e094", size = 315347, upload-time = "2026-05-07T19:43:28.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/ff/0165060d60d1c9c0bbaa5492bbffaffe821afdfee4300b7fa035da7dadcb/rapidyaml-0.12.1-cp312-cp312-win_arm64.whl", hash = "sha256:aaf84d355b3dc0c8b027cc27418eff2c37888d77d5e92bfd7b54d6124f06daf6", size = 312000, upload-time = "2026-05-07T19:43:29.52Z" },
+    { url = "https://files.pythonhosted.org/packages/20/fe/a24ceda80e0ead701b997af6be525ed1f12405e192c5080cee2e7607c087/rapidyaml-0.12.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:26df56dd872ae679ad7eb78ec704f75514ca6ea5c9229c2e336d7df2f90360dd", size = 5069159, upload-time = "2026-05-07T19:43:30.874Z" },
+    { url = "https://files.pythonhosted.org/packages/52/0c/3702d9125258abcdc9049651e34158ae2cf3557221dde637edee66765869/rapidyaml-0.12.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b9f3900d2ae4bf72358b01e823d97cd4eea541c77fbf83198ee5189c088ec34a", size = 5092680, upload-time = "2026-05-07T19:43:32.197Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d7/5215d653c8617b90ca121d04f7d1ef508dea36dc07c43646c9361d6080eb/rapidyaml-0.12.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ff4002c071ebd731257c25713b57bb9df3525e7aea1347ede824e209e9b5638f", size = 5069159, upload-time = "2026-05-07T19:43:33.519Z" },
+    { url = "https://files.pythonhosted.org/packages/52/70/ed49d7c6a3786c087dda8753549ecc00a7be56fadaea8b787e2ebb70364b/rapidyaml-0.12.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b32a72128bcbfd399330e5d4c3f6fd7366cecbb369ecdaa9b32fd79934cc8d1f", size = 292423, upload-time = "2026-05-07T19:43:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/59/371171d64e109964bab0a527bf6bd4696adb2ff41b3a851edae812270e30/rapidyaml-0.12.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09132b2eb4e8b1d3fe285b38609d9fc58dccdd43d6df3798ee38acbfd7f2bf15", size = 272203, upload-time = "2026-05-07T19:43:36.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/48/03a3c30aa899a40a068fcf7c28e1afa08cc528f55298d53ddeeb872f5c66/rapidyaml-0.12.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f3fe91b67ec3afbb290d370e7acce4f02399f1d13a4b157df6dac395a107d1b", size = 281894, upload-time = "2026-05-07T19:43:37.23Z" },
+    { url = "https://files.pythonhosted.org/packages/61/8b/85799d7e330f44d5352037e19d867d0a373d46428027aa669b9de261cb9e/rapidyaml-0.12.1-cp313-cp313-win32.whl", hash = "sha256:43a96e347c6f1aaca0378519d6bb512e1312e83005fbecdaeb5ea6ae8a9d8a13", size = 263066, upload-time = "2026-05-07T19:43:38.383Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/007cdf7aa9dbbd7a3e742a7af9235eb329b210946cdcfd48bf5966e5a809/rapidyaml-0.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:72c8966ca52425eb875645bed1d02b227774d13d90479b0d671f3ec29a3b4101", size = 315204, upload-time = "2026-05-07T19:43:39.397Z" },
+    { url = "https://files.pythonhosted.org/packages/67/2d/932fd4ab7bbce7eeaab195adaf711f609f4bf94e3b9dbc26b30f7fdb18a7/rapidyaml-0.12.1-cp313-cp313-win_arm64.whl", hash = "sha256:5d0d2d0d85493b7239810073893ff301004226b85b35425d46dbced9f34d2fb4", size = 311874, upload-time = "2026-05-07T19:43:40.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/82/c126035a3470e0cdc0f9446de842acf38af2a7f1e5c0b6dfb072895ca67e/rapidyaml-0.12.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9dae5e7cfc7ebed8d32d4378ea77c72b9de2ff7db2ea3ae066d7623731420db1", size = 5649856, upload-time = "2026-05-07T19:43:41.747Z" },
+    { url = "https://files.pythonhosted.org/packages/69/f7/09c6dc1ff4327d1bb9e47b8068bb4a5dced83d1190568303a0b4a0fb8972/rapidyaml-0.12.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5e5dd676cd5071592c36dc5a8fe01e8eacf036b8df47fbe5bdedb540856a24a1", size = 5673400, upload-time = "2026-05-07T19:43:43.132Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fa/df944aa94d29544c87f96d508b19ed5c00de02b42de6d3541055329e80b8/rapidyaml-0.12.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:eb2ed5a365f39041f9da353851951846f7bbec8aa7e0f7a8c531707e2ee99211", size = 5649853, upload-time = "2026-05-07T19:43:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/19/322e915eb0a4bfa9eca6d3be9f724ad026f9c3c8e3281c543d2980c799e4/rapidyaml-0.12.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:30f4270c78e4613cd6cbfbd68d23065e44dd783e5bbfccfa301a066aa743b360", size = 292289, upload-time = "2026-05-07T19:43:46.077Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e2/ab47a96c90dd32c039d983bc04f11836f6d50ae080d739696c98d3871689/rapidyaml-0.12.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b64974ba546d6d21935da84e85829ee8ab5c78b7db0d607aa3399a21f31355e", size = 272462, upload-time = "2026-05-07T19:43:47.262Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d2/15a25bb2947a5decf149ef36547d3ad367f032654910f25e6bc7d6f871c8/rapidyaml-0.12.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d57e96874d66588bf2af8b96e6b178cae7f33a791e1cccd78bef1656c0b10fc6", size = 281860, upload-time = "2026-05-07T19:43:48.35Z" },
+    { url = "https://files.pythonhosted.org/packages/33/07/a64ab8cc6c34565d3a5e687d3e7898fe59c1a4b76608b56b0782f40007e2/rapidyaml-0.12.1-cp314-cp314-win32.whl", hash = "sha256:96b303eb6537c4dd9a4ed1c6d0296ec7c7340b637f1580dce60d99ccf1869448", size = 270639, upload-time = "2026-05-07T19:43:49.394Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/e80303b4c14d1dc41c39d71f4cb46e6f3b6683921f99bd039fec98397808/rapidyaml-0.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:ce932c0df3237c4a92428bf0407c59af217739c23c99751151eee46871c7690a", size = 325210, upload-time = "2026-05-07T19:43:50.521Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3a/9dc97f8f98394381e054b21a6f2d288ecf0e266f225a70356dd2f4394d56/rapidyaml-0.12.1-cp314-cp314-win_arm64.whl", hash = "sha256:e7492e635020edb2813393ece03bede28d6f90f30daa3464217263015c3c06b0", size = 321624, upload-time = "2026-05-07T19:43:51.896Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed Changes

Adds support for rapidyaml emitter option via the compile flag `--yaml-use-rapidyaml`

In my local tests, this cuts compile times in a rather large codebase by a factor of 3.

It supports the current yaml styles implement (literal, folded, double-quotes), however the initial compilation will output formatting differences when compared with a previous compilation with PyYAML _but_ it is expected to be semantically equivalent.

## Docs and Tests

* [x] Tests added
* [x] Updated documentation
