### PR TITLE
Fix Kadet inventory_global default boxing

### DIFF
--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -43,6 +43,7 @@ def reset_cache():
     global \
         inv, \
         global_inv, \
+        inventory_global_kadet, \
         inv_cache, \
         gpg_obj, \
         gkms_obj, \
@@ -51,10 +52,12 @@ def reset_cache():
         dot_kapitan, \
         ref_controller_obj, \
         revealer_obj, \
-        inv_sources
+        inv_sources, \
+        kapitan_input_kadet
 
     inv = {}
     global_inv = {}
+    inventory_global_kadet = {}
     inv_cache = {}
     inv_sources = set()
     gpg_obj = None
@@ -64,6 +67,7 @@ def reset_cache():
     dot_kapitan = {}
     ref_controller_obj = None
     revealer_obj = None
+    kapitan_input_kadet = None
 
 
 def from_dict(cache_dict: dict[str, Any]) -> None:

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -34,16 +34,21 @@ search_paths = contextvars.ContextVar("current search_paths in thread")
 current_target = contextvars.ContextVar("current target in thread")
 
 
-@cache
-def inventory_global(lazy=False):
+def _inventory_global(default_box=False):
     # At hoc inventory for kadet
-    if not cached.inventory_global_kadet:
-        cached.inventory_global_kadet = Dict(cached.global_inv, default_box=lazy)
-    return cached.inventory_global_kadet
+    if default_box not in cached.inventory_global_kadet:
+        cached.inventory_global_kadet[default_box] = Dict(
+            cached.global_inv, default_box=default_box
+        )
+    return cached.inventory_global_kadet[default_box]
+
+
+def inventory_global(lazy=True):
+    return _inventory_global(default_box=lazy)
 
 
 def inventory(lazy=False):
-    return inventory_global(lazy)[current_target.get()]
+    return _inventory_global(default_box=lazy)[current_target.get()]
 
 
 def topics(name=None, lazy=False):

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -20,8 +20,10 @@ class TestResetCache:
         # Set some values
         cached.inv = {"key": "value"}
         cached.global_inv = {"global": "data"}
+        cached.inventory_global_kadet = {True: {"global": "kadet"}}
         cached.inv_cache = {"cache": "entry"}
         cached.inv_sources = {"source1", "source2"}
+        cached.kapitan_input_kadet = "kadet-cache"
         cached.gpg_obj = "gpg"
         cached.gkms_obj = "gkms"
         cached.awskms_obj = "awskms"
@@ -36,8 +38,10 @@ class TestResetCache:
         # Verify all cleared
         assert cached.inv == {}
         assert cached.global_inv == {}
+        assert cached.inventory_global_kadet == {}
         assert cached.inv_cache == {}
         assert cached.inv_sources == set()
+        assert cached.kapitan_input_kadet is None
         assert cached.gpg_obj is None
         assert cached.gkms_obj is None
         assert cached.awskms_obj is None

--- a/tests/test_kadet.py
+++ b/tests/test_kadet.py
@@ -10,7 +10,12 @@
 import tempfile
 import unittest
 
-from kadet import ABORT_EXCEPTION_TYPE, BaseObj, Dict
+import kadet
+from box.exceptions import BoxKeyError
+from kadet import BaseObj, Dict
+
+from kapitan import cached
+from kapitan.inputs import kadet as kapitan_kadet
 
 
 class KadetTestObj(BaseObj):
@@ -117,7 +122,7 @@ class KadetTest(unittest.TestCase):
         self.assertEqual(output, desired_output)
 
     def test_need(self):
-        with self.assertRaises(ABORT_EXCEPTION_TYPE):
+        with self.assertRaises(kadet.ABORT_EXCEPTION_TYPE):
             KadetTestObj(this_should_error=True)
 
     def test_update_root_yaml(self):
@@ -165,3 +170,74 @@ class KadetTest(unittest.TestCase):
         output = kobj.dump()
         desired_output = {"this": "that", "list": [1, 2, 3]}
         self.assertEqual(output, desired_output)
