### PR TITLE
Optimize OmegaConf literal marker processing

### DIFF
--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -219,7 +219,8 @@ library), enabled with `--yaml-use-rapidyaml`.
           --validate            validate compile output against schemas as specified
                                 in inventory
           --parallelism INT, -p INT
-                                Number of concurrent compile processes, default is 4
+                                Number of concurrent compile processes, default is
+                                min(len(targets), available CPU count)
           --indent INT, -i INT  Indentation spaces for YAML/JSON, default is 2
           --refs-path REFS_PATH
                                 set refs path, default is "./refs"

--- a/docs/pages/core_concepts.md
+++ b/docs/pages/core_concepts.md
@@ -58,7 +58,7 @@ You can tell **Kapitan** to **compile** all your targets by running the followin
 ```
 $ kapitan compile
 Rendered inventory (0.06s): discovered 200 targets.
-Compiling 200/200 targets using 64 concurrent processes: (64 CPU detected)
+Compiling 200/200 targets using 64 concurrent processes: (64 CPU available)
 ...
 Compiled production (0.68s)
 ...
@@ -70,7 +70,7 @@ Alternatively, you can select just the target you want to compile, using the `-t
 ```
 $ kapitan compile -t production
 Rendered inventory (0.06s): discovered 200 targets.
-Compiling 1/200 targets using 1 concurrent processes: (64 CPU detected)
+Compiling 1/200 targets using 1 concurrent processes: (64 CPU available)
 Compiled production (0.68s)
 Compiled 1 targets in 0.73s
 ```

--- a/docs/pages/glossary.md
+++ b/docs/pages/glossary.md
@@ -67,7 +67,7 @@ The directory tree produced by `kapitan compile`, located at `compiled/`. Each t
 
 ### Parallelism
 
-Kapitan compiles targets in parallel using multiple processes. The default parallelism is `min(number_of_targets, cpu_count)`. You can control it with the `-p` flag.
+Kapitan compiles targets in parallel using multiple processes. The default parallelism is `min(number_of_targets, available_cpu_count)`, where available CPUs account for process affinity and container CPU limits. You can control it with the `-p` flag.
 
 ## References and secrets
 

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -181,7 +181,7 @@ parameters:
 **Resolution:**
 
 - Compile only the target you need: `kapitan compile -t <target>`.
-- Increase parallelism with `-p` (defaults to CPU count).
+- Increase parallelism with `-p` (defaults to available CPU count).
 - Consider switching to the **reclass-rs** backend for faster inventory rendering.
 - If using OmegaConf, check for expensive custom resolvers.
 

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -254,7 +254,7 @@ def build_parser():
         type=int,
         default=from_dot_kapitan("compile", "parallelism", None),
         metavar="INT",
