### PR TITLE
Fix Kadet cache key collisions from input_params

### DIFF
--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -128,28 +128,29 @@ class Kadet(InputType):
         Write the kadet evaluated items as files to compile_path.  External variables are not used in Kadet.
         """
 
-        input_params = config.input_params
+        input_params = dict(config.input_params)
         target_name = self.target_name
         current_target.set(target_name)
         search_paths.set(self.search_paths)
         inputs_hash = None
         output_obj = None
 
+        # set compile_path allowing kadet functions to have context on where files
+        # are being compiled on the current kapitan run
+        # we only do this if user didn't pass its own value
+        input_params.setdefault("compile_path", compile_path)
+
         if cache_obj := self.cacheable():
             inputs_hash = self.inputs_hash(
                 inventory_digest(current_target.get()),
                 target_name,
                 Path(input_path),
+                input_params,
             )
 
             output_obj = cache_obj.get(inputs_hash)
 
         if output_obj is None:
-            # set compile_path allowing kadet functions to have context on where files
-            # are being compiled on the current kapitan run
-            # we only do this if user didn't pass its own value
-            input_params.setdefault("compile_path", compile_path)
-
             kadet_module, spec = module_from_path(input_path)
             sys.modules[spec.name] = kadet_module
             spec.loader.exec_module(kadet_module)

--- a/tests/test_kadet.py
+++ b/tests/test_kadet.py
@@ -9,8 +9,15 @@
 
 import tempfile
 import unittest
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
 
-from kadet import ABORT_EXCEPTION_TYPE, BaseObj, Dict
+import kadet
+from kadet import BaseObj, Dict
+
+from kapitan.inputs.kadet import Kadet
+from kapitan.inventory.model.input_types import KapitanInputTypeKadetConfig
 
 
 class KadetTestObj(BaseObj):
@@ -117,7 +124,7 @@ class KadetTest(unittest.TestCase):
         self.assertEqual(output, desired_output)
 
     def test_need(self):
-        with self.assertRaises(ABORT_EXCEPTION_TYPE):
+        with self.assertRaises(kadet.ABORT_EXCEPTION_TYPE):
             KadetTestObj(this_should_error=True)
 
     def test_update_root_yaml(self):
@@ -165,3 +172,43 @@ class KadetTest(unittest.TestCase):
         output = kobj.dump()
         desired_output = {"this": "that", "list": [1, 2, 3]}
         self.assertEqual(output, desired_output)
+
+
+class KadetCompileCacheTest(unittest.TestCase):
+    def test_compile_cache_key_includes_input_params(self):
+        input_params = {"value": "second"}
+        config = KapitanInputTypeKadetConfig(
+            input_paths=["component"],
+            output_path=".",
+            input_params=input_params,
+        )
+        compiler = Kadet(
+            "compiled",
+            ["."],
+            None,
+            "test-target",
+            Namespace(cache=True),
+        )
+
+        cache = mock.Mock()
+        cache.get.return_value = {}
+
+        with (
+            mock.patch.object(compiler, "cacheable", return_value=cache),
+            mock.patch.object(
+                compiler, "inputs_hash", return_value="cache-key"
+            ) as inputs_hash,
+            mock.patch(
+                "kapitan.inputs.kadet.inventory_digest", return_value=b"inventory"
+            ),
+        ):
+            compiler.compile_file(config, "component", "compiled/test-target")
+
+        inputs_hash.assert_called_once_with(
+            b"inventory",
+            "test-target",
+            Path("component"),
+            {"value": "second", "compile_path": "compiled/test-target"},
+        )
+        cache.get.assert_called_once_with("cache-key")
+        self.assertEqual(config.input_params, input_params)


### PR DESCRIPTION
## Summary

- Include Kadet's effective `input_params` in the compilation cache key.
- Build those params from a local copy so `compile_file()` no longer mutates `config.input_params` when adding the default `compile_path`.
- Add a focused unit test that asserts `Kadet.compile_file()` passes the effective params into `inputs_hash()` and leaves the original config params unchanged.

## Bug

Kadet cache keys currently include the target inventory digest, target name, and Kadet input path, but not the per-input parameters passed to the Kadet component.

When `kapitan compile --cache` is used, two compile entries can call the same Kadet component with different `input_params`. Without those params in the key, both entries compute the same cache key, so the second call can load and write the first call's cached output. That makes parameterized Kadet components produce stale or incorrect manifests whenever the same component is reused with different params.

`compile_file()` also adds a default `compile_path` to the params passed into Kadet modules. This PR treats that effective params dict as part of the cache input, while avoiding mutation of the original `config.input_params` object.

## Root cause

The regression was introduced by `65e98654a62eefc4b5bef1c0b6ac7f23289aa0f6` (`Implement kadet input type cache (#1319)`). That commit added Kadet cache lookup and `inputs_hash()`, but the key only used:

- `inventory_digest(current_target.get())`
- `target_name`
- `Path(input_path)`

Kadet `input_params` already existed before that change, so enabling the new cache created a collision path for parameterized Kadet inputs.

## Tests

- `uv run pytest -q tests/test_kadet.py --no-cov`
- `uv run pytest -q tests/test_compile.py::CompileTestResourcesTestKadet --no-cov`
- `uv run ruff check kapitan/inputs/kadet.py tests/test_kadet.py`
