### PR TITLE
docs: improve internal linking and navigation across core pages

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,12 +1,64 @@
 ---
 comments: true
 ---
-# :kapitan-logo: FAQ
 
-## Why do I need **Kapitan**?
+# :kapitan-logo: **Kapitan FAQ**
 
-See [Why do I need **Kapitan**?](pages/blog/posts/2022-12-04.md#why-do-i-need-kapitan)
+## Why do I need Kapitan?
+
+See the blog post [Why do I need **Kapitan**?](pages/blog/posts/2022-12-04.md#why-do-i-need-kapitan) for a detailed explanation of the problems Kapitan solves, including configuration sprawl, duplication across environments, and secrets management.
+
+## What is the Kapitan inventory?
+
+The [inventory](pages/inventory/introduction.md) is a hierarchical YAML structure that captures all the data you want to make available to Kapitan's templating engines. It is divided into [targets](pages/inventory/targets.md) (environments or deployments) and [classes](pages/inventory/classes.md) (reusable configuration fragments). Learn more in the [inventory introduction](pages/inventory/introduction.md).
+
+## How do I install Kapitan?
+
+The easiest way is via Docker:
+
+```shell
+docker run -t --rm -v $(pwd):/src:delegated kapicorp/kapitan -h
+```
+
+Or install with pip:
+
+```shell
+pip3 install --user --upgrade kapitan
+```
+
+See the [Getting Started](getting_started.md) page for full installation instructions.
+
+## Which input type should I use?
+
+It depends on your use case:
+
+- **[Jsonnet](pages/input_types/jsonnet.md)** — structured data, Kubernetes manifests, JSON Schema validation
+- **[Jinja](pages/input_types/jinja.md)** — scripts, documentation, text templates
+- **[Kadet](pages/input_types/kadet.md)** — Python-based generation, reusable libraries
+- **[Helm](pages/input_types/helm.md)** — rendering existing Helm charts
+- **[Kustomize](pages/input_types/kustomize.md)** — patching Kubernetes manifests
+- **[CUE](pages/input_types/cuelang.md)** — typed configuration with validation
+
+## How does Kapitan manage secrets?
+
+Kapitan uses [References](references.md) (formerly Secrets) to manage sensitive and dynamic values. Supported backends include GPG, AWS KMS, GCP KMS, Azure Key Vault, HashiCorp Vault, and plain/base64 for non-sensitive data. See the [References documentation](references.md) for setup instructions.
+
+## What is parameter interpolation?
+
+Parameter interpolation lets you reference values defined elsewhere in the inventory using the `${variable:name}` syntax. This reduces duplication and makes configuration more maintainable. Read the [parameter interpolation guide](pages/inventory/parameters_interpolation.md) for details.
+
+## How do I compile a target?
+
+```shell
+kapitan compile -t <target_name>
+```
+
+Without a target flag, Kapitan compiles all discovered targets. See the [`kapitan compile` CLI reference](pages/commands/kapitan_compile.md) for all options.
+
+## Where can I find examples?
+
+The [kapicorp/kapitan-reference](https://github.com/kapicorp/kapitan-reference) repository contains working examples for Kubernetes, Terraform, and more. You can also explore the [input type documentation](pages/input_types/introduction.md) for small, focused examples.
 
 ## Ask your question
 
-Please use the comments facility below to ask your question
+Please use the comments facility below to ask your question.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,3 +144,12 @@ Compiled echo-server (0.14s)
     ```shell
     sudo pip3 install --upgrade kapitan
     ```
+
+---
+
+## Next steps
+
+- Learn the [Kapitan core concepts](pages/core_concepts.md): how inventory, targets, classes, and input types work together.
+- Understand the [Kapitan inventory](pages/inventory/introduction.md): targets, classes, and parameter interpolation.
+- Explore [input types](pages/input_types/introduction.md) such as [Jsonnet](pages/input_types/jsonnet.md), [Jinja](pages/input_types/jinja.md), [Kadet](pages/input_types/kadet.md), [Helm](pages/input_types/helm.md), and [Kustomize](pages/input_types/kustomize.md).
+- Manage secrets and external values with [Kapitan References](references.md).

--- a/docs/pages/core_concepts.md
+++ b/docs/pages/core_concepts.md
@@ -163,4 +163,4 @@ parameters:
 
 - Dive deeper into the [Kapitan inventory](inventory/introduction.md): how [targets](inventory/targets.md), [classes](inventory/classes.md), and [parameter interpolation](inventory/parameters_interpolation.md) model your configuration.
 - Choose an [input type](input_types/introduction.md) for your use case: [Jsonnet](input_types/jsonnet.md), [Jinja](input_types/jinja.md), [Kadet](input_types/kadet.md), [Helm](input_types/helm.md), [Kustomize](input_types/kustomize.md), or [CUE](input_types/cuelang.md).
-- Learn how to manage secrets and dynamic values with [Kapitan References](../../references.md).
+- Learn how to manage secrets and dynamic values with [Kapitan References](../references.md).

--- a/docs/pages/core_concepts.md
+++ b/docs/pages/core_concepts.md
@@ -156,3 +156,11 @@ parameters:
     headquarters: London
     timezone: Europe/London
 ```
+
+---
+
+## Next steps
+
+- Dive deeper into the [Kapitan inventory](inventory/introduction.md): how [targets](inventory/targets.md), [classes](inventory/classes.md), and [parameter interpolation](inventory/parameters_interpolation.md) model your configuration.
+- Choose an [input type](input_types/introduction.md) for your use case: [Jsonnet](input_types/jsonnet.md), [Jinja](input_types/jinja.md), [Kadet](input_types/kadet.md), [Helm](input_types/helm.md), [Kustomize](input_types/kustomize.md), or [CUE](input_types/cuelang.md).
+- Learn how to manage secrets and dynamic values with [Kapitan References](../../references.md).

--- a/docs/pages/input_types/introduction.md
+++ b/docs/pages/input_types/introduction.md
@@ -151,3 +151,17 @@ Input types can be specified in the inventory under `kapitan.compile` in the fol
     ```
 
     1. (Default: global --prune)
+
+---
+
+## Next steps
+
+- Learn how the [Kapitan inventory](../inventory/introduction.md) feeds data into every input type.
+- Choose the right template engine for your use case:
+  - [Jsonnet](jsonnet.md) for structured data and Kubernetes manifests
+  - [Jinja](jinja.md) for scripts and documentation
+  - [Kadet](kadet.md) for Python-based generation
+  - [Helm](helm.md) for existing Helm charts
+  - [Kustomize](kustomize.md) for Kubernetes manifest patches
+  - [CUE](cuelang.md) for typed configuration validation
+- Manage secrets and external values with [Kapitan References](../../references.md).

--- a/docs/pages/input_types/jsonnet.md
+++ b/docs/pages/input_types/jsonnet.md
@@ -133,3 +133,12 @@ If `validation.valid` is not true, it will then fail compilation and display `va
 
     Compile error: failed to compile target: minikube-mysql
     ```
+
+---
+
+## Next steps
+
+- Learn how the [Kapitan inventory](../inventory/introduction.md) makes data available to Jsonnet templates.
+- Explore other [input types](../introduction.md) such as [Jinja](jinja.md), [Kadet](kadet.md), and [Helm](helm.md).
+- Validate your generated output with [`kapitan validate`](../commands/kapitan_validate.md).
+- Manage secrets in Jsonnet templates with [Kapitan References](../../references.md).

--- a/docs/pages/input_types/jsonnet.md
+++ b/docs/pages/input_types/jsonnet.md
@@ -139,6 +139,6 @@ If `validation.valid` is not true, it will then fail compilation and display `va
 ## Next steps
 
 - Learn how the [Kapitan inventory](../inventory/introduction.md) makes data available to Jsonnet templates.
-- Explore other [input types](../introduction.md) such as [Jinja](jinja.md), [Kadet](kadet.md), and [Helm](helm.md).
+- Explore other [input types](introduction.md) such as [Jinja](jinja.md), [Kadet](kadet.md), and [Helm](helm.md).
 - Validate your generated output with [`kapitan validate`](../commands/kapitan_validate.md).
 - Manage secrets in Jsonnet templates with [Kapitan References](../../references.md).

--- a/docs/pages/inventory/advanced.md
+++ b/docs/pages/inventory/advanced.md
@@ -40,3 +40,11 @@ For instance you could define the following:
         Compiled acme (0.06s)
         Compiled acme-documentation (0.09s)
         ```
+
+---
+
+## Next steps
+
+- Review the [inventory introduction](introduction.md) for a refresher on targets and classes.
+- Learn about [inventory backends](backends.md) such as reclass-rs and OmegaConf.
+- Explore the [`kapitan compile` CLI reference](../commands/kapitan_compile.md#using-labels) for more label options.

--- a/docs/pages/inventory/classes.md
+++ b/docs/pages/inventory/classes.md
@@ -51,4 +51,13 @@ If we open the file, we find another familiar yaml fragment.
 
 Notice that this class includes an import definition for another class, `kapitan.common`. We've already learned this means that kapitan will import a file on disk called `inventory/classes/kapitan/common.yml`
 
-You can also see that in the `parameters` section we now encounter a new syntax which unlocks another powerful inventory feature: *parameters interpolation*!
+You can also see that in the `parameters` section we now encounter a new syntax which unlocks another powerful inventory feature: [parameter interpolation](parameters_interpolation.md)!
+
+---
+
+## Next steps
+
+- Learn how to define environments and deployments with [Kapitan inventory targets](targets.md).
+- Understand how to reference values across classes and targets with [parameter interpolation](parameters_interpolation.md).
+- Explore [advanced inventory features](advanced.md) such as wildcard classes and inventory backends.
+- See how classes power [input types](../input_types/introduction.md) like [Jsonnet](../input_types/jsonnet.md) and [Jinja](../input_types/jinja.md).

--- a/docs/pages/inventory/introduction.md
+++ b/docs/pages/inventory/introduction.md
@@ -66,3 +66,13 @@ parameters:
 
 
 By combining [**target**](targets.md) and [**classes**](classes.md), the **Inventory** becomes the SSOT for your whole configuration, and learning how to use it will unleash the real power of **Kapitan**.
+
+---
+
+## Next steps
+
+- Learn how to define environments and deployments with [Kapitan inventory targets](targets.md).
+- Understand how to compose reusable configuration with [Kapitan inventory classes](classes.md).
+- Discover how to reference values across the inventory with [parameter interpolation](parameters_interpolation.md).
+- Explore [advanced inventory features](advanced.md) such as target labels and inventory backends.
+- See how the inventory drives [input types](../input_types/introduction.md) like [Jsonnet](../input_types/jsonnet.md), [Jinja](../input_types/jinja.md), and [Helm](../input_types/helm.md).

--- a/docs/pages/inventory/parameters_interpolation.md
+++ b/docs/pages/inventory/parameters_interpolation.md
@@ -63,4 +63,13 @@ classes:
 
 Here in this case `application.location` refers to a value `location` which has been defined elsewhere, perhaps (but not necessarily) in the `project.production` class.
 
-Also notice that the class name (`project.production`) is not in any ways influencing the name or the structed of the yaml it imports into the file
+Also notice that the class name (`project.production`) is not in any ways influencing the name or the structed of the yaml it imports into the file.
+
+---
+
+## Next steps
+
+- Review the [Kapitan inventory introduction](introduction.md) to understand how targets and classes form the configuration hierarchy.
+- Learn how to define environments with [Kapitan inventory targets](targets.md).
+- Compose reusable fragments with [Kapitan inventory classes](classes.md).
+- Explore [advanced inventory features](advanced.md) such as inventory backends and wildcard classes.

--- a/docs/pages/inventory/targets.md
+++ b/docs/pages/inventory/targets.md
@@ -71,3 +71,12 @@ inventory/
 ```
 
 In this example, the `my-cluster.yml` target file is located within the `clusters/production/` subdirectory, and can be identified with `clusters.production.my-cluster`.
+
+---
+
+## Next steps
+
+- Compose reusable configuration fragments with [Kapitan inventory classes](classes.md).
+- Learn how to reference values across classes and targets with [parameter interpolation](parameters_interpolation.md).
+- Explore [advanced inventory features](advanced.md) such as target labels.
+- See how targets are compiled with different [input types](../input_types/introduction.md).

--- a/docs/references.md
+++ b/docs/references.md
@@ -791,3 +791,11 @@ For example, to reveal the secret stored at `path/to/secret_inside_kapitan`
     ```
 
 *Note:* Cryptographic algorithm used for encryption is *rsa-oaep-256*.
+
+---
+
+## Next steps
+
+- Learn how to model your configuration with the [Kapitan inventory](pages/inventory/introduction.md).
+- See how references are used during [compilation](pages/input_types/introduction.md).
+- Explore the [`kapitan compile`](pages/commands/kapitan_compile.md) and [`kapitan refs`](pages/commands/kapitan_inventory.md) CLI commands.


### PR DESCRIPTION
## Summary

Adds contextual cross-links and "Next steps" sections to key documentation pages to help users and search crawlers discover related content.

## Changes

- **getting_started.md**: Next steps linking to Core Concepts, Inventory, Input Types, and References
- **pages/core_concepts.md**: Next steps linking to Inventory, Input Types, and References
- **pages/inventory/introduction.md**: Next steps linking to Targets, Classes, Parameters, Advanced features, and Input Types
- **pages/inventory/targets.md**: Next steps linking to Classes, Parameters, Advanced features, and Input Types
- **pages/inventory/classes.md**: Next steps linking to Targets, Parameters, Advanced features, and Input Types; improved inline link to parameter interpolation
- **pages/inventory/parameters_interpolation.md**: Next steps linking to Inventory, Targets, Classes, and Advanced features
- **pages/inventory/advanced.md**: Next steps linking to Inventory, Backends, and CLI reference
- **pages/input_types/introduction.md**: Next steps linking to Inventory and each individual input type
- **pages/input_types/jsonnet.md**: Next steps linking to Inventory, Input Types, Validate, and References
- **references.md**: Next steps linking to Inventory, Compile, and CLI commands
- **FAQ.md**: expanded from 2 questions to 8 real questions with links to relevant docs pages

## Affected URLs

- https://kapitan.dev/getting_started/
- https://kapitan.dev/pages/core_concepts/
- https://kapitan.dev/pages/inventory/introduction/
- https://kapitan.dev/pages/inventory/targets/
- https://kapitan.dev/pages/inventory/classes/
- https://kapitan.dev/pages/inventory/parameters_interpolation/
- https://kapitan.dev/pages/inventory/advanced/
- https://kapitan.dev/pages/input_types/introduction/
- https://kapitan.dev/pages/input_types/jsonnet/
- https://kapitan.dev/references/
- https://kapitan.dev/FAQ/

## Test plan

- [x] `uv run mkdocs build` passes without errors
- [x] Internal links resolve correctly in the generated site
- [x] FAQ page renders with 8 questions and links to docs

## Risk assessment

Low. All changes are additive (new "Next steps" sections at the bottom of pages, expanded FAQ). No existing URLs are renamed or moved.