-        help="Number of concurrent compile processes, default is min(len(targets), os.cpu_count())",
+        help="Number of concurrent compile processes, default is min(len(targets), available CPU count)",
     )
     compile_parser.add_argument(
         "--indent",

--- a/kapitan/inventory/backends/omegaconf/__init__.py
+++ b/kapitan/inventory/backends/omegaconf/__init__.py
@@ -18,6 +18,7 @@ from kadet import Dict
 from kapitan.errors import InventoryError
 from kapitan.inventory import Inventory, InventoryTarget
 from kapitan.inventory.model import KapitanInventoryMetadata, KapitanInventoryParameters
+from kapitan.utils import available_cpu_count
 from omegaconf import ListMergeMode, OmegaConf
 
 from .migrate import migrate
@@ -79,7 +80,7 @@ class OmegaConfInventory(Inventory):
         if not self.initialised:
             manager = mp.Manager()
             shared_targets = manager.dict()
-            with mp.Pool(min(len(targets), os.cpu_count())) as pool:
+            with mp.Pool(min(len(targets), available_cpu_count())) as pool:
                 r = pool.map_async(
                     self.inventory_worker,
                     [(self, target, shared_targets) for target in targets.values()],

--- a/kapitan/inventory/backends/omegaconf/resolvers.py
+++ b/kapitan/inventory/backends/omegaconf/resolvers.py
@@ -34,10 +34,28 @@ def process_literals(obj):
     Converts __KAPITAN_LITERAL__content__KAPITAN_LITERAL_END__ back to ${content}.
     """
     if isinstance(obj, dict):
-        return {k: process_literals(v) for k, v in obj.items()}
+        result = None
+        for k, v in obj.items():
+            processed = process_literals(v)
+            if result is not None:
+                result[k] = processed
+            elif processed is not v:
+                result = dict(obj)
+                result[k] = processed
+        return obj if result is None else result
     if isinstance(obj, list):
-        return [process_literals(item) for item in obj]
+        result = None
+        for index, item in enumerate(obj):
+            processed = process_literals(item)
+            if result is not None:
+                result[index] = processed
+            elif processed is not item:
+                result = list(obj)
+                result[index] = processed
+        return obj if result is None else result
     if isinstance(obj, str):
+        if LITERAL_MARKER_PREFIX not in obj:
+            return obj
         return LITERAL_PATTERN.sub(r"${\1}", obj)
     return obj
 

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -23,6 +23,7 @@ from kapitan.errors import CompileError, InventoryError, KapitanError
 from kapitan.inputs import get_compiler
 from kapitan.profiling import worker_profile
 from kapitan.resources import get_inventory
+from kapitan.utils import available_cpu_count
 
 
 logger = logging.getLogger(__name__)
@@ -84,10 +85,11 @@ def compile_targets(inventory_path, search_paths, ref_controller, args):
             f"No matching targets found in inventory: {labels if labels else args.targets}"
         )
 
-    parallelism = args.parallelism or min(len(targets), os.cpu_count())
+    available_cpus = available_cpu_count()
+    parallelism = args.parallelism or min(len(targets), available_cpus)
 
     logger.info(
-        f"Compiling {len(targets)}/{len(discovered_targets)} targets using {parallelism} concurrent processes: ({os.cpu_count()} CPU detected)"
+        f"Compiling {len(targets)}/{len(discovered_targets)} targets using {parallelism} concurrent processes: ({available_cpus} CPU available)"
     )
 
     # check if --fetch or --force-fetch is enabled

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -39,6 +39,10 @@ from kapitan.version import VERSION
 
 logger = logging.getLogger(__name__)
 
+_CGROUP_V2_CPU_MAX = "/sys/fs/cgroup/cpu.max"
+_CGROUP_V1_CPU_QUOTA = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+_CGROUP_V1_CPU_PERIOD = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
 
 try:
     from enum import StrEnum
@@ -49,6 +53,63 @@ try:
     from yaml import CSafeLoader as YamlLoader
 except ImportError:
     from yaml import SafeLoader as YamlLoader
+
+
+def available_cpu_count():
+    """Return CPUs available to this process, accounting for container limits."""
+    os_cpu_count = os.cpu_count() or 1
+    try:
+        cpu_count = min(
+            os_cpu_count,
+            _cpu_count_from_affinity(os_cpu_count),
+            _cpu_count_from_cgroup(os_cpu_count),
+        )
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        logger.debug("Unable to detect available CPU count: %s", exc)
+        cpu_count = os_cpu_count
+
+    return max(1, int(cpu_count or 1))
+
+
+def _cpu_count_from_affinity(os_cpu_count):
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is None:
+        return os_cpu_count
+
+    try:
+        return len(sched_getaffinity(0))
+    except (NotImplementedError, OSError):
+        return os_cpu_count
+
+
+def _cpu_count_from_cgroup(os_cpu_count):
+    try:
+        if os.path.exists(_CGROUP_V2_CPU_MAX):
+            cpu_quota_us, cpu_period_us = _read_cpu_file(_CGROUP_V2_CPU_MAX).split()
+        elif os.path.exists(_CGROUP_V1_CPU_QUOTA) and os.path.exists(
+            _CGROUP_V1_CPU_PERIOD
+        ):
+            cpu_quota_us = _read_cpu_file(_CGROUP_V1_CPU_QUOTA)
+            cpu_period_us = _read_cpu_file(_CGROUP_V1_CPU_PERIOD)
+        else:
+            return os_cpu_count
+
+        if cpu_quota_us == "max":
+            return os_cpu_count
+
+        cpu_quota_us = int(cpu_quota_us)
+        cpu_period_us = int(cpu_period_us)
+        if cpu_quota_us > 0 and cpu_period_us > 0:
+            return math.ceil(cpu_quota_us / cpu_period_us)
+    except (OSError, ValueError):
+        logger.debug("Unable to detect CPU count from cgroup files", exc_info=True)
+
+    return os_cpu_count
+
+
+def _read_cpu_file(path):
+    with open(path, encoding="utf-8") as cpu_file:
+        return cpu_file.read().strip()
 
 
 def fatal_error(message):

--- a/tests/test_omegaconf.py
+++ b/tests/test_omegaconf.py
@@ -19,7 +19,12 @@ from kapitan.errors import InventoryError
 from kapitan.inventory import get_inventory_backend
 from kapitan.inventory.backends.omegaconf import OmegaConfInventory
 from kapitan.inventory.backends.omegaconf.migrate import migrate_dir, migrate_str
-from kapitan.inventory.backends.omegaconf.resolvers import register_resolvers
+from kapitan.inventory.backends.omegaconf.resolvers import (
+    LITERAL_MARKER_PREFIX,
+    LITERAL_MARKER_SUFFIX,
+    process_literals,
+    register_resolvers,
+)
 from kapitan.resources import get_inventory
 
 
@@ -161,6 +166,31 @@ class TestOmegaConfClassResolution(unittest.TestCase):
         self.assertEqual(resolved, os.path.join(classes_dir, "common.yml"))
 
         shutil.rmtree(temp_dir)
+
+
+class TestOmegaConfProcessLiterals(unittest.TestCase):
+    """Tests for escaped interpolation marker processing."""
+
+    def test_process_literals_preserves_unmodified_tree(self):
+        data = {"a": ["plain", {"nested": "value"}], "b": 1}
+
+        result = process_literals(data)
+
+        self.assertIs(result, data)
+        self.assertIs(result["a"], data["a"])
+        self.assertIs(result["a"][1], data["a"][1])
+
+    def test_process_literals_copies_only_changed_branches(self):
+        literal = f"prefix {LITERAL_MARKER_PREFIX}USER{LITERAL_MARKER_SUFFIX}"
+        unchanged = {"nested": "value"}
+        data = {"a": ["plain", literal], "b": unchanged}
+
+        result = process_literals(data)
+
+        self.assertIsNot(result, data)
+        self.assertIsNot(result["a"], data["a"])
+        self.assertIs(result["b"], unchanged)
+        self.assertEqual(result["a"][1], "prefix ${USER}")
 
 
 class TestOmegaConfInventoryMigrationTiming(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,9 +13,11 @@ import shutil
 import stat
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from kapitan.utils import (
     SafeCopyError,
+    available_cpu_count,
     compare_versions,
     copy_tree,
     deep_get,
@@ -241,6 +243,105 @@ class Sha256StringTest(unittest.TestCase):
         digest = sha256_string("héllo wörld 🌍")
         self.assertEqual(len(digest), 64)
         self.assertTrue(all(c in "0123456789abcdef" for c in digest))
+
+
+class AvailableCpuCountTest(unittest.TestCase):
+    """Test available_cpu_count uses process-aware CPU detection."""
+
+    def test_uses_affinity_count(self):
+        with (
+            patch("kapitan.utils.os.cpu_count", return_value=64),
+            patch(
+                "kapitan.utils.os.sched_getaffinity",
+                create=True,
+                return_value={0, 1},
+            ),
+            patch("kapitan.utils.os.path.exists", return_value=False),
+        ):
+            self.assertEqual(available_cpu_count(), 2)
+
+    def test_uses_cgroup_v2_quota(self):
+        with (
+            patch("kapitan.utils.os.cpu_count", return_value=64),
+            patch(
+                "kapitan.utils.os.sched_getaffinity",
+                create=True,
+                return_value=set(range(64)),
+            ),
+            patch(
+                "kapitan.utils.os.path.exists",
+                side_effect=lambda path: path == "/sys/fs/cgroup/cpu.max",
+            ),
+            patch("kapitan.utils._read_cpu_file", return_value="250000 100000"),
+        ):
+            self.assertEqual(available_cpu_count(), 3)
+
+    def test_uses_cgroup_v1_quota(self):
+        cgroup_files = {
+            "/sys/fs/cgroup/cpu/cpu.cfs_quota_us": "150000",
+            "/sys/fs/cgroup/cpu/cpu.cfs_period_us": "100000",
+        }
+        with (
+            patch("kapitan.utils.os.cpu_count", return_value=64),
+            patch(
+                "kapitan.utils.os.sched_getaffinity",
+                create=True,
+                return_value=set(range(64)),
+            ),
+            patch(
+                "kapitan.utils.os.path.exists",
+                side_effect=lambda path: path in cgroup_files,
+            ),
+            patch(
+                "kapitan.utils._read_cpu_file",
+                side_effect=lambda path: cgroup_files[path],
+            ),
+        ):
+            self.assertEqual(available_cpu_count(), 2)
+
+    def test_cgroup_quota_takes_minimum_with_affinity(self):
+        with (
+            patch("kapitan.utils.os.cpu_count", return_value=64),
+            patch(
+                "kapitan.utils.os.sched_getaffinity",
+                create=True,
+                return_value={0, 1},
+            ),
+            patch(
+                "kapitan.utils.os.path.exists",
+                side_effect=lambda path: path == "/sys/fs/cgroup/cpu.max",
+            ),
+            patch("kapitan.utils._read_cpu_file", return_value="300000 100000"),
+        ):
+            self.assertEqual(available_cpu_count(), 2)
+
+    def test_cgroup_max_uses_os_cpu_count(self):
+        with (
+            patch("kapitan.utils.os.cpu_count", return_value=8),
+            patch(
+                "kapitan.utils.os.sched_getaffinity",
+                create=True,
+                return_value=set(range(8)),
+            ),
+            patch(
+                "kapitan.utils.os.path.exists",
+                side_effect=lambda path: path == "/sys/fs/cgroup/cpu.max",
+            ),
+            patch("kapitan.utils._read_cpu_file", return_value="max 100000"),
+        ):
+            self.assertEqual(available_cpu_count(), 8)
+
+    def test_never_returns_less_than_one(self):
+        with (
+            patch("kapitan.utils.os.cpu_count", return_value=None),
+            patch(
+                "kapitan.utils.os.sched_getaffinity",
+                create=True,
+                return_value=set(),
+            ),
+            patch("kapitan.utils.os.path.exists", return_value=False),
+        ):
+            self.assertEqual(available_cpu_count(), 1)
 
 
 class RenderJinja2TemplateTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

This is a small follow-up on top of #1523 that trims allocation work in the OmegaConf inventory render path.

`process_literals()` currently rebuilds every dict/list in the resolved parameter tree even when there are no `${escape:...}` literal markers to rewrite. This change makes that walk identity-preserving for unchanged branches and only copies the dict/list branch where a literal marker replacement actually occurs.

## Stacking requirement

- Depends on #1523 a.
- This intentionally does not duplicate #1524. 
- After #1523 lands, this branch should be rebased/refreshed so the PR diff shows only the literal-processing change.

## Validation

- `git diff --check`
- `uv run ruff check kapitan/inventory/backends/omegaconf/resolvers.py tests/test_omegoconf.py`
- `uv run --extra omegaconf pytest tests/test_omegoconf.py tests/test_inventory_backend_examples.py -q --no-cov` -> 59 passed, 13 skipped (`reclass-rs` optional backend unavailable locally)
