### PR TITLE
docs: SEO technical foundation — metadata, Open Graph, robots.txt, and README alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kapitan: advanced configuration management tool
+# Kapitan: Configuration Management for Kubernetes, Terraform, and Infrastructure
 
 [![Test, Build and Publish docker image](https://github.com/kapicorp/kapitan/actions/workflows/test-build-publish.yml/badge.svg?branch=master&event=push)](https://github.com/kapicorp/kapitan/actions/workflows/test-build-publish.yml)
 ![Python Version](https://img.shields.io/pypi/pyversions/kapitan)
@@ -7,17 +7,19 @@
 [![Releases](https://img.shields.io/github/release/kapicorp/kapitan.svg)](https://github.com/kapicorp/kapitan/releases)
 [![Docker Image Size](https://img.shields.io/docker/image-size/kapicorp/kapitan/latest.svg)](https://hub.docker.com/r/kapicorp/kapitan)
 
-<img src="docs/images/kapitan_logo.png" width="25">
+<img src="docs/images/kapitan_logo.png" width="25" alt="Kapitan logo">
 
+**Kapitan** is an open source configuration management tool for **Kubernetes**, **Terraform**, and complex infrastructure systems. It helps teams generate, organize, reuse, and validate configuration across environments using an **inventory-driven model**, templates (**Jsonnet**, **Jinja2**, **Kadet**), and integrations with **Helm**, **Kustomize**, **CUE**, and external references.
 
-**`Kapitan`** aims to be your *one-stop tool* to help you manage the ever growing complexity of your configurations.
+Kapitan provides native **secrets management** (GPG, AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault) and is designed for **Platform Engineering** and **GitOps** workflows.
 
-Join the community [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3)
+- **Documentation**: <https://kapitan.dev>
+- **Community**: [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3) on Kubernetes Slack
+- **Quick Start**: <https://kapitan.dev/getting_started/>
 
-## [**Official site**](https://kapitan.dev) <https://kapitan.dev>
+## What is Kapitan?
 
-
-## [**Quick Start**](https://kapitan.dev/getting_started/#quickstart)
+Kapitan lets you model infrastructure configuration with reusable **inventory classes** and **targets**, then compile that data into manifests, scripts, documentation, and Terraform resources. Instead of copying values across Helm values files, Kustomize overlays, and Terraform variables, you define everything once in the Kapitan inventory and let each input type generate the files it needs.
 
 ## Install Kapitan
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,7 +1,10 @@
 ---
 comments: true
+title: "Kapitan FAQ: Common Questions About Inventory, Compile, and Secrets"
+description: "Find answers to frequently asked questions about Kapitan inventory, targets, classes, compilation, references, secrets, and supported input types."
 ---
-# :kapitan-logo: FAQ
+
+# :kapitan-logo: **Kapitan FAQ**
 
 ## Why do I need **Kapitan**?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan — Configuration Management for Kubernetes, Terraform, and Infrastructure"
+description: "Kapitan is an open source configuration management tool for Kubernetes, Terraform, and complex infrastructure. Generate, organize, and reuse configuration across environments."
+---
+
 # :kapitan-logo: **Kapitan: Keep your ship together**
 
 ![GitHub Sponsors](https://img.shields.io/github/sponsors/kapicorp?style=for-the-badge)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,4 +1,9 @@
-# :kapitan-logo: **Kapitan Overview**
+---
+title: "Getting Started with Kapitan for Kubernetes and Infrastructure Configuration"
+description: "Install Kapitan with Docker or pip, clone a reference repository, and compile your first Kubernetes and infrastructure targets in minutes."
+---
+
+# :kapitan-logo: **Getting Started with Kapitan**
 
 ## Setup your installation
 

--- a/docs/pages/core_concepts.md
+++ b/docs/pages/core_concepts.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan Core Concepts: Inventory, Targets, Classes, and Input Types"
+description: "Learn how Kapitan organizes configuration with inventory, targets, classes, and input types to generate Kubernetes, Terraform, and infrastructure manifests."
+---
+
 # :kapitan-logo: **Kapitan Core Concepts**
 
 **Kapitan** essentially allows you to organise your data with the **`inventory`**, and uses it to configure and run multiple [**`Input Types`**](input_types/introduction.md) which generate files.

--- a/docs/pages/input_types/helm.md
+++ b/docs/pages/input_types/helm.md
@@ -1,4 +1,9 @@
-# :kapitan-logo: **Input Type | Helm**
+---
+title: "Kapitan Helm Input Type: Render Helm Charts Without Tiller"
+description: "Render Helm charts inside Kapitan without the Helm executable or Tiller. Override values, fetch dependencies, and output Kubernetes manifests."
+---
+
+# :kapitan-logo: **Kapitan Helm Input Type**
 
 This is a Python binding to `helm template` command for users with helm charts. This does not require the helm executable, and the templates are rendered without the Tiller server.
 

--- a/docs/pages/input_types/introduction.md
+++ b/docs/pages/input_types/introduction.md
@@ -1,4 +1,9 @@
-# Introduction
+---
+title: "Kapitan Input Types: Jsonnet, Jinja, Kadet, Helm, Kustomize, and CUE"
+description: "Explore Kapitan input types including Jsonnet, Jinja2, Kadet, Helm, Kustomize, CUE, copy, remove, and external. Choose the right templating engine for your infrastructure."
+---
+
+# :kapitan-logo: **Kapitan Input Types**
 
 **Note:** make sure to read up on [inventory](../inventory/introduction.md) before moving on.
 

--- a/docs/pages/input_types/jinja.md
+++ b/docs/pages/input_types/jinja.md
@@ -1,4 +1,9 @@
-# :kapitan-logo: **Input Type | Jinja2**
+---
+title: "Kapitan Jinja2 Input Type: Templates for Scripts and Documentation"
+description: "Learn how to use Jinja2 templates in Kapitan to generate scripts, documentation, and configuration files with access to the full Kapitan inventory."
+---
+
+# :kapitan-logo: **Kapitan Jinja2 Input Type**
 
 This input type is probably the most simple input type to use: it is very versatile and is commonly used to create scripts and documentation files.
 

--- a/docs/pages/input_types/jsonnet.md
+++ b/docs/pages/input_types/jsonnet.md
@@ -1,4 +1,9 @@
-# :kapitan-logo: **Input Type | Jsonnet**
+---
+title: "Kapitan with Jsonnet: Generate Kubernetes and Infrastructure Config"
+description: "Use Jsonnet with Kapitan to generate Kubernetes manifests and infrastructure configuration. Access inventory data, validate with JSON Schema, and output YAML or JSON."
+---
+
+# :kapitan-logo: **Kapitan with Jsonnet**
 
 Jsonnet is a superset of json format that includes features such as conditionals, variables and imports. Refer to [jsonnet docs](https://jsonnet.org/learning/tutorial.html) to understand how it works.
 

--- a/docs/pages/input_types/kadet.md
+++ b/docs/pages/input_types/kadet.md
@@ -1,4 +1,9 @@
-# :kapitan-logo: **Input Type | Kadet**
+---
+title: "Kapitan Kadet Input Type: Python-Based Configuration Generation"
+description: "Use Python and Kadet with Kapitan to generate infrastructure configuration. Define resources as classes and access the Kapitan inventory from Python code."
+---
+
+# :kapitan-logo: **Kapitan Kadet Input Type**
 
 Kadet is an extensible **input type** for **Kapitan** that enables you to generate templates using **Python**.
 

--- a/docs/pages/inventory/classes.md
+++ b/docs/pages/inventory/classes.md
@@ -1,4 +1,9 @@
-# Classes
+---
+title: "Kapitan Inventory Classes: Reusable Configuration Fragments"
+description: "Learn how Kapitan classes let you compose reusable YAML configuration fragments and import them into targets and other classes."
+---
+
+# :kapitan-logo: **Kapitan Inventory Classes**
 
 ## Usage
 

--- a/docs/pages/inventory/introduction.md
+++ b/docs/pages/inventory/introduction.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan Inventory Explained: Targets, Classes, and Parameters"
+description: "Learn how Kapitan inventory uses targets, classes, and parameters to model reusable infrastructure configuration across environments."
+---
+
 # :kapitan-logo: **What is the inventory?**
 
 The **Inventory** is a core component of Kapitan: this section aims to explain how it works and how to best take advantage of it.

--- a/docs/pages/inventory/parameters_interpolation.md
+++ b/docs/pages/inventory/parameters_interpolation.md
@@ -1,4 +1,9 @@
-# Parameters Interpolation
+---
+title: "Kapitan Inventory Parameter Interpolation and Variable References"
+description: "Learn how to use parameter interpolation in Kapitan inventory to reference values across classes, targets, and nested YAML structures."
+---
+
+# :kapitan-logo: **Kapitan Inventory Parameter Interpolation**
 
 !!! note
 

--- a/docs/pages/inventory/targets.md
+++ b/docs/pages/inventory/targets.md
@@ -1,5 +1,10 @@
 
-# :kapitan-logo: **Targets**
+---
+title: "Kapitan Inventory Targets: Defining Environments and Deployments"
+description: "Learn how to define Kapitan targets for production, staging, and development. Organize targets hierarchically and compile environment-specific configuration."
+---
+
+# :kapitan-logo: **Kapitan Inventory Targets**
 
 In the world of Kapitan, a target represents a specific environment or deployment scenario where you want to apply your configurations.
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan References: Secrets Management and External Values"
+description: "Kapitan References manage secrets and dynamic values with support for GPG, AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault, and more."
+---
+
 # :kapitan-logo: **Kapitan References** (formally ***Secrets***)
 
 One of the motivations behing Kapitan's design is that we believe that everything about your setup should be tracked, and Kapitan takes this to the extreme. Sometimes, however, we have to manage values that we do not think they belong to the **Inventory**: perhaps they are either too variable (for instance, a *Git commit sha* that changes with every build) or too sensitive, like a password or a generic secret, and then they should always be encrypted.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kapitan.dev/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@
 # pip install mkdocs mkdocs-material pymdown-extensions
 site_name: "Kapitan: Keep your ship together"
 site_url: "https://kapitan.dev/"
+site_description: "Kapitan is an open source configuration management tool for Kubernetes, Terraform, and complex infrastructure. Generate, organize, and reuse configuration across environments."
 strict: true
 plugins:
   - blog:
@@ -10,6 +11,7 @@ plugins:
       post_url_date_format: dd/MM/yyyy
   - search
   - markdown-exec
+  - meta
 
 theme:
   name: material
@@ -92,7 +94,6 @@ nav:
           - CueLang: pages/input_types/cuelang.md
           - Helm: pages/input_types/helm.md
           - Kustomize: pages/input_types/kustomize.md
-          - Cuelang: pages/input_types/cuelang.md
           - Jsonnet: pages/input_types/jsonnet.md
           - External: pages/input_types/external.md
           - Copy: pages/input_types/copy.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,4 +1,68 @@
 {% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="{{ (page.meta or {}).get('title', page.title) }}" />
+  <meta property="og:description" content="{{ (page.meta or {}).get('description', config.site_description) }}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="{{ page.canonical_url }}" />
+  <meta property="og:image" content="{{ config.site_url }}images/kapitan_logo.png" />
+  <meta property="og:site_name" content="{{ config.site_name }}" />
+
+  <!-- Twitter Cards -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="{{ (page.meta or {}).get('title', page.title) }}" />
+  <meta name="twitter:description" content="{{ (page.meta or {}).get('description', config.site_description) }}" />
+  <meta name="twitter:image" content="{{ config.site_url }}images/kapitan_logo.png" />
+
+  {% if page.is_homepage %}
+  <!-- JSON-LD structured data for homepage -->
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "@id": "{{ config.site_url }}",
+        "url": "{{ config.site_url }}",
+        "name": "{{ config.site_name }}",
+        "description": "{{ config.site_description }}",
+        "publisher": {
+          "@id": "{{ config.site_url }}#organization"
+        }
+      },
+      {
+        "@type": "Organization",
+        "@id": "{{ config.site_url }}#organization",
+        "name": "KapiCorp",
+        "url": "{{ config.site_url }}",
+        "sameAs": [
+          "https://github.com/kapicorp",
+          "https://twitter.com/kapitandev"
+        ]
+      },
+      {
+        "@type": "SoftwareApplication",
+        "@id": "{{ config.site_url }}#kapitan",
+        "name": "Kapitan",
+        "applicationCategory": "DeveloperApplication",
+        "operatingSystem": "Linux, macOS, Windows",
+        "offers": {
+          "@type": "Offer",
+          "price": "0",
+          "priceCurrency": "USD"
+        },
+        "url": "{{ config.site_url }}",
+        "sameAs": "https://github.com/kapicorp/kapitan"
+      }
+    ]
+  }
+  </script>
+  {% endif %}
+{% endblock %}
+
 {% block scripts %}
   {{ super() }}
    <!-- Google Tag Manager (noscript) -->


### PR DESCRIPTION
## Summary

This PR delivers the first phase of an SEO improvement program for kapitan.dev. It adds foundational technical SEO signals and improves page metadata across the documentation site.

## Changes

- **mkdocs.yml**
  - Added `site_description` for fallback meta descriptions and Open Graph
  - Added explicit `meta` plugin to ensure Material for MkDocs reads page front matter
  - Removed duplicate `CueLang`/`Cuelang` navigation entry

- **overrides/main.html**
  - Added Open Graph tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`, `og:site_name`)
  - Added Twitter Card tags (`twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`)
  - Added JSON-LD structured data on the homepage: `WebSite`, `Organization`, `SoftwareApplication`

- **docs/robots.txt**
  - Allow all crawlers and reference `https://kapitan.dev/sitemap.xml`

- **Page metadata (14 pages)**
  - Added unique `title` and `description` front matter to priority pages:
    - Home, Getting Started, Core Concepts
    - Inventory (introduction, targets, classes, parameters interpolation)
    - References
    - Input Types (introduction, Jsonnet, Jinja, Kadet, Helm)
    - FAQ

- **README.md**
  - Rewrote title and first paragraph to align with website positioning
  - Added "What is Kapitan?" section explaining inventory, classes, targets, and input types
  - Added logo alt text

## Affected URLs

All canonical documentation URLs on https://kapitan.dev/

## Test plan

- [x] `uv run mkdocs build` passes without errors
- [x] Generated HTML includes `<meta name="description">` on priority pages
- [x] Generated HTML includes Open Graph and Twitter Card tags
- [x] Homepage includes JSON-LD structured data
- [x] `robots.txt` is present in build output
- [x] Sitemap contains clean directory-style URLs (no `.html` extensions)

## Risk assessment

Low. Changes are additive (new metadata, new robots.txt, template additions). No existing URLs are renamed or moved. The only content rewrites are in README.md and page H1s/titles, which are improved for clarity.