### PR TITLE
refactor(refs): memoize KMS handlers via functools.cache instead of cached globals

### DIFF
--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -44,6 +44,16 @@ kapitan_input_kadet = None
 # bumps the same shared CacheMetrics across processes.
 input_cache_metrics: dict | None = None
 
+# Memoized secret-handler factories register their ``cache_clear`` here so
+# ``reset_cache`` can flush them without importing the optional cloud SDK
+# modules. Populated lazily as each refs.secrets.* module is imported.
+_handler_cache_clearers: list = []
+
+
+def register_handler_cache_clearer(clear_fn) -> None:
+    """Register a callable that clears a memoized secret-handler factory cache."""
+    _handler_cache_clearers.append(clear_fn)
+
 
 def reset_cache():
     global \
@@ -70,6 +80,10 @@ def reset_cache():
     dot_kapitan = {}
     ref_controller_obj = None
     revealer_obj = None
+
+    # flush memoized secret-handler factories (lru_cache stores)
+    for clear_fn in _handler_cache_clearers:
+        clear_fn()
 
 
 def from_dict(cache_dict: dict[str, Any]) -> None:

--- a/kapitan/refs/secrets/awskms.py
+++ b/kapitan/refs/secrets/awskms.py
@@ -6,6 +6,7 @@
 "awskms secrets module"
 
 import base64
+import functools
 
 import boto3
 
@@ -20,10 +21,19 @@ class AWSKMSError(KapitanError):
     """Generic AWS KMS errors"""
 
 
+@functools.cache
+def _awskms_client():
+    return boto3.session.Session().client("kms")
+
+
 def awskms_obj():
-    if not cached.awskms_obj:
-        cached.awskms_obj = boto3.session.Session().client("kms")
+    # cached.awskms_obj kept as a backward-compatible mirror (pool seeding,
+    # serialization); the memoized factory above is the source of truth.
+    cached.awskms_obj = _awskms_client()
     return cached.awskms_obj
+
+
+cached.register_handler_cache_clearer(_awskms_client.cache_clear)
 
 
 class AWSKMSSecret(Base64Ref):

--- a/kapitan/refs/secrets/azkms.py
+++ b/kapitan/refs/secrets/azkms.py
@@ -1,6 +1,7 @@
 "azkms secret module"
 
 import base64
+import functools
 import logging
 from urllib.parse import urlparse
 
