### PR TITLE
docs: add ArgoCD CMP/FluxCD integration guide

### DIFF
--- a/docs/pages/argocd.md
+++ b/docs/pages/argocd.md
@@ -1,0 +1,93 @@
+# :kapitan-logo: ArgoCD Integration
+
+Kapitan can be used as an [ArgoCD Config Management Plugin (CMP)](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/).
+
+## Prerequisites
+
+- ArgoCD v2.8+
+- The `kapicorp/kapitan` image accessible from your cluster
+
+## Setup
+
+Add a Kapitan sidecar to the ArgoCD repo-server. The sidecar must:
+
+- Run the `kapicorp/kapitan` image
+- Start with `/var/run/argocd/argocd-cmp-server` (copied from the ArgoCD image via an init container)
+- Mount a CMP plugin config that defines a `generate` command for Kapitan
+
+### CMP plugin config
+
+The `generate` command should produce Kubernetes manifests from your compiled output. A typical script concatenates the generated YAML files and runs `kapitan refs --reveal` to decrypt secrets:
+
+```bash
+rm -rf all_manifests.yml
+for f in *.yml; do
+  echo '---' >> all_manifests.yml
+  cat "$f" >> all_manifests.yml
+done
+kapitan refs --reveal --file all_manifests.yml
+```
+
+A minimal Helm values snippet:
+
+```yaml
+configs:
+  cmp:
+    plugins:
+      kapitan:
+        generate:
+          command: [bash, -c]
+          args:
+            - |
+              rm -rf all_manifests.yml
+              for f in *.yml; do
+                echo '---' >> all_manifests.yml
+                cat "$f" >> all_manifests.yml
+              done
+              kapitan refs --reveal --file all_manifests.yml
+
+repoServer:
+  extraContainers:
+    - name: kapitan
+      image: kapicorp/kapitan
+      command: [/var/run/argocd/argocd-cmp-server]
+      volumeMounts:
+        - mountPath: /var/run/argocd
+          name: var-files
+        - mountPath: /home/argocd/cmp-server/plugins
+          name: plugins
+        - mountPath: /home/argocd/cmp-server/config/plugin.yaml
+          name: cmp-plugin
+          subPath: plugin.yaml
+```
+
+See the [ArgoCD CMP documentation](https://argo-cd.readthedocs.io/en/stable/operator-manual/config-management-plugins/) for the full sidecar wiring.
+
+## Application
+
+Create an ArgoCD Application that uses the plugin:
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: my-kapitan-app
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/example/kapitan-project.git
+    targetRevision: main
+    path: compiled/my-target
+    plugin:
+      name: kapitan
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+Update `spec.source.repoURL` and `spec.source.path` to match your repository and compiled target output.

--- a/docs/pages/fluxcd.md
+++ b/docs/pages/fluxcd.md
@@ -1,0 +1,63 @@
+# :kapitan-logo: FluxCD Integration
+
+Kapitan works with [FluxCD](https://fluxcd.io) by compiling manifests in CI and publishing them as [OCI artifacts](https://fluxcd.io/flux/cheatsheets/oci-artifacts/). FluxCD pulls the artifact and applies it to the cluster.
+
+## Prerequisites
+
+- FluxCD v2.0+
+- `flux` CLI installed in your CI pipeline
+
+## Workflow
+
+1. CI runs `kapitan compile`
+2. CI pushes the `compiled/` directory as an OCI artifact
+3. FluxCD pulls the artifact and applies it
+
+## CI
+
+Push the compiled output with the `flux` CLI:
+
+```shell
+kapitan compile
+flux push artifact oci://ghcr.io/org/app-manifests:$(git rev-parse --short HEAD) \
+  --path="./compiled" \
+  --source="$(git config --get remote.origin.url)" \
+  --revision="$(git branch --show-current)@sha1:$(git rev-parse HEAD)"
+```
+
+## FluxCD Resources
+
+Pull the artifact:
+
+```yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: app-manifests
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: oci://ghcr.io/org/app-manifests
+  ref:
+    tag: latest
+```
+
+Apply it:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: app
+  namespace: flux-system
+spec:
+  interval: 10m
+  sourceRef:
+    kind: OCIRepository
+    name: app-manifests
+  path: ./
+  prune: true
+  wait: true
+```
+
+See the [FluxCD OCI cheatsheet](https://fluxcd.io/flux/cheatsheets/oci-artifacts/) for tagging strategies, cosign signing, and verification.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
         - External dependencies: pages/external_dependencies.md
         - Publishing generators: pages/publishing_generators.md
         - ArgoCD integration: pages/argocd.md
+        - FluxCD integration: pages/fluxcd.md
       - CLI reference:
           - compile: pages/commands/kapitan_compile.md
           - inventory: pages/commands/kapitan_inventory.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
         - Remote repositories: pages/remote_repositories.md
         - External dependencies: pages/external_dependencies.md
         - Publishing generators: pages/publishing_generators.md
+        - ArgoCD integration: pages/argocd.md
       - CLI reference:
           - compile: pages/commands/kapitan_compile.md
           - inventory: pages/commands/kapitan_inventory.md


### PR DESCRIPTION
## Summary

Adds documentation for integrating Kapitan with ArgoCD and FluxCD.

- ArgoCD: minimal CMP sidecar configuration and example Application manifest
- FluxCD: CI-time compilation workflow and OCI artifact publishing

Closes #926
Closes #927