### PR TITLE
feat: discover generator-provided schema.json for dependency validation

### DIFF
--- a/docs/pages/external_dependencies.md
+++ b/docs/pages/external_dependencies.md
@@ -235,6 +235,8 @@ Kapitan also supports caching Use the `--cache` flag to cache the fetched items 
           subpath: relative/path/inside/artifact # mkdocs (3)!
           insecure: false # mkdocs (4)!
           tls_verify: true # mkdocs (5)!
+          schema_path: path/to/schema.json # mkdocs (6)!
+          schema_inventory_path: parameters.components.mygenerator # mkdocs (7)!
     ```
 
     1. Directory where the pulled artifact contents will be written.
@@ -242,6 +244,8 @@ Kapitan also supports caching Use the `--cache` flag to cache the fetched items 
     3. Optional sub-directory inside the pulled artifact to copy instead of the entire artifact root. Required when the artifact was pushed from a parent directory (oras preserves push-time paths).
     4. Set to `true` to allow pulling from an HTTP (non-TLS) registry. Defaults to `false`. Note: this is distinct from TLS certificate verification use `tls_verify` for self-signed certificates.
     5. Controls TLS certificate verification. Set to `false` to skip verification (e.g. self-signed certs in dev), or provide a path to a custom CA bundle as a string (e.g. `"/etc/ssl/certs/my-ca.crt"`). Defaults to `true`.
+    6. Optional path to a JSON Schema file for this dependency. If omitted, Kapitan looks for `<output_path>/schema.json`.
+    7. Optional dot-separated inventory path (e.g. `parameters.components.argocd`) that the schema validates. See [Generator schema validation](generator_schema_validation.md).
 
     !!! note
 

--- a/docs/pages/generator_schema_validation.md
+++ b/docs/pages/generator_schema_validation.md
@@ -1,3 +1,8 @@
+---
+title: Generator schema validation in Kapitan
+description: Ship a JSON Schema alongside a generator so Kapitan validates the relevant inventory input at compile time, catching type and key mistakes early.
+---
+
 # Generator schema validation
 
 Generator authors can ship a JSON Schema alongside their generator code so that Kapitan validates the relevant inventory input at compile time. This catches common mistakes (wrong types, missing keys) before rendering starts.

--- a/docs/pages/generator_schema_validation.md
+++ b/docs/pages/generator_schema_validation.md
@@ -1,0 +1,197 @@
+# Generator schema validation
+
+Generator authors can ship a JSON Schema alongside their generator code so that Kapitan validates the relevant inventory input at compile time. This catches common mistakes (wrong types, missing keys) before rendering starts.
+
+---
+
+## How it works
+
+After fetching a target's dependencies, Kapitan looks for a `schema.json` file next to each dependency's fetched contents. If the file exists, Kapitan validates the inventory subtree defined by `schema_inventory_path` against it.
+
+Findings are emitted as **warnings by default** so existing inventories keep compiling. You can opt into **error** mode for CI or **info** mode for quieter output.
+
+---
+
+## For generator authors
+
+Place a `schema.json` file in the root of the directory you publish. For a Kadet generator the bundle would look like this:
+
+```text
+my-generator/
+├── __init__.py
+├── lib/
+│   └── utils.py
+└── schema.json
+```
+
+The schema is normal [JSON Schema](https://json-schema.org/). A minimal example:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "namespace": {
+      "type": "string",
+      "minLength": 1
+    },
+    "syncPolicy": {
+      "type": "object",
+      "properties": {
+        "automated": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}
+```
+
+Keep reusable definitions inside the same file using `$defs` so consumers only need the single file.
+
+### Generating a schema
+
+You can write the schema by hand or generate it from code:
+
+- **Python / Pydantic** — if your generator already uses Pydantic models for its input, call `Model.model_json_schema()` and save the result as `schema.json`.
+- **TypeScript** — use `typescript-json-schema` to emit a schema from an interface or type definition.
+- **JSON sample data** — tools such as `genson` or online generators can infer a draft schema from representative inventory YAML/JSON.
+
+Whatever approach you choose, keep the schema in the repository that defines the generator so it is versioned together with the code.
+
+---
+
+## For consumers
+
+### Default discovery
+
+If you do not configure anything extra, Kapitan checks `<output_path>/schema.json` for every dependency:
+
+```yaml
+parameters:
+  kapitan:
+    dependencies:
+      - type: git
+        source: https://example.com/org/generators.git
+        ref: argocd-v1.0.4
+        subdir: argocd
+        output_path: lib/argocd
+```
+
+Kapitan looks for `lib/argocd/schema.json` after fetching.
+
+### Override the schema path
+
+If the schema lives elsewhere, set `schema_path` on the dependency:
+
+```yaml
+parameters:
+  kapitan:
+    dependencies:
+      - type: git
+        source: https://example.com/org/generators.git
+        ref: argocd-v1.0.4
+        subdir: argocd
+        output_path: lib/argocd
+        schema_path: lib/argocd/my/path/schema.json
+```
+
+### Define the inventory subtree to validate
+
+By default Kapitan does not know which part of the inventory a schema applies to. Use `schema_inventory_path` to point to the relevant subtree:
+
+```yaml
+parameters:
+  kapitan:
+    dependencies:
+      - type: git
+        source: https://example.com/org/generators.git
+        ref: argocd-v1.0.4
+        subdir: argocd
+        output_path: lib/argocd
+        schema_inventory_path: parameters.components.argocd
+```
+
+The path is a dot-separated key path starting from the root of the merged target parameters.
+
+### Validation severity
+
+Control the behaviour per target with `generator_schema_validation`:
+
+```yaml
+parameters:
+  kapitan:
+    generator_schema_validation: warn
+```
+
+| Value | Behaviour |
+|---|---|
+| `warn` (default) | Log findings as warnings; compilation continues. |
+| `error` | Collect all violations, then raise `CompileError` on the first dependency that has errors; compilation stops. |
+| `info` | Log findings at info level; compilation continues. |
+| `disabled` | Skip validation entirely. |
+
+You can set this globally in a shared class or per target.
+
+---
+
+## Discovery rule
+
+For every dependency entry under `parameters.kapitan.dependencies`:
+
+1. Fetch the dependency as Kapitan already does.
+2. Determine the candidate schema path:
+   - use `schema_path` if set
+   - otherwise use `<output_path>/schema.json`
+3. If the file does not exist, skip schema validation for that dependency.
+4. If the file exists, load it as JSON Schema.
+5. Validate the inventory subtree indicated by `schema_inventory_path`.
+6. Emit diagnostics according to `generator_schema_validation`.
+
+---
+
+## Example warning
+
+With `generator_schema_validation: warn` and an inventory like:
+
+```yaml
+parameters:
+  components:
+    argocd:
+      syncPolicy:
+        automated: "true"
+```
+
+Kapitan logs:
+
+```text
+E-argocd.type
+
+parameters.components.argocd.syncPolicy.automated must satisfy schema constraint
+  Problem: 'true' is not of type 'boolean'
+  Schema: /home/user/project/lib/argocd/schema.json
+
+inventory/classes/argocd.yml:5:20
+
+  3 |     argocd:
+  4 |       syncPolicy:
+> 5 |         automated: "true"
+  6 |
+```
+
+When the source file cannot be found (e.g. the value is computed or inherited without a direct YAML source), Kapitan still prints the error code, key path, problem, and schema path. Source locations are reported only for exact key matches in the inventory YAML files.
+
+---
+
+## Compatibility
+
+- Dependencies without a `schema.json` continue to work unchanged.
+- Missing `schema_inventory_path` skips validation for that dependency.
+- If `schema_inventory_path` is configured but does not exist in the merged inventory, Kapitan logs a warning so you notice the typo.
+- The feature is backward compatible: the default is `warn`, so existing repositories are not broken.
+- No generator metadata file or schema directory convention is required.
+
+## Notes
+
+- **Multiple errors** — When a schema has several violations, Kapitan reports every mismatch for that dependency in one pass so you can fix them all at once.
+- **Source location caching** — YAML files are parsed once per compile pass and cached, so validation stays fast even for large inventories.