@@ -24,31 +25,37 @@ class AzureKMSError(KapitanError):
     """
 
 
+@functools.cache
+def _azkms_client(key_id):
+    # e.g of key_id https://kapitanbackend.vault.azure.net/keys/myKey/deadbeef
+    url = urlparse(key_id)
+    # ['', 'keys', 'myKey', 'deadbeef'] or ['kapitanbackend.vault.azure.net', 'keys', 'myKey', 'deadbeef']
+    # depending on if key_id is prefixed with https://
+    attrs = url.path.split("/")
+    key_vault_uri = url.hostname or attrs[0]
+    key_name = attrs[-2]
+    key_version = attrs[-1]
+
+    # If --verbose is set, show requests from azure
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        logging.getLogger("azure").setLevel(logging.ERROR)
+    credential = DefaultAzureCredential()
+    key_client = KeyClient(vault_url=f"https://{key_vault_uri}", credential=credential)
+    key = key_client.get_key(key_name, key_version)
+    return CryptographyClient(key, credential)
+
+
 def azkms_obj(key_id):
     """
     Return Azure Key Vault Object
     """
-    # e.g of key_id https://kapitanbackend.vault.azure.net/keys/myKey/deadbeef
-    if not cached.azkms_obj:
-        url = urlparse(key_id)
-        # ['', 'keys', 'myKey', 'deadbeef'] or ['kapitanbackend.vault.azure.net', 'keys', 'myKey', 'deadbeef']
-        # depending on if key_id is prefixed with https://
-        attrs = url.path.split("/")
-        key_vault_uri = url.hostname or attrs[0]
-        key_name = attrs[-2]
-        key_version = attrs[-1]
-
-        # If --verbose is set, show requests from azure
-        if logger.getEffectiveLevel() > logging.DEBUG:
-            logging.getLogger("azure").setLevel(logging.ERROR)
-        credential = DefaultAzureCredential()
-        key_client = KeyClient(
-            vault_url=f"https://{key_vault_uri}", credential=credential
-        )
-        key = key_client.get_key(key_name, key_version)
-        cached.azkms_obj = CryptographyClient(key, credential)
-
+    # cached.azkms_obj kept as a backward-compatible mirror (pool seeding,
+    # serialization); the memoized factory above is the source of truth.
+    cached.azkms_obj = _azkms_client(key_id)
     return cached.azkms_obj
+
+
+cached.register_handler_cache_clearer(_azkms_client.cache_clear)
 
 
 class AzureKMSSecret(Base64Ref):

--- a/kapitan/refs/secrets/gkms.py
+++ b/kapitan/refs/secrets/gkms.py
@@ -6,6 +6,7 @@
 "gkms secrets module"
 
 import base64
+import functools
 import logging
 import warnings
 
@@ -30,14 +31,23 @@ class GoogleKMSError(KapitanError):
     """Generic Google KMS errors"""
 
 
+@functools.cache
+def _gkms_client():
+    # If --verbose is set, show requests from googleapiclient (which are actually logging.INFO)
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        logging.getLogger("googleapiclient.discovery").setLevel(logging.ERROR)
+    kms_client = gcloud.build("cloudkms", "v1", cache_discovery=False)
+    return kms_client.projects().locations().keyRings().cryptoKeys()
+
+
 def gkms_obj():
-    if not cached.gkms_obj:
-        # If --verbose is set, show requests from googleapiclient (which are actually logging.INFO)
-        if logger.getEffectiveLevel() > logging.DEBUG:
-            logging.getLogger("googleapiclient.discovery").setLevel(logging.ERROR)
-        kms_client = gcloud.build("cloudkms", "v1", cache_discovery=False)
-        cached.gkms_obj = kms_client.projects().locations().keyRings().cryptoKeys()
+    # cached.gkms_obj kept as a backward-compatible mirror (pool seeding,
+    # serialization); the memoized factory above is the source of truth.
+    cached.gkms_obj = _gkms_client()
     return cached.gkms_obj
+
+
+cached.register_handler_cache_clearer(_gkms_client.cache_clear)
 
 
 class GoogleKMSSecret(Base64Ref):


### PR DESCRIPTION
## What

First migration step for #1510: it moves memoization of the `gkms` / `awskms` / `azkms` secret-handler clients off the `kapitan.cached` module globals onto module-local `@functools.cache` factories.

- `gkms_obj` / `awskms_obj` / `azkms_obj` now delegate to a memoized `_*_client()` factory. `azkms` is keyed on `key_id`, so distinct keys get distinct clients (previously the first key won and later ones were ignored).
- `cached.{gkms,awskms,azkms}_obj` stay as backward-compatible mirrors, so pool seeding and `cached.as_dict`/`from_dict` serialization aren't affected. They're vestigial now and get removed in the later cleanup step.
- `reset_cache()` flushes the new factory caches through a small clearer registry. That keeps the previous "reset clears handlers" behavior and prevents cross-run client reuse.

I left `gpg_obj` untouched on purpose. Its `*args`/`**kwargs` first-wins semantics need separate care and follow in a later step.

No call-site or public-signature changes.

## Relationship to #1527 (not a dependency, but recommended first)

This PR is independent of #1527. It branches from `master`, touches only `kapitan/cached.py` and `kapitan/refs/secrets/{gkms,awskms,azkms}.py` (disjoint from #1527's test-only files), and can be reviewed and merged in any order.

That said, I'd merge #1527 first. It adds the characterization safety net (including the construct-once + memoize contract for these exact handlers), which is what guards this refactor against silent behavior changes.

## Verification

- Targeted: `tests/test_cached.py`, `tests/test_refs.py`, `tests/test_azure.py` give 57 passed; ruff lint + format clean.
- With #1527's net applied locally, `tests/test_kms_factories.py` passes unchanged against this refactor (construct-once + memoize contract preserved).
- Two unrelated failures exist in this environment regardless of this PR (verified identical on `master`): `test_cuelang_input` (`cue` binary not installed) and `test_linter` (pre-existing `UnicodeDecodeError`). Neither touches the code changed here.