### PR TITLE
docs: add Open Graph, Twitter Cards, and structured data metadata

### DIFF
--- a/docs/pages/contribute/code.md
+++ b/docs/pages/contribute/code.md
@@ -2,6 +2,8 @@
 comments: true
 tags:
   - community
+title: "Contribute to Kapitan"
+description: "Guidelines for contributing code to Kapitan, from opening issues and pull requests to development setup and testing."
 ---
 # :kapitan-logo: **Kapitan** code
 

--- a/docs/pages/input_types/kustomize.md
+++ b/docs/pages/input_types/kustomize.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan Kustomize Input Type"
+description: "Use Kustomize within Kapitan to patch and customize Kubernetes manifests across environments."
+---
+
 # Kustomize Input Type
 
 The Kustomize input type allows you to use [Kustomize](https://kustomize.io/) to manage and customize Kubernetes manifests within Kapitan. This input type is particularly useful when you need to:

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan Support"
+description: "Get help with Kapitan through the community Slack channel, GitHub discussions, and documentation resources."
+---
+
 # :kapitan-logo: **Get support with Kapitan**
 
 ## Community

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -3,22 +3,22 @@
 {% block extrahead %}
   {{ super() }}
 
-  <!-- Open Graph -->
+  {# Open Graph #}
+  <meta property="og:type" content="website" />
   <meta property="og:title" content="{{ (page.meta or {}).get('title', page.title) }}" />
   <meta property="og:description" content="{{ (page.meta or {}).get('description', config.site_description) }}" />
-  <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ page.canonical_url }}" />
   <meta property="og:image" content="{{ config.site_url }}images/kapitan_logo.png" />
   <meta property="og:site_name" content="{{ config.site_name }}" />
 
-  <!-- Twitter Cards -->
-  <meta name="twitter:card" content="summary" />
+  {# Twitter Cards #}
+  <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="{{ (page.meta or {}).get('title', page.title) }}" />
   <meta name="twitter:description" content="{{ (page.meta or {}).get('description', config.site_description) }}" />
   <meta name="twitter:image" content="{{ config.site_url }}images/kapitan_logo.png" />
 
   {% if page.is_homepage %}
-  <!-- JSON-LD structured data for homepage -->
+  {# JSON-LD structured data for homepage #}
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -47,15 +47,18 @@
         "@type": "SoftwareApplication",
         "@id": "{{ config.site_url }}#kapitan",
         "name": "Kapitan",
+        "description": "{{ config.site_description }}",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Linux, macOS, Windows",
+        "softwareVersion": "{{ config.extra.version.provider if config.extra and config.extra.version else '' }}",
+        "license": "https://github.com/kapicorp/kapitan/blob/master/LICENSE",
+        "url": "{{ config.site_url }}",
+        "sameAs": "https://github.com/kapicorp/kapitan",
         "offers": {
           "@type": "Offer",
           "price": "0",
           "priceCurrency": "USD"
-        },
-        "url": "{{ config.site_url }}",
-        "sameAs": "https://github.com/kapicorp/kapitan"
+        }
       }
     ]
   }
@@ -65,15 +68,13 @@
 
 {% block scripts %}
   {{ super() }}
-   <!-- Google Tag Manager (noscript) -->
-   <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WPN4JBMH"
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-WPN4JBMH"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
+  <!-- End Google Tag Manager (noscript) -->
 {% endblock %}
 
- {% block content %}
-
-
+{% block content %}
   <!-- Edit button -->
   {% if page.edit_url %}
   <a
@@ -83,6 +84,6 @@
   >
       {% include ".icons/material/pencil.svg" %}
   </a>
-{% endif %}
-{{ page.content }}
+  {% endif %}
+  {{ page.content }}
 {% endblock %}


### PR DESCRIPTION
## Summary

Adds social preview metadata (Open Graph, Twitter Cards) and basic JSON-LD structured data to the Kapitan documentation site.

## Motivation

When links to the Kapitan docs are shared on Slack, LinkedIn, Mastodon, or other platforms, the preview should show a professional title, description, and image rather than a generic or blank card. This PR implements that and establishes a metadata convention for future pages.

## Affected files

- `overrides/main.html` — adds Open Graph, Twitter Card, and JSON-LD tags while preserving existing GTM and edit button blocks
- `docs/README.md` — adds frontmatter title and description
- `docs/getting_started.md` — adds frontmatter
- `docs/pages/core_concepts.md` — adds frontmatter
- `docs/FAQ.md` — adds frontmatter
- `docs/references.md` — adds frontmatter
- `docs/pages/input_types/introduction.md` — adds frontmatter
- `docs/pages/input_types/jsonnet.md` — adds frontmatter
- `docs/pages/input_types/helm.md` — adds frontmatter
- `docs/pages/input_types/kustomize.md` — adds frontmatter
- `docs/pages/inventory/introduction.md` — adds frontmatter
- `docs/support.md` — adds frontmatter
- `docs/pages/contribute/code.md` — adds frontmatter

## User-facing impact

- Priority documentation pages now render unique, accurate social previews.
- Homepage includes `SoftwareApplication` JSON-LD structured data.
- No visual changes to the site itself.

## SEO impact

- Open Graph and Twitter Card metadata improve click-through rates from social shares.
- JSON-LD helps search engines understand the project type and properties.
- Unique descriptions per page avoid duplicate meta content penalties.

## Test plan

- [x] `uv run mkdocs build --strict` passes without errors
- [x] Generated HTML contains `og:title`, `og:description`, `og:image` on priority pages
- [x] Generated HTML contains `twitter:card` and related tags
- [x] Homepage contains JSON-LD `SoftwareApplication` script
- [x] Existing Google Tag Manager noscript and edit button functionality are preserved

## Risk assessment

Low. Changes are additive metadata in HTML head and YAML frontmatter. Existing template blocks are preserved.

## Follow-up work intentionally left out

- A dedicated 1200x630 landscape social preview image would look more professional than the current square logo. This can be added later by updating `og:image` and `twitter:image`.
- Additional structured data types (e.g., `TechArticle` for blog posts, `FAQPage` for FAQ) are not included yet.
- Pages introduced in PR #1470 will need frontmatter added once merged.