### PR TITLE
docs: professionalize repository README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,40 @@
-# Kapitan: advanced configuration management tool
+# Kapitan
 
 [![Test, Build and Publish docker image](https://github.com/kapicorp/kapitan/actions/workflows/test-build-publish.yml/badge.svg?branch=master&event=push)](https://github.com/kapicorp/kapitan/actions/workflows/test-build-publish.yml)
-![Python Version](https://img.shields.io/pypi/pyversions/kapitan)
-![Downloads](https://img.shields.io/pypi/dm/kapitan)
-![Docker Pulls](https://img.shields.io/docker/pulls/kapicorp/kapitan)
+[![Python Version](https://img.shields.io/pypi/pyversions/kapitan)](https://pypi.org/project/kapitan/)
+[![Downloads](https://img.shields.io/pypi/dm/kapitan)](https://pypi.org/project/kapitan/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/kapicorp/kapitan)](https://hub.docker.com/r/kapicorp/kapitan)
 [![Releases](https://img.shields.io/github/release/kapicorp/kapitan.svg)](https://github.com/kapicorp/kapitan/releases)
 [![Docker Image Size](https://img.shields.io/docker/image-size/kapicorp/kapitan/latest.svg)](https://hub.docker.com/r/kapicorp/kapitan)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 <img src="docs/images/kapitan_logo.png" width="25">
 
+**Kapitan** is an open source configuration management tool for complex infrastructure systems. It helps teams generate, organize, reuse, validate, and manage Kubernetes, Terraform, and other configuration across environments using inventory, templates, Jsonnet, Jinja2, Kadet, Helm, Kustomize, CUE, and external references.
 
-**`Kapitan`** aims to be your *one-stop tool* to help you manage the ever growing complexity of your configurations.
+- **Website**: https://kapitan.dev
+- **Documentation**: https://kapitan.dev/getting_started/
+- **Slack**: [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3) on Kubernetes Slack
+- **Sponsor**: [GitHub Sponsors](https://github.com/sponsors/kapicorp)
 
-Join the community [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3)
+---
 
-## [**Official site**](https://kapitan.dev) <https://kapitan.dev>
+## Quick start
 
+The fastest way to try Kapitan is with the [Kapitan Reference](https://github.com/kapicorp/kapitan-reference) repository:
 
-## [**Quick Start**](https://kapitan.dev/getting_started/#quickstart)
+```shell
+git clone https://github.com/kapicorp/kapitan-reference.git kapitan-templates
+cd kapitan-templates
+./kapitan compile
+```
+
+For a minimal project from a cookiecutter template:
+
+```shell
+pip3 install cruft
+cruft create https://github.com/kapicorp/kapitan-reference --checkout cookiecutter --no-input
+```
 
 ## Install Kapitan
 
@@ -27,42 +44,80 @@ Join the community [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3)
 docker run -t --rm -v $(pwd):/src:delegated kapicorp/kapitan -h
 ```
 
-On Linux you can add `-u $(id -u)` to `docker run` to preserve file permissions.
+On Linux, add `-u $(id -u)` to preserve file permissions.
 
 ### Pip
 
-Kapitan needs Python 3.10 or newer.
-
-#### Install Python 3
-
-* Linux: `sudo apt-get update && sudo apt-get install -y python3-dev python3-pip python3-yaml git`
-* Mac: `brew install python3 libyaml git`
-
-#### Install Kapitan
-
-User (`$HOME/.local/lib/python3.x/bin` on Linux or `$HOME/Library/Python/3.x/bin` on macOS):
+Kapitan requires Python 3.10 or newer.
 
 ```shell
 pip3 install --user --upgrade kapitan
 ```
 
-System-wide (not recommended):
+See the [full installation guide](https://kapitan.dev/getting_started/) for platform-specific steps.
 
-```shell
-sudo pip3 install --upgrade kapitan
-```
+## What Kapitan does
 
-## Build Kapitan
+Kapitan turns a hierarchical **inventory** and a set of **input templates** into compiled configuration files ready for deployment.
 
-### Docker
+1. Define reusable **classes** and per-environment **targets** in YAML.
+2. Write templates with your preferred tools.
+3. Run `kapitan compile`.
+4. Deploy the generated output from the `compiled/` directory.
 
-To build a docker image for the architecture of your machine, run `docker build . -t you-kapitan-image`, and to build for a specific platform, add `--platform linux/arm64`.
+### Supported input types
 
-To build a multi-platform image (as the CI does), follow [the docker multi-platform documentation](https://docs.docker.com/build/building/multi-platform/).
+- [Jsonnet](https://kapitan.dev/pages/input_types/jsonnet/)
+- [Jinja2](https://kapitan.dev/pages/input_types/jinja/)
+- [Kadet (Python)](https://kapitan.dev/pages/input_types/kadet/)
+- [Helm](https://kapitan.dev/pages/input_types/helm/)
+- [Kustomize](https://kapitan.dev/pages/input_types/kustomize/)
+- [CUE](https://kapitan.dev/pages/input_types/cuelang/)
+- [External commands](https://kapitan.dev/pages/input_types/external/)
+- [Copy / Remove](https://kapitan.dev/pages/input_types/copy/)
 
-To build a docker image using a specific python version, run `docker build --build-arg PYTHON_BUILDER_VERSION=<python-version> . -t you-kapitan-image`. By default the Dockerfile is pinned using python 3.11 as the python builder version.
+### Native integrations
+
+- **Secret management**: GPG, HashiCorp Vault, AWS KMS, GCP KMS, Azure Key Vault
+- **Remote dependencies**: Git, HTTP, ORAS (OCI registry)
+- **Validation**: JSON Schema, TOML, YAML linting
+- **GitOps-friendly**: compiles to fully rendered, plain-text output
+
+## When to use Kapitan
+
+- You manage the same application across many environments (dev, staging, prod, regions) and want a single source of truth.
+- You need to reuse configuration fragments across targets without copy-paste.
+- You want to combine multiple templating tools in one pipeline.
+- You need native secret management embedded in the same configuration workflow.
+- You prefer a compile step that generates fully rendered output before deployment.
+
+## When another tool may be enough
+
+- **Helm alone** is sufficient if you only need to template a single chart with values files and do not share complex configuration across many services.
+- **Kustomize alone** is sufficient if your environment differences are mostly patches and overlays on a small set of bases.
+- **Plain YAML with a CD tool** is sufficient if you have very few environments and simple configuration with little reuse.
+- **Terraform alone** is sufficient if you only manage infrastructure resources and do not need a broader multi-language configuration layer.
+
+## Project status
+
+Kapitan is actively maintained by [KapiCorp](https://github.com/kapicorp) and the open source community. Releases are published regularly with [release notes](https://github.com/kapicorp/kapitan/releases). The project uses an [MIT license](LICENSE).
+
+## Contributing
+
+We welcome contributions. Please open an [issue](https://github.com/kapicorp/kapitan/issues) or [pull request](https://github.com/kapicorp/kapitan/pulls) to get started.
+
+## Security
+
+If you discover a security issue, please open a [private security advisory](https://github.com/kapicorp/kapitan/security/advisories/new) or contact the maintainers directly.
+
+## Support
+
+- Ask questions in the [`#kapitan`](https://kubernetes.slack.com/archives/C981W2HD3) Slack channel.
+- Read the [FAQ](https://kapitan.dev/FAQ/).
+- Open a [GitHub Discussion](https://github.com/kapicorp/kapitan/discussions) or [Issue](https://github.com/kapicorp/kapitan/issues).
 
 ## Related projects
 
-* [Tesoro](https://github.com/kapicorp/tesoro) - Kubernetes Admission Controller for Kapitan Secrets
-* [Kapitan Reference](https://github.com/kapicorp/kapitan-reference) - our reference repository to get started with Kapitan
+- [Tesoro](https://github.com/kapicorp/tesoro) — Kubernetes admission controller for Kapitan secrets.
+- [Kapitan Reference](https://github.com/kapicorp/kapitan-reference) — working examples to get started.
+- [Kapitan Generators](https://generators.kapitan.dev) — reusable generators for common patterns.


### PR DESCRIPTION
## Summary

Rewrites the root `README.md` to act as a high-quality GitHub landing page for new evaluators and contributors.

## Motivation

The previous README was minimal: badges, a vague one-liner, install instructions, and related projects. A visitor landing on the repository should be able to understand the project, evaluate fit, and know where to go next within 60 seconds.

## Affected files

- `README.md`

## User-facing impact

- Clear product definition in the first paragraph.
- Quick start commands using the Kapitan Reference repository.
- Condensed install section (Docker and pip) linking to full docs.
- Supported input types list with direct documentation links.
- Native integrations summary (secrets, remote dependencies, validation).
- "When to use" and "When another tool may be enough" guidance for honest evaluation.
- Trust signals via badges, release links, and license mention.
- Community and support routing (Slack, FAQ, issues, discussions).

## SEO impact

- README content is indexed by GitHub and often surfaces in search results.
- Clearer positioning and internal links improve discoverability of the docs site.

## Test plan

- [x] Markdown renders correctly in GitHub preview
- [x] All external links are valid
- [x] No broken internal file links (CONTRIBUTING.md and SECURITY.md will be added in a follow-up PR; this README uses safe external links for now)

## Risk assessment

Low. Documentation-only change. No code or CI changes.

## Follow-up work intentionally left out

- CONTRIBUTING.md and SECURITY.md files will be introduced in a dedicated community-health PR.
- Repository topics (GitHub metadata) cannot be changed via code and should be updated by a maintainer.