### PR TITLE
Automated dev pre-releases to PyPI on merge to master

### DIFF
--- a/.github/workflows/python-pypi-publish-dev.yml
+++ b/.github/workflows/python-pypi-publish-dev.yml
@@ -1,0 +1,55 @@
+---
+name: Publish Dev Pre-release to PyPI
+
+# Publish a PEP 440 dev pre-release (e.g. 0.35.2.dev3) to PyPI on every
+# merge to the default branch. This gives users an easy way to test the
+# latest master without waiting for a stable release.
+#
+# For stable releases, see: python-pypi-publish.yml
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  pypi-publish-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # NOTE:
+      # Remove user/password and uncomment id-token permission once Trusted
+      # Publishing (OIDC) is setup in pypi. See:
+      # https://github.com/pypa/gh-action-pypi-publish
+      # id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: recursive
+          # Full history is required for uv-dynamic-versioning to compute the
+          # distance from the latest tag (e.g. 3 commits after v0.35.1).
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
+      - name: Build and check
+        run: |
+          uv build
+          uvx twine check dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -144,3 +144,25 @@ Compiled echo-server (0.14s)
     ```shell
     sudo pip3 install --upgrade kapitan
     ```
+
+#### Pre-release versions
+
+Every merge to `master` is automatically published to PyPI as a PEP 440 pre-release. To install the latest development build:
+
+=== "pip"
+
+    ```shell
+    pip3 install --user --upgrade --pre kapitan
+    ```
+
+=== "uv"
+
+    ```shell
+    uv tool install --upgrade --prerelease allow kapitan
+    ```
+
+=== "poetry"
+
+    ```shell
+    poetry add --allow-prereleases kapitan
+    ```

--- a/kapitan/version.py
+++ b/kapitan/version.py
@@ -7,10 +7,20 @@
 
 """Project description variables."""
 
+from importlib.metadata import PackageNotFoundError, version
+
+
 PROJECT_NAME = "kapitan"
-VERSION = "0.35.1"
 DESCRIPTION = "Generic templated configuration management for Kubernetes, Terraform and other things"
 AUTHOR = "Ricardo Amaro"
 AUTHOR_EMAIL = "ramaro@kapicorp.com"
 LICENCE = "Apache License 2.0"
 URL = "https://github.com/kapicorp/kapitan"
+
+# When running from an installed package (wheel, sdist), use the version
+# computed by the build backend (uv-dynamic-versioning). When running from
+# source without installation, fall back to the static version.
+try:
+    VERSION = version("kapitan")
+except PackageNotFoundError:
+    VERSION = "0.35.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,14 +149,13 @@ source = "uv-dynamic-versioning"
 # NOTE: preview version with: uvx uv-dynamic-versioning
 # https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/version_source.md#configuration
 vcs = "git"
-style = "semver"
-format = "{base}"
+style = "pep440"
+bump = true
+# On tagged commits: produce the clean tag version (e.g. 0.35.1).
+# On master merges: produce a PEP 440 dev pre-release (e.g. 0.35.2.dev3).
+format-jinja = "{% if distance == 0 %}{{ serialize_pep440(base) }}{% else %}{{ serialize_pep440(base, dev=distance) }}{% endif %}"
 # https://github.com/ninoseki/uv-dynamic-versioning/blob/main/docs/tips.md#dependabot
 fallback-version = "0.0.0"
-
-[tool.uv-dynamic-versioning.from-file]
-source = "kapitan/version.py"
-pattern = '^VERSION = "(.*)"$'
 
 [tool.pytest.ini_options]
 minversion = "8.0"


### PR DESCRIPTION
## Summary

Closes #1489

This PR automates publishing PEP 440 dev pre-releases (e.g. `0.35.2.dev3`) to PyPI on every merge to `master`.

## Changes

### 1. `pyproject.toml` — dynamic dev versioning

Switched `uv-dynamic-versioning` from static `format = \"{base}\"` to a Jinja template that produces dev versions from git history:

- `style = \"pep440\"` (was `"semver"`) so dev releases like `0.35.2.dev6` pass validation
- `bump = true` so post-tag commits bump the patch before adding `dev<N>`
- `format-jinja` produces:
  - Clean version on tagged commits: `0.35.1`
  - Dev pre-release on master: `0.35.2.dev3`

Removed `[tool.uv-dynamic-versioning.from-file]` which was overriding git-based versioning by always returning the static `0.35.1` from `kapitan/version.py`.

### 2. `kapitan/version.py` — runtime version discovery

Now reads the actual installed package version via `importlib.metadata.version("kapitan")`, falling back to the static `"0.35.1"` when running from source without installation.

### 3. `.github/workflows/python-pypi-publish-dev.yml` — CI workflow

- Triggers on every push to `master` / `main`
- Checks out full history (`fetch-depth: 0`) so `uv-dynamic-versioning` can compute distance from the latest tag
- Builds with `uv build` and publishes to PyPI using the existing `PYPI_TOKEN` secret

## How it works

| Event | Version produced | Example |
|-------|----------------|---------|
| Commit exactly on tag `v0.35.1` | Clean release | `0.35.1` |
| 3 commits after `v0.35.1` on master | Dev pre-release | `0.35.2.dev3` |

Users can install the latest `master` with:
```bash
pip install --pre kapitan
```

## Follow-ups

1. **Trusted Publishers (OIDC)** — The existing release workflow has a todo about switching from `secrets.PYPI_TOKEN` to PyPI Trusted Publishers. Doing this for the dev workflow too would remove the need for a long-lived token.
2. **Test on a fork** — Push this branch to a fork, set `PYPI_TOKEN`, and verify a dev release lands on PyPI correctly.