### PR TITLE
docs: professionalize website homepage and navigation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,113 @@
+---
+title: "Kapitan: Configuration management for complex infrastructure"
+description: "Kapitan is an open source configuration management tool that helps teams generate, organize, reuse, validate, and manage Kubernetes, Terraform, and other configuration across environments using inventory, templates, and references."
+---
+
 # :kapitan-logo: **Kapitan: Keep your ship together**
 
 ![GitHub Sponsors](https://img.shields.io/github/sponsors/kapicorp?style=for-the-badge)
 ![GitHub Stars](https://img.shields.io/github/stars/kapicorp/kapitan?style=for-the-badge)
 
-**Kapitan** aims to be your *one-stop configuration management solution* to help you manage the ever growing complexity of your configurations by enabling **Platform Engineering** and **GitOps** workflows.
+**Kapitan** is an open source configuration management tool for complex infrastructure systems. It helps teams generate, organize, reuse, validate, and manage Kubernetes, Terraform, and other configuration across environments using inventory, templates, Jsonnet, Jinja2, Kadet, Helm, Kustomize, CUE, and external references.
 
-It streamlines complex deployments across heterogeneous environments while providing a secure and adaptable framework for managing infrastructure configurations.  **Kapitan**'s inventory-driven model, powerful templating capabilities, and native secret management tools offer granular control, fostering consistency, reducing errors, and safeguarding sensitive data.
+<div class="grid cards" markdown>
 
-Empower your team to make changes to your infrastructure whilst maintaining full control, with a GitOps approach and full transparency.
+-   :material-rocket-launch:{ .lg .middle } **Quick start**
 
-* :fontawesome-brands-slack: Join the community [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3)
-* :fontawesome-brands-github: Help us grow: [give us a star](https://github.com/kapicorp/kapitan/stargazers) or even better [sponsor our project](pages/contribute/sponsor.md)
+    ---
 
-## [Why do I need **Kapitan**?](pages/blog/posts/2022-12-04.md#why-do-i-need-kapitan)
+    Get up and running in minutes with the [getting started guide](getting_started.md) or the [Kapitan Reference repository](https://github.com/kapicorp/kapitan-reference).
 
-## [Video Tutorials to get started](https://www.youtube.com/@kapitandev)
+    [:octicons-arrow-right-24: Getting started](getting_started.md)
+
+-   :material-book-open-variant:{ .lg .middle } **Core concepts**
+
+    ---
+
+    Learn how Kapitan uses inventory, targets, classes, and input types to turn templates into structured output.
+
+    [:octicons-arrow-right-24: Read concepts](pages/core_concepts.md)
+
+-   :material-code-tags:{ .lg .middle } **Examples**
+
+    ---
+
+    Explore working examples in the Kapitan Reference repository, covering Kubernetes, Terraform, and multiple input types.
+
+    [:octicons-arrow-right-24: Kapitan Reference](https://github.com/kapicorp/kapitan-reference)
+
+-   :material-handshake:{ .lg .middle } **Contribute**
+
+    ---
+
+    Help improve Kapitan by contributing code, documentation, or feedback. We welcome pull requests and issue reports.
+
+    [:octicons-arrow-right-24: How to contribute](pages/contribute/code.md)
+
+</div>
+
+## What Kapitan does
+
+Kapitan turns a hierarchical **inventory** and a set of **input templates** into compiled configuration files ready for deployment. You define reusable classes, per-environment targets, and parameters in YAML. Kapitan compiles them into Kubernetes manifests, Terraform plans, scripts, documentation, or any text-based output you need.
+
+```mermaid
+graph LR
+    A["Inventory\n(classes + targets)"] --> B["kapitan compile"]
+    C["Input types\n(Jsonnet, Jinja, Helm, Kustomize, CUE, Kadet)"] --> B
+    D["References\n(secrets)"] --> B
+    B --> E["Compiled output\n(manifests, plans, scripts)"]
+```
+
+## When Kapitan fits
+
+- You manage the same application across many environments (dev, staging, prod, regions) and need a single source of truth.
+- You want to reuse configuration fragments (classes) across targets without copy-paste.
+- You need to combine multiple templating tools (Helm, Kustomize, Jsonnet, Jinja2, Python, CUE) in one pipeline.
+- You want native secret management (GPG, Vault, AWS KMS, GCP KMS, Azure Key Vault) embedded in the same workflow.
+- You prefer a GitOps-friendly compile step that generates fully rendered output before deployment.
+
+## When another tool may be enough
+
+- **Helm alone** is sufficient if you only need to template a single chart with values files and do not share complex configuration across many services.
+- **Kustomize alone** is sufficient if your environment differences are mostly patches and overlays on a small set of bases.
+- **Plain YAML with a CD tool** is sufficient if you have very few environments and simple configuration with little reuse.
+- **Terraform alone** is sufficient if you only manage infrastructure resources and do not need a broader multi-language configuration layer.
+
+## Install and try
+
+### Docker (recommended)
+
+```shell
+alias kapitan="docker run -t --rm -v $(pwd):/src:delegated kapicorp/kapitan"
+kapitan compile -h
+```
+
+### Pip
+
+```shell
+pip3 install --user --upgrade kapitan
+```
+
+Kapitan requires Python 3.10 or newer.
+
+[:octicons-arrow-right-24: Full installation guide](getting_started.md)
+
+## Trust and community
+
+- **Open source** — MIT license, actively maintained by [KapiCorp](https://github.com/kapicorp).
+- **Releases** — regular tagged releases with release notes on [GitHub](https://github.com/kapicorp/kapitan/releases).
+- **Community** — ask questions and share patterns in the [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3) Slack channel.
+- **Related projects** — [Tesoro](https://github.com/kapicorp/tesoro) (Kubernetes admission controller for Kapitan secrets) and [Kapitan Reference](https://github.com/kapicorp/kapitan-reference) (working examples).
+
+[:fontawesome-brands-github: View on GitHub](https://github.com/kapicorp/kapitan) · [:fontawesome-brands-slack: Join #kapitan](https://kubernetes.slack.com/archives/C981W2HD3) · [:material-heart: Sponsor us](pages/contribute/sponsor.md)
+
+## Learn more
+
+### Why Kapitan?
+
+Read the original motivation and design thinking in the blog post: [Why do I need **Kapitan**?](pages/blog/posts/2022-12-04.md#why-do-i-need-kapitan)
+
+### Video tutorials
 
 !!! info "[Kapitan Youtube Channel](https://www.youtube.com/@kapitandev)"
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -103,7 +103,7 @@ Compiled echo-server (0.14s)
 === "Linux"
 
     ```shell
-    sudo apt-get update && sudo apt-get install -y python3.8-dev python3-pip python3-yaml
+    sudo apt-get update && sudo apt-get install -y python3-dev python3-pip python3-yaml
     ```
 
 === "Mac"
@@ -121,7 +121,7 @@ Compiled echo-server (0.14s)
 === "Linux"
 
     !!! note ""
-        `kapitan` will be installed in `$HOME/.local/lib/python3.7/bin`
+        `kapitan` will be installed in `$HOME/.local/lib/python3.x/bin`
 
     ```shell
     pip3 install --user --upgrade kapitan
@@ -130,7 +130,7 @@ Compiled echo-server (0.14s)
 === "Mac"
 
     !!! note ""
-        `kapitan` will be installed in `$HOME/Library/Python/3.7/bin`
+        `kapitan` will be installed in `$HOME/Library/Python/3.x/bin`
 
     ```shell
     pip3 install --user --upgrade kapitan

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,6 @@ nav:
           - CueLang: pages/input_types/cuelang.md
           - Helm: pages/input_types/helm.md
           - Kustomize: pages/input_types/kustomize.md
-          - Cuelang: pages/input_types/cuelang.md
           - Jsonnet: pages/input_types/jsonnet.md
           - External: pages/input_types/external.md
           - Copy: pages/input_types/copy.md


### PR DESCRIPTION
## Summary

Rewrites the website homepage (`docs/README.md`) to function as a professional product landing page rather than a minimal intro. Also fixes a duplicate navigation entry and outdated Python version references in the getting started guide.

## Motivation

The current homepage answers "what is Kapitan?" only vaguely. A visitor arriving from search or a referral link should immediately understand the project scope, who it serves, when to choose it, and where to go next. This change addresses that without duplicating the full documentation.

## Affected URLs and files

- `docs/README.md` — homepage rewrite
- `docs/getting_started.md` — Python version fixes (3.8/3.7 → generic 3.x)
- `mkdocs.yml` — removed duplicate Cuelang navigation entry

Generated URL: https://kapitan.dev/

## User-facing impact

- Homepage now includes:
  - One-sentence product definition
  - Audience statement
  - Four routed action cards (quick start, concepts, examples, contribute)
  - "When Kapitan fits" guidance
  - "When another tool may be enough" guidance
  - Quick install command block
  - Trust and community links
  - Mermaid workflow diagram
- No existing URLs are renamed or moved.

## SEO impact

- Page gains a clear `<h1>` structure and semantic sections.
- Internal links to high-value docs pages increase crawl depth.
- No meta tags yet (reserved for a follow-up PR focused on metadata and social previews).

## Screenshots / rendered examples

Build tested with `uv run mkdocs build --strict`.

## Test plan

- [x] `uv run mkdocs build --strict` passes without errors
- [x] No new warnings except pre-existing `tags.md` nav omission
- [x] Internal links resolve to existing documentation files

## Risk assessment

Low. Content changes only. No URL moves. The duplicate nav removal is a safe cleanup.

## Follow-up work intentionally left out

- Open Graph / social card metadata will be handled in a dedicated PR.
- Links to `pages/kubernetes_configuration_management.md` and `pages/kapitan_vs_helm_kustomize.md` are omitted because those pages are introduced in PR #1470. Once #1470 is merged, the homepage cards can be updated to link to them.