--- a/docs/pages/publishing_generators.md
+++ b/docs/pages/publishing_generators.md
@@ -155,3 +155,8 @@ Use `--force-fetch` to invalidate the cache and re-pull regardless.
 
 See [External dependencies OCI](external_dependencies.md#defining-dependencies) for the full
 reference of available fields.
+
+!!! tip "Ship a schema with your generator"
+    You can include a `schema.json` file in the bundle root so consumers get
+    automatic inventory validation. See
+    [Generator schema validation](generator_schema_validation.md) for details.

--- a/kapitan/dependency_manager/schema_validation.py
+++ b/kapitan/dependency_manager/schema_validation.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class _SourceTrackerCache:
+class SourceTrackerCache:
     """Cache _SourceTracker instances by filepath to avoid re-parsing YAML files."""
 
     def __init__(self):
@@ -113,7 +113,7 @@ class _SourceTracker:
 def _find_source_location(
     full_path: list[str],
     inventory_path: str,
-    tracker_cache: _SourceTrackerCache,
+    tracker_cache: SourceTrackerCache,
 ) -> dict | None:
     """Search inventory YAML files for the source of *full_path*.
 
@@ -173,7 +173,7 @@ def _format_validation_error(
     dependency_output_path: str,
     inventory_dotted_path: str | None,
     inventory_path: str,
-    tracker_cache: _SourceTrackerCache,
+    tracker_cache: SourceTrackerCache,
 ) -> str:
     """Format a single validation error with source context.
 
@@ -225,7 +225,7 @@ def _validate_against_schema(
     dependency_output_path: str,
     inventory_dotted_path: str | None,
     inventory_path: str,
-    tracker_cache: _SourceTrackerCache,
+    tracker_cache: SourceTrackerCache,
 ) -> list[dict]:
     """Validate *data* against the JSON Schema stored at *schema_path*.
 
@@ -284,7 +284,7 @@ def validate_generator_schemas(
     target_obj,
     parameters: dict,
     inventory_path: str,
-    tracker_cache: _SourceTrackerCache | None = None,
+    tracker_cache: SourceTrackerCache | None = None,
 ) -> list[dict]:
     """Validate generator schemas for a single target.
 
@@ -300,7 +300,7 @@ def validate_generator_schemas(
     ``dependency``, ``schema_path``, ``inventory_path``, ``errors``.
     """
     if tracker_cache is None:
-        tracker_cache = _SourceTrackerCache()
+        tracker_cache = SourceTrackerCache()
 
     findings = []
 

--- a/kapitan/dependency_manager/schema_validation.py
+++ b/kapitan/dependency_manager/schema_validation.py
@@ -1,0 +1,341 @@
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generator schema discovery and validation for Kapitan dependencies."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+from jsonschema.validators import validator_for
+
+
+if TYPE_CHECKING:
+    from jsonschema import ValidationError
+
+
+logger = logging.getLogger(__name__)
+
+
+class _SourceTrackerCache:
+    """Cache _SourceTracker instances by filepath to avoid re-parsing YAML files."""
+
+    def __init__(self):
+        self._cache: dict[Path, _SourceTracker] = {}
+
+    def get(self, filepath: Path) -> _SourceTracker:
+        if filepath not in self._cache:
+            self._cache[filepath] = _SourceTracker(filepath)
+        return self._cache[filepath]
+
+
+def _resolve_schema_path(dep) -> Path | None:
+    """Resolve the candidate schema file for a dependency.
+
+    Uses ``schema_path`` if set, otherwise falls back to
+    ``<output_path>/schema.json``.  Returns ``None`` if the file does not
+    exist.
+    """
+    if dep.schema_path is not None:
+        candidate = Path(dep.schema_path)
+    else:
+        candidate = Path(dep.output_path) / "schema.json"
+
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def _get_inventory_subtree(parameters: dict, path: str | None):
+    """Resolve a dotted inventory path from *parameters*.
+
+    E.g. ``parameters.components.argocd`` walks into the dict and returns
+    the value at that key path.  Returns ``None`` when *path* is ``None``
+    or any key along the path is missing.
+    """
+    if path is None:
+        return None
+
+    keys = path.split(".")
+    value = parameters
+    for key in keys:
+        if not isinstance(value, dict) or key not in value:
+            return None
+        value = value[key]
+    return value
+
+
+class _SourceTracker:
+    """Scan a YAML file and record dotted key paths mapped to line/column."""
+
+    def __init__(self, filepath: Path):
+        self.filepath = filepath
+        self.locations: dict[str, tuple[int, int, str]] = {}
+        self._scan()
+
+    def _scan(self):
+        try:
+            with self.filepath.open("r", encoding="utf-8") as fh:
+                loader = yaml.SafeLoader(fh)
+                try:
+                    node = loader.get_single_node()
+                finally:
+                    loader.dispose()
+        except Exception:
+            return
+        if node is None:
+            return
+        self._walk(node, [])
+
+    def _walk(self, node, path: list[str]):
+        if isinstance(node, yaml.MappingNode):
+            for key_node, value_node in node.value:
+                key = key_node.value
+                new_path = path + [key]
+                dotted = ".".join(new_path)
+                if isinstance(value_node, yaml.ScalarNode):
+                    self.locations[dotted] = (
+                        value_node.start_mark.line + 1,
+                        value_node.start_mark.column + 1,
+                        value_node.value,
+                    )
+                self._walk(value_node, new_path)
+        elif isinstance(node, yaml.SequenceNode):
+            for idx, item_node in enumerate(node.value):
+                self._walk(item_node, path + [str(idx)])
+
+
+def _find_source_location(
+    full_path: list[str],
+    inventory_path: str,
+    tracker_cache: _SourceTrackerCache,
+) -> dict | None:
+    """Search inventory YAML files for the source of *full_path*.
+
+    Returns a dict with ``filepath``, ``line``, ``col``, and ``context``
+    (list of ``(lineno, text)`` tuples) or ``None`` when no source can be
+    determined.
+    """
+    dotted = ".".join(full_path)
+    # Search targets first (more specific) then classes.
+    search_roots = [
+        Path(inventory_path) / "targets",
+        Path(inventory_path) / "classes",
+    ]
+    candidate_files: list[Path] = []
+    for root in search_roots:
+        if not root.is_dir():
+            continue
+        candidate_files.extend(root.rglob("*.yml"))
+        candidate_files.extend(root.rglob("*.yaml"))
+
+    for yaml_file in candidate_files:
+        tracker = tracker_cache.get(yaml_file)
+        if dotted in tracker.locations:
+            line, col, _found_value = tracker.locations[dotted]
+            context = _read_context(yaml_file, line)
+            return {
+                "filepath": str(yaml_file),
+                "line": line,
+                "col": col,
+                "context": context,
+            }
+
+    return None
+
+
+def _read_context(
+    filepath: Path, target_line: int, radius: int = 3
+) -> list[tuple[int, str]]:
+    """Return ``(lineno, text)`` for lines around *target_line* (1-based)."""
+    try:
+        with filepath.open("r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return []
+
+    result = []
+    start = max(0, target_line - radius - 1)
+    end = min(len(lines), target_line + radius)
+    for i in range(start, end):
+        result.append((i + 1, lines[i].rstrip("\n")))
+    return result
+
+
+def _format_validation_error(
+    error: ValidationError,
+    schema_path: str,
+    dependency_output_path: str,
+    inventory_dotted_path: str | None,
+    inventory_path: str,
+    tracker_cache: _SourceTrackerCache,
+) -> str:
+    """Format a single validation error with source context.
+
+    Returns a compiler-style multi-line message.
+    """
+    # Error code: E-<dep-name>.<validator>
+    dep_name = Path(dependency_output_path).name or "generator"
+    validator = error.validator or "validation"
+    error_code = f"E-{dep_name}.{validator}"
+
+    # Build the full key path inside the inventory.
+    json_path = list(error.path)
+    if inventory_dotted_path:
+        full_path = inventory_dotted_path.split(".") + json_path
+    else:
+        full_path = json_path
+    key_path = ".".join(full_path) if full_path else "<root>"
+
+    # Human-readable problem.
+    problem = error.message
+
+    lines: list[str] = [f"{error_code}", ""]
+    lines.append(f"{key_path} must satisfy schema constraint")
+    lines.append(f"  Problem: {problem}")
+    lines.append(f"  Schema: {schema_path}")
+
+    # Try to locate the source file.
+    source = _find_source_location(full_path, inventory_path, tracker_cache)
+    if source:
+        lines.append("")
+        lines.append(f"{source['filepath']}:{source['line']}:{source['col']}")
+        lines.append("")
+
+        max_lineno = max(ln for ln, _ in source["context"])
+        num_width = len(str(max_lineno))
+        for lineno, text in source["context"]:
+            prefix = f"{lineno:>{num_width}} |"
+            if lineno == source["line"]:
+                lines.append(f"> {prefix} {text}")
+            else:
+                lines.append(f"  {prefix} {text}")
+
+    return "\n".join(lines)
+
+
+def _validate_against_schema(
+    data,
+    schema_path: Path,
+    dependency_output_path: str,
+    inventory_dotted_path: str | None,
+    inventory_path: str,
+    tracker_cache: _SourceTrackerCache,
+) -> list[dict]:
+    """Validate *data* against the JSON Schema stored at *schema_path*.
+
+    Returns a list of structured error dicts, each containing
+    ``message``, ``validator``, ``path``, and ``formatted``.
+    """
+    try:
+        with schema_path.open("r", encoding="utf-8") as f:
+            schema = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        return [
+            {
+                "message": f"Failed to load schema from {schema_path}: {e}",
+                "validator": "schema-load",
+                "path": [],
+                "formatted": f"Failed to load schema from {schema_path}: {e}",
+            }
+        ]
+
+    try:
+        ValidatorClass = validator_for(schema)
+        ValidatorClass.check_schema(schema)
+        validator = ValidatorClass(schema)
+    except Exception as e:
+        return [
+            {
+                "message": f"Invalid schema in {schema_path}: {e}",
+                "validator": "schema-invalid",
+                "path": [],
+                "formatted": f"Invalid schema in {schema_path}: {e}",
+            }
+        ]
+
+    errors = []
+    for error in validator.iter_errors(data):
+        formatted = _format_validation_error(
+            error,
+            str(schema_path),
+            dependency_output_path,
+            inventory_dotted_path,
+            inventory_path,
+            tracker_cache,
+        )
+        errors.append(
+            {
+                "message": error.message,
+                "validator": error.validator or "validation",
+                "path": list(error.path),
+                "formatted": formatted,
+            }
+        )
+    return errors
+
+
+def validate_generator_schemas(
+    target_obj,
+    parameters: dict,
+    inventory_path: str,
+    tracker_cache: _SourceTrackerCache | None = None,
+) -> list[dict]:
+    """Validate generator schemas for a single target.
+
+    Iterates over the target's dependencies, discovers any schema files,
+    extracts the configured inventory subtree, and validates it.
+
+    *target_obj* is the target's ``KapitanInventorySettings`` (which holds
+    ``dependencies``).  *parameters* is the full merged ``parameters`` dict
+    for the target.  *inventory_path* is the root inventory directory used
+    to resolve source file locations.
+
+    Returns a list of finding dicts, each with keys:
+    ``dependency``, ``schema_path``, ``inventory_path``, ``errors``.
+    """
+    if tracker_cache is None:
+        tracker_cache = _SourceTrackerCache()
+
+    findings = []
+
+    for dep in target_obj.dependencies or []:
+        schema_path = _resolve_schema_path(dep)
+        if schema_path is None:
+            continue
+
+        inventory_dotted_path = dep.schema_inventory_path
+        data = _get_inventory_subtree(parameters, inventory_dotted_path)
+        if data is None:
+            if inventory_dotted_path is not None:
+                logger.warning(
+                    "Schema %s exists but inventory path %r does not resolve; skipping validation",
+                    schema_path,
+                    inventory_dotted_path,
+                )
+            continue
+
+        errors = _validate_against_schema(
+            data,
+            schema_path,
+            dep.output_path,
+            inventory_dotted_path,
+            inventory_path,
+            tracker_cache,
+        )
+        if errors:
+            findings.append(
+                {
+                    "dependency": dep.output_path,
+                    "schema_path": str(schema_path),
+                    "inventory_path": inventory_dotted_path,
+                    "errors": errors,
+                }
+            )
+
+    return findings

--- a/kapitan/inventory/model/__init__.py
+++ b/kapitan/inventory/model/__init__.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -25,6 +25,9 @@ class KapitanInventorySettings(BaseModel):
     target_full_path: str = ""
     secrets: KapitanReferenceConfig | None = None
     validate_: list[dict] = Field(alias="validate", default=[])
+    generator_schema_validation: Literal["warn", "error", "disabled", "info"] = Field(
+        default="warn", exclude=True
+    )
 
 
 class KapitanMetadataName(BaseModel):

--- a/kapitan/inventory/model/dependencies.py
+++ b/kapitan/inventory/model/dependencies.py
@@ -19,6 +19,8 @@ class KapitanDependencyBaseConfig(BaseModel):
     source: str
     output_path: str
     force_fetch: bool | None = False
+    schema_path: str | None = None
+    schema_inventory_path: str | None = None
 
 
 class KapitanDependencyHelmConfig(KapitanDependencyBaseConfig):

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -20,7 +20,7 @@ from reclass.errors import NotFoundError, ReclassException
 from kapitan import cached
 from kapitan.dependency_manager.base import fetch_dependencies
 from kapitan.dependency_manager.schema_validation import (
-    _SourceTrackerCache,
+    SourceTrackerCache,
     validate_generator_schemas,
 )
 from kapitan.errors import CompileError, InventoryError, KapitanError
@@ -220,7 +220,7 @@ def compile_targets(inventory_path, search_paths, ref_controller, args):
         # Validate generator schemas after dependencies are fetched.
         # This runs in the main process so schema errors surface early
         # before compilation work starts in the pool.
-        tracker_cache = _SourceTrackerCache()
+        tracker_cache = SourceTrackerCache()
         for target_name in targets:
             target = inventory.targets.get(target_name)
             if target is None:

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -19,6 +19,10 @@ from reclass.errors import NotFoundError, ReclassException
 
 from kapitan import cached
 from kapitan.dependency_manager.base import fetch_dependencies
+from kapitan.dependency_manager.schema_validation import (
+    _SourceTrackerCache,
+    validate_generator_schemas,
+)
 from kapitan.errors import CompileError, InventoryError, KapitanError
 from kapitan.inputs import CACHEABLE_INPUT_TYPES, get_compiler
 from kapitan.inputs.cache import CacheMetrics
@@ -80,6 +84,18 @@ def _log_cache_metrics(metrics_by_type):
         )
     if not any_activity:
         logger.info("Compile cache: no lookups")
+
+
+def _emit_schema_findings(findings, validation_mode):
+    """Log or raise schema validation findings based on the configured mode."""
+    for finding in findings:
+        for error in finding["errors"]:
+            if validation_mode == "error":
+                raise CompileError(error["formatted"])
+            if validation_mode == "info":
+                logger.info(error["formatted"])
+            else:
+                logger.warning(error["formatted"])
 
 
 def compile_targets(inventory_path, search_paths, ref_controller, args):
@@ -200,6 +216,28 @@ def compile_targets(inventory_path, search_paths, ref_controller, args):
             cached.as_dict() if args.inventory_pool_cache else None,
             cached.input_cache_metrics,
         )
+
+        # Validate generator schemas after dependencies are fetched.
+        # This runs in the main process so schema errors surface early
+        # before compilation work starts in the pool.
+        tracker_cache = _SourceTrackerCache()
+        for target_name in targets:
+            target = inventory.targets.get(target_name)
+            if target is None:
+                continue
+            kapitan_config = target.parameters.kapitan
+            if kapitan_config is None:
+                continue
+            validation_mode = kapitan_config.generator_schema_validation
+            if validation_mode == "disabled":
+                continue
+            # Wrap dumped parameters so dotted paths like
+            # "parameters.components.argocd" resolve correctly.
+            parameters = {"parameters": target.parameters.model_dump()}
+            findings = validate_generator_schemas(
+                kapitan_config, parameters, inventory_path, tracker_cache
+            )
+            _emit_schema_findings(findings, validation_mode)
 
         with multiprocessing.Pool(
             parallelism, initializer=_pool_init, initargs=pool_initargs

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -133,6 +133,7 @@ nav:
           - Publishing generators: pages/publishing_generators.md
           - ArgoCD integration: pages/argocd.md
           - FluxCD integration: pages/fluxcd.md
+          - Generator schema validation: pages/generator_schema_validation.md
       - CLI reference:
           - compile: pages/commands/kapitan_compile.md
           - inventory: pages/commands/kapitan_inventory.md

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -638,3 +638,32 @@ class OciFetchDependencyTest(unittest.TestCase):
                     (dep.source, [dep]), save_dir=save_dir, force=False
                 )
             self.assertIn("resolves outside", str(ctx.exception))
+
+    @patch("kapitan.dependency_manager.base.oras.client.OrasClient")
+    def test_nested_artifact_without_subpath_emits_warning(self, MockClient):
+        """When output_path has only subdirs (no files) and no subpath is set, warn."""
+        with (
+            tempfile.TemporaryDirectory() as save_dir,
+            tempfile.TemporaryDirectory() as out_dir,
+        ):
+            dep = self._make_dep(output_path=out_dir)
+
+            def fake_pull(target, outdir, allowed_media_type):
+                # Simulate oras preserving push-time path: all content nested.
+                nested = Path(outdir) / "system" / "generators" / "mygenerator"
+                nested.mkdir(parents=True, exist_ok=True)
+                (nested / "__init__.py").write_text("def main(): return {}")
+
+            MockClient.return_value.pull.side_effect = fake_pull
+
+            with self.assertLogs(
+                "kapitan.dependency_manager.base", level="WARNING"
+            ) as log:
+                fetch_oci_dependency(
+                    (dep.source, [dep]), save_dir=save_dir, force=False
+                )
+
+            warning_text = "\n".join(log.output)
+            self.assertIn("only subdirectories", warning_text)
+            self.assertIn("subpath", warning_text)
+            self.assertIn("system", warning_text)

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -638,32 +638,3 @@ class OciFetchDependencyTest(unittest.TestCase):
                     (dep.source, [dep]), save_dir=save_dir, force=False
                 )
             self.assertIn("resolves outside", str(ctx.exception))
-
-    @patch("kapitan.dependency_manager.base.oras.client.OrasClient")
-    def test_nested_artifact_without_subpath_emits_warning(self, MockClient):
-        """When output_path has only subdirs (no files) and no subpath is set, warn."""
-        with (
-            tempfile.TemporaryDirectory() as save_dir,
-            tempfile.TemporaryDirectory() as out_dir,
-        ):
-            dep = self._make_dep(output_path=out_dir)
-
-            def fake_pull(target, outdir, allowed_media_type):
-                # Simulate oras preserving push-time path: all content nested.
-                nested = Path(outdir) / "system" / "generators" / "mygenerator"
-                nested.mkdir(parents=True, exist_ok=True)
-                (nested / "__init__.py").write_text("def main(): return {}")
-
-            MockClient.return_value.pull.side_effect = fake_pull
-
-            with self.assertLogs(
-                "kapitan.dependency_manager.base", level="WARNING"
-            ) as log:
-                fetch_oci_dependency(
-                    (dep.source, [dep]), save_dir=save_dir, force=False
-                )
-
-            warning_text = "\n".join(log.output)
-            self.assertIn("only subdirectories", warning_text)
-            self.assertIn("subpath", warning_text)
-            self.assertIn("system", warning_text)

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for generator schema discovery and validation."""
+
+import json
+import logging
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import pytest
+import yaml
+
+from kapitan.cached import reset_cache
+from kapitan.cli import main as kapitan
+from kapitan.dependency_manager.schema_validation import (
+    _resolve_schema_path,
+    _SourceTrackerCache,
+    validate_generator_schemas,
+)
+from kapitan.inventory.model import KapitanInventorySettings
+from kapitan.inventory.model.dependencies import KapitanDependencyGitConfig
+
+
+class GeneratorSchemaValidationTest(unittest.TestCase):
+    """Unit tests for generator schema discovery and validation."""
+
+    def _make_dep(self, output_path, schema_path=None, schema_inventory_path=None):
+        return KapitanDependencyGitConfig(
+            type="git",
+            source="https://example.com/repo.git",
+            output_path=output_path,
+            schema_path=schema_path,
+            schema_inventory_path=schema_inventory_path,
+        )
+
+    def test_schema_discovery_default_path(self):
+        """When schema_path is not set, discover <output_path>/schema.json."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+            schema_file = output_dir / "schema.json"
+            schema_file.write_text(json.dumps({"type": "object"}))
+
+            dep = self._make_dep(output_path=str(output_dir))
+
+            result = _resolve_schema_path(dep)
+            self.assertEqual(result, schema_file)
+
+    def test_schema_discovery_explicit_path(self):
+        """When schema_path is set, it overrides the default location."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+            custom_schema = Path(tmp) / "custom" / "schema.json"
+            custom_schema.parent.mkdir(parents=True)
+            custom_schema.write_text(json.dumps({"type": "object"}))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_path=str(custom_schema),
+            )
+
+            result = _resolve_schema_path(dep)
+            self.assertEqual(result, custom_schema)
+
+    def test_missing_schema_returns_none(self):
+        """When no schema file exists, _resolve_schema_path returns None."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+
+            dep = self._make_dep(output_path=str(output_dir))
+
+            result = _resolve_schema_path(dep)
+            self.assertIsNone(result)
+
+    def test_validation_warn(self):
+        """Schema mismatches return findings with error details."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+            schema = {
+                "type": "object",
+                "properties": {
+                    "namespace": {"type": "string"},
+                    "syncPolicy": {
+                        "type": "object",
+                        "properties": {
+                            "automated": {"type": "boolean"},
+                        },
+                    },
+                },
+            }
+            (output_dir / "schema.json").write_text(json.dumps(schema))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.components.argocd",
+            )
+            parameters = {
+                "parameters": {
+                    "components": {
+                        "argocd": {
+                            "namespace": "argocd",
+                            "syncPolicy": {
+                                "automated": "true",
+                            },
+                        },
+                    },
+                },
+            }
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            findings = validate_generator_schemas(target_obj, parameters, str(tmp))
+
+            self.assertEqual(len(findings), 1)
+            self.assertIn("boolean", findings[0]["errors"][0]["message"])
+
+    def test_validation_error_mode(self):
+        """validate_generator_schemas returns findings regardless of mode."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+            schema = {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                },
+            }
+            (output_dir / "schema.json").write_text(json.dumps(schema))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.data",
+            )
+            parameters = {
+                "parameters": {
+                    "data": {"count": "not-an-int"},
+                },
+            }
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            findings = validate_generator_schemas(target_obj, parameters, str(tmp))
+            self.assertEqual(len(findings), 1)
+            self.assertIn("not-an-int", findings[0]["errors"][0]["message"])
+
+    def test_validation_disabled(self):
+        """validate_generator_schemas still returns findings when called directly."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+            schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+            (output_dir / "schema.json").write_text(json.dumps(schema))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.data",
+            )
+            parameters = {"parameters": {"data": {"x": "bad"}}}
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            findings = validate_generator_schemas(target_obj, parameters, str(tmp))
+            self.assertEqual(len(findings), 1)
+
+    def test_missing_schema_skips_validation(self):
+        """Missing schema files produce no findings."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.components.argocd",
+            )
+            parameters = {
+                "parameters": {
+                    "components": {
+                        "argocd": {"namespace": "argocd"},
+                    },
+                },
+            }
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            findings = validate_generator_schemas(target_obj, parameters, str(tmp))
+            self.assertEqual(len(findings), 0)
+
+    def test_validation_source_location(self):
+        """When inventory files are present, the formatted error includes source location."""
+        with tempfile.TemporaryDirectory() as tmp:
+            inv_dir = Path(tmp) / "inventory"
+            classes_dir = inv_dir / "classes"
+            classes_dir.mkdir(parents=True)
+
+            # Write a class that defines the violating value.
+            class_file = classes_dir / "argocd.yml"
+            class_file.write_text(
+                "parameters:\n"
+                "  components:\n"
+                "    argocd:\n"
+                "      syncPolicy:\n"
+                '        automated: "true"\n'
+            )
+
+            output_dir = Path(tmp) / "lib" / "argocd"
+            output_dir.mkdir(parents=True)
+            schema = {
+                "type": "object",
+                "properties": {
+                    "syncPolicy": {
+                        "type": "object",
+                        "properties": {
+                            "automated": {"type": "boolean"},
+                        },
+                    },
+                },
+            }
+            (output_dir / "schema.json").write_text(json.dumps(schema))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.components.argocd",
+            )
+            parameters = {
+                "parameters": {
+                    "components": {
+                        "argocd": {
+                            "syncPolicy": {
+                                "automated": "true",
+                            },
+                        },
+                    },
+                },
+            }
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            findings = validate_generator_schemas(target_obj, parameters, str(inv_dir))
+
+            self.assertEqual(len(findings), 1)
+            formatted = findings[0]["errors"][0]["formatted"]
+            # Should contain the source file path and line context.
+            self.assertIn(str(class_file), formatted)
+            self.assertIn("automated:", formatted)
+            self.assertIn("E-argocd.type", formatted)
+
+    def test_validation_multiple_errors(self):
+        """A schema mismatch against multiple constraints reports every error."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "testgen"
+            output_dir.mkdir(parents=True)
+            schema = {
+                "type": "object",
+                "properties": {
+                    "count": {"type": "integer"},
+                    "name": {"type": "string"},
+                },
+            }
+            (output_dir / "schema.json").write_text(json.dumps(schema))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.components.testgen",
+            )
+            parameters = {
+                "parameters": {
+                    "components": {
+                        "testgen": {
+                            "count": "not-an-int",
+                            "name": 123,
+                        },
+                    },
+                },
+            }
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            findings = validate_generator_schemas(target_obj, parameters, str(tmp))
+
+            self.assertEqual(len(findings), 1)
+            self.assertEqual(len(findings[0]["errors"]), 2)
+
+    def test_validation_missing_inventory_path_warns(self):
+        """When a schema exists but the configured inventory path is missing, a warning is logged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp) / "lib" / "testgen"
+            output_dir.mkdir(parents=True)
+            (output_dir / "schema.json").write_text(json.dumps({"type": "object"}))
+
+            dep = self._make_dep(
+                output_path=str(output_dir),
+                schema_inventory_path="parameters.does.not.exist",
+            )
+            parameters = {"parameters": {"components": {"testgen": {}}}}
+
+            target_obj = KapitanInventorySettings(dependencies=[dep])
+            with self.assertLogs(level=logging.WARNING) as cm:
+                findings = validate_generator_schemas(target_obj, parameters, str(tmp))
+
+            self.assertEqual(len(findings), 0)
+            self.assertTrue(
+                any("does not resolve" in msg for msg in cm.output),
+                f"Expected warning about missing inventory path, got: {cm.output}",
+            )
+
+    def test_source_tracker_cache_reuses_instances(self):
+        """_SourceTrackerCache returns the same tracker for repeated lookups."""
+        with tempfile.TemporaryDirectory() as tmp:
+            yaml_file = Path(tmp) / "test.yml"
+            yaml_file.write_text("foo: bar\n")
+
+            cache = _SourceTrackerCache()
+            tracker1 = cache.get(yaml_file)
+            tracker2 = cache.get(yaml_file)
+
+            self.assertIs(tracker1, tracker2)
+
+
+class TestGeneratorSchemaValidationCompile:
+    """End-to-end compile tests for generator schema validation."""
+
+    @pytest.fixture
+    def schema_validation_inventory(self, temp_dir):
+        """Create an isolated inventory for schema validation compile tests."""
+        inv_dir = Path(temp_dir) / "inventory"
+        targets_dir = inv_dir / "targets"
+        classes_dir = inv_dir / "classes"
+        targets_dir.mkdir(parents=True)
+        classes_dir.mkdir(parents=True)
+
+        common = {"parameters": {"kapitan": {"compile": []}}}
+        (classes_dir / "common.yml").write_text(yaml.dump(common))
+
+        # Create schema for dependency
+        schema_dir = Path(temp_dir) / "lib" / "testgen"
+        schema_dir.mkdir(parents=True)
+        schema = {"type": "object", "properties": {"count": {"type": "integer"}}}
+        (schema_dir / "schema.json").write_text(json.dumps(schema))
+
+        # Create a dummy file for copy input so compile_target writes output
+        (Path(temp_dir) / "dummy.txt").write_text("hello")
+
+        return temp_dir
+
+    def _write_target(self, base_dir, mode):
+        target = {
+            "classes": ["common"],
+            "parameters": {
+                "kapitan": {
+                    "vars": {
+                        "target": "test",
+                    },
+                    "compile": [
+                        {
+                            "output_path": ".",
+                            "input_type": "copy",
+                            "input_paths": ["dummy.txt"],
+                        }
+                    ],
+                    "generator_schema_validation": mode,
+                    "dependencies": [
+                        {
+                            "type": "git",
+                            "source": "https://example.com/repo.git",
+                            "output_path": "lib/testgen",
+                            "schema_inventory_path": "parameters.components.testgen",
+                        }
+                    ],
+                },
+                "components": {
+                    "testgen": {
+                        "count": "not-an-int",
+                    }
+                },
+            },
+        }
+        targets_dir = Path(base_dir) / "inventory" / "targets"
+        (targets_dir / "test.yml").write_text(yaml.dump(target))
+
+    def test_compile_error_mode_raises(self, schema_validation_inventory):
+        """With generator_schema_validation: error, compile exits with failure."""
+        self._write_target(schema_validation_inventory, "error")
+        original_dir = os.getcwd()
+        os.chdir(schema_validation_inventory)
+        reset_cache()
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                kapitan("compile", "-t", "test")
+            assert exc_info.value.code == 1
+        finally:
+            os.chdir(original_dir)
+            reset_cache()
+
+    def test_compile_warn_mode_succeeds(self, schema_validation_inventory):
+        """With generator_schema_validation: warn, compile succeeds despite mismatch."""
+        self._write_target(schema_validation_inventory, "warn")
+        original_dir = os.getcwd()
+        os.chdir(schema_validation_inventory)
+        reset_cache()
+        try:
+            kapitan("compile", "-t", "test")
+        finally:
+            os.chdir(original_dir)
+            reset_cache()

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -7,9 +7,9 @@
 
 """Tests for generator schema discovery and validation."""
 
+import importlib.util
 import json
 import logging
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -20,12 +20,28 @@ import yaml
 from kapitan.cached import reset_cache
 from kapitan.cli import main as kapitan
 from kapitan.dependency_manager.schema_validation import (
+    SourceTrackerCache,
     _resolve_schema_path,
-    _SourceTrackerCache,
     validate_generator_schemas,
 )
+from kapitan.inventory import InventoryBackends
 from kapitan.inventory.model import KapitanInventorySettings
 from kapitan.inventory.model.dependencies import KapitanDependencyGitConfig
+
+
+# Backends to exercise in end-to-end compile tests. Optional backends are
+# skipped at runtime when their module is not installed.
+INVENTORY_BACKENDS = [
+    InventoryBackends.RECLASS,
+    InventoryBackends.RECLASS_RS,
+    InventoryBackends.OMEGACONF,
+]
+
+
+def _skip_if_backend_unavailable(backend):
+    module_name = backend.replace("-", "_")
+    if not importlib.util.find_spec(module_name):
+        pytest.skip(f"backend module {module_name} not available")
 
 
 class GeneratorSchemaValidationTest(unittest.TestCase):
@@ -308,12 +324,12 @@ class GeneratorSchemaValidationTest(unittest.TestCase):
             )
 
     def test_source_tracker_cache_reuses_instances(self):
-        """_SourceTrackerCache returns the same tracker for repeated lookups."""
+        """SourceTrackerCache returns the same tracker for repeated lookups."""
         with tempfile.TemporaryDirectory() as tmp:
             yaml_file = Path(tmp) / "test.yml"
             yaml_file.write_text("foo: bar\n")
 
-            cache = _SourceTrackerCache()
+            cache = SourceTrackerCache()
             tracker1 = cache.get(yaml_file)
             tracker2 = cache.get(yaml_file)
 
@@ -381,28 +397,28 @@ class TestGeneratorSchemaValidationCompile:
         targets_dir = Path(base_dir) / "inventory" / "targets"
         (targets_dir / "test.yml").write_text(yaml.dump(target))
 
-    def test_compile_error_mode_raises(self, schema_validation_inventory):
+    @pytest.mark.parametrize("backend", INVENTORY_BACKENDS)
+    def test_compile_error_mode_raises(
+        self, schema_validation_inventory, monkeypatch, backend
+    ):
         """With generator_schema_validation: error, compile exits with failure."""
+        _skip_if_backend_unavailable(backend)
         self._write_target(schema_validation_inventory, "error")
-        original_dir = os.getcwd()
-        os.chdir(schema_validation_inventory)
+        monkeypatch.chdir(schema_validation_inventory)
         reset_cache()
-        try:
-            with pytest.raises(SystemExit) as exc_info:
-                kapitan("compile", "-t", "test")
-            assert exc_info.value.code == 1
-        finally:
-            os.chdir(original_dir)
-            reset_cache()
+        with pytest.raises(SystemExit) as exc_info:
+            kapitan("compile", "-t", "test", "--inventory-backend", backend)
+        assert exc_info.value.code == 1
+        reset_cache()
 
-    def test_compile_warn_mode_succeeds(self, schema_validation_inventory):
+    @pytest.mark.parametrize("backend", INVENTORY_BACKENDS)
+    def test_compile_warn_mode_succeeds(
+        self, schema_validation_inventory, monkeypatch, backend
+    ):
         """With generator_schema_validation: warn, compile succeeds despite mismatch."""
+        _skip_if_backend_unavailable(backend)
         self._write_target(schema_validation_inventory, "warn")
-        original_dir = os.getcwd()
-        os.chdir(schema_validation_inventory)
+        monkeypatch.chdir(schema_validation_inventory)
         reset_cache()
-        try:
-            kapitan("compile", "-t", "test")
-        finally:
-            os.chdir(original_dir)
-            reset_cache()
+        kapitan("compile", "-t", "test", "--inventory-backend", backend)
+        reset_cache()


### PR DESCRIPTION
## Summary

Closes #1487

Implements generator schema discovery and validation. After fetching dependencies, Kapitan looks for a `schema.json` next to each dependency's contents and validates the configured inventory subtree against it.

## Changes

- **Dependency model** (`kapitan/inventory/model/dependencies.py`):
  - Added `schema_path` and `schema_inventory_path` to `KapitanDependencyBaseConfig` (available on all dependency types).

- **Inventory settings** (`kapitan/inventory/model/__init__.py`):
  - Added `generator_schema_validation` (`warn` | `error` | `info` | `disabled`, default `warn`).

- **Validation module** (`kapitan/dependency_manager/schema_validation.py`):
  - Schema discovery (`_resolve_schema_path`) with default `<output_path>/schema.json` fallback.
  - Inventory subtree extraction (`_get_inventory_subtree`) using the exact dotted path format (e.g. `parameters.components.argocd`).
  - Source location tracking via YAML AST scanning (`_SourceTracker`) with a `_SourceTrackerCache` to avoid re-parsing inventory files per error.
  - Reports **all** validation errors for a dependency in one pass via `jsonschema.Validator.iter_errors()`.
  - Warns when a schema exists but the configured `schema_inventory_path` does not resolve in the merged inventory.
  - Compiler-style formatted errors with file path, line/column, and surrounding context.

- **Compile pipeline** (`kapitan/targets.py`):
  - Hooks validation after `fetch_dependencies()` in the main process so errors surface before compilation work starts.
  - Wraps `target.parameters.model_dump()` as `{"parameters": ...}` so dotted inventory paths resolve correctly.
  - Warns by default; raises `CompileError` in `error` mode.

- **Tests** (`tests/test_schema_validation.py`):
  - Unit tests for schema discovery, multiple-error reporting, missing schema, missing inventory path warnings, and source location tracking.
  - End-to-end compile tests verifying `warn` mode continues compilation and `error` mode exits with failure.

- **Documentation**:
  - New page: `docs/pages/generator_schema_validation.md`
  - Cross-references in `external_dependencies.md` and `publishing_generators.md`
  - Nav entry in `mkdocs.yml`

## Verification

```bash
uv run pytest tests/test_schema_validation.py -v --no-cov
make lint
uv run mkdocs build
```

All tests pass.