+
+
+class InventoryGlobalTest(unittest.TestCase):
+    def setUp(self):
+        self.original_global_inv = cached.global_inv
+        self.original_inventory_global_kadet = cached.inventory_global_kadet
+        cached.inventory_global_kadet = {}
+        kapitan_kadet.inventory_digest.cache_clear()
+
+    def tearDown(self):
+        cached.global_inv = self.original_global_inv
+        cached.inventory_global_kadet = self.original_inventory_global_kadet
+        kapitan_kadet.inventory_digest.cache_clear()
+
+    def test_inventory_global_uses_default_box_by_default(self):
+        cached.global_inv = {
+            "test-target": {
+                "parameters": {
+                    "cluster": {
+                        "name": "test-cluster",
+                    },
+                },
+            },
+        }
+        inventory_global = kapitan_kadet.inventory_global()
+        inventory_global["test-target"].parameters.generated.value = "boxed"
+
+        self.assertEqual(
+            inventory_global["test-target"].parameters.generated.value, "boxed"
+        )
+
+    def test_inventory_global_default_box_survives_inventory_digest(self):
+        cached.global_inv = {
+            "test-target": {
+                "parameters": {
+                    "cluster": {
+                        "name": "test-cluster",
+                    },
+                },
+            },
+        }
+        target_token = kapitan_kadet.current_target.set("test-target")
+        try:
+            kapitan_kadet.inventory_digest("test-target")
+            inventory_global = kapitan_kadet.inventory_global()
+            inventory_global["test-target"].parameters.generated.value = "boxed"
+
+            self.assertEqual(
+                inventory_global["test-target"].parameters.generated.value, "boxed"
+            )
+        finally:
+            kapitan_kadet.current_target.reset(target_token)
+
+    def test_inventory_keeps_non_lazy_default(self):
+        cached.global_inv = {
+            "test-target": {
+                "parameters": {
+                    "cluster": {
+                        "name": "test-cluster",
+                    },
+                },
+            },
+        }
+        target_token = kapitan_kadet.current_target.set("test-target")
+        try:
+            inventory = kapitan_kadet.inventory()
+
+            with self.assertRaises(BoxKeyError):
+                inventory.parameters.generated.value = "boxed"
+        finally:
+            kapitan_kadet.current_target.reset(target_token)


### PR DESCRIPTION
## Summary

Fix Kadet `inventory_global()` default-box behavior by separating the cached Kadet inventory wrappers for lazy/default-box and non-lazy access.

## Why this changed behavior between 0.34 and 0.35

The shared wrapper behavior already existed in 0.34: `inventory()` delegated through `inventory_global(lazy)` and both helpers reused `cached.inventory_global_kadet`. That meant the first caller decided whether the cached wrapper used `default_box=True` or `False`.

In 0.35, Kadet input caching added a preflight inventory digest path before the Kadet module is executed. That path calls `inventory_digest()`, which calls `inventory()` with the default `lazy=False`. When compile cache is enabled, Kapitan itself can therefore initialize the shared global Kadet wrapper as non-lazy before user Kadet code later calls `inventory_global()`.

That makes `inventory_global()` unexpectedly lose default-box behavior in 0.35 for users who compile Kadet with cache enabled.

## What changed

- Cache Kadet global inventory wrappers by `default_box` mode instead of using a single shared wrapper.
- Make `inventory_global()` default to the default-box wrapper.
- Preserve `inventory()` default behavior as non-lazy unless called with `lazy=True`.
- Clear Kadet wrapper/input caches in `reset_cache()` so wrappers cannot outlive refreshed global inventory state.
- Add regression coverage for the 0.35 cache-preflight call order where `inventory_digest()` runs before `inventory_global()`.

## Validation

- `uv run pytest tests/test_kadet.py tests/test_cached.py --no-cov`
- `uv run ruff check kapitan/inputs/kadet.py kapitan/cached.py tests/test_kadet.py tests/test_cached.py`
