### PR TITLE
refactor(jinja2,utils): make reveal_maybe and null_presenter testable without globals

### DIFF
--- a/kapitan/jinja2_filters.py
+++ b/kapitan/jinja2_filters.py
@@ -93,11 +93,26 @@ def load_jinja2_filters_from_file(env, jinja2_filters):
 
 
 # Custom filters
+def make_reveal_maybe(reveal, revealer):
+    """Build a ``reveal_maybe`` filter bound to an explicit reveal flag and revealer.
+
+    Keeps the filter unit-testable without mutating global state; callers that
+    have the reveal flag and revealer to hand should prefer this over the
+    cache-reading ``reveal_maybe`` shim below.
+    """
+
+    def reveal_maybe(ref_tag):
+        "Will reveal ref_tag if valid and --reveal flag is used"
+        if reveal:
+            return revealer.reveal_raw(ref_tag)
+        return ref_tag
+
+    return reveal_maybe
+
+
 def reveal_maybe(ref_tag):
-    "Will reveal ref_tag if valid and --reveal flag is used"
-    if cached.args.reveal:
-        return cached.revealer_obj.reveal_raw(ref_tag)
-    return ref_tag
+    "Backward-compatible filter reading the global cache; see make_reveal_maybe."
+    return make_reveal_maybe(cached.args.reveal, cached.revealer_obj)(ref_tag)
 
 
 def base64_encode(string):

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -250,8 +250,16 @@ def multiline_str_presenter(dumper, data, style_selection="double-quotes"):
 
 
 def null_presenter(dumper, data):
-    """Configures yaml for omitting value from null-datatype"""
-    flag_value = getattr(cached.args, "yaml_dump_null_as_empty", False)
+    """Configures yaml for omitting value from null-datatype.
+
+    The flag is read from the dumper instance (``dumper.yaml_dump_null_as_empty``)
+    when set explicitly, falling back to the global cache otherwise. Setting the
+    attribute on the dumper makes this representer testable without mutating
+    global state.
+    """
+    flag_value = getattr(dumper, "yaml_dump_null_as_empty", None)
+    if flag_value is None:
+        flag_value = getattr(cached.args, "yaml_dump_null_as_empty", False)
     if flag_value:
         return dumper.represent_scalar("tag:yaml.org,2002:null", "")
     return dumper.represent_scalar("tag:yaml.org,2002:null", "null")

--- a/tests/test_helpers_explicit.py
+++ b/tests/test_helpers_explicit.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the explicit (global-free) paths of leaf helpers.
+
+These exercise make_reveal_maybe and null_presenter through their explicit
+inputs, proving they work without mutating kapitan.cached. The cache-reading
+shims remain covered by the existing characterization tests.
+"""
+
+import unittest
+
+import yaml
+
+# kapitan.utils and kapitan.jinja2_filters have a circular import; importing
+# utils first (it sorts before jinja2_filters) resolves the load order.
+from kapitan import utils
+from kapitan.jinja2_filters import make_reveal_maybe
+
+
+PrettyDumper = utils.PrettyDumper
+
+
+class _FakeRevealer:
+    def __init__(self):
+        self.calls = []
+
+    def reveal_raw(self, ref_tag):
+        self.calls.append(ref_tag)
+        return f"revealed:{ref_tag}"
+
+
+class MakeRevealMaybeTest(unittest.TestCase):
+    """make_reveal_maybe binds an explicit reveal flag + revealer (no globals)."""
+
+    def test_reveal_true_calls_revealer(self):
+        revealer = _FakeRevealer()
+        filt = make_reveal_maybe(reveal=True, revealer=revealer)
+        self.assertEqual(filt("?{gpg:foo}"), "revealed:?{gpg:foo}")
+        self.assertEqual(revealer.calls, ["?{gpg:foo}"])
+
+    def test_reveal_false_passes_through(self):
+        revealer = _FakeRevealer()
+        filt = make_reveal_maybe(reveal=False, revealer=revealer)
+        self.assertEqual(filt("?{gpg:foo}"), "?{gpg:foo}")
+        self.assertEqual(revealer.calls, [])
+
+
+class _EmptyNullDumper(PrettyDumper):
+    yaml_dump_null_as_empty = True
+
+
+class _ExplicitNullDumper(PrettyDumper):
+    yaml_dump_null_as_empty = False
+
+
+class NullPresenterExplicitTest(unittest.TestCase):
+    """null_presenter reads the flag off the dumper without touching cached."""
+
+    def test_dumper_flag_true_omits_value(self):
+        out = yaml.dump({"a": None, "b": 1}, Dumper=_EmptyNullDumper)
+        self.assertEqual(out, "a:\nb: 1\n")
+
+    def test_dumper_flag_false_emits_null(self):
+        out = yaml.dump({"a": None, "b": 1}, Dumper=_ExplicitNullDumper)
+        self.assertEqual(out, "a: null\nb: 1\n")


### PR DESCRIPTION
## What

Part of #1510: decouples two leaf helpers from `kapitan.cached` so they can be unit-tested without mutating global state (this covers the "untestable Jinja2 filters / YAML presenters" points in the issue).

- `jinja2_filters`: adds `make_reveal_maybe(reveal, revealer)`, a factory returning a closure bound to explicit inputs. `reveal_maybe(ref_tag)` becomes a thin cache-reading shim over it, so the registered filter and its runtime behavior stay the same.
- `utils.null_presenter`: reads the flag from the dumper instance (`dumper.yaml_dump_null_as_empty`) when set, falling back to `cached.args` otherwise. Setting the attribute on a dumper makes the representer testable without touching the global cache.

Both global reads stay as fallbacks (removed in a later cleanup step). No call-site or public-signature changes.

Adds `tests/test_helpers_explicit.py` exercising the explicit, global-free paths.

## Note on a latent circular import

`kapitan.utils` and `kapitan.jinja2_filters` import each other. Importing `jinja2_filters` before `utils` fails with a partial-init `ImportError` (reproducible on `master`, unrelated to this change). The new test imports `from kapitan import utils` first to load them in the working order. Worth a proper fix separately, but out of scope here.

## Relationship to #1527 / #1528 (independent, but #1527 recommended first)

Independent of #1527 and #1528. It branches from `master`, touches only `kapitan/jinja2_filters.py`, `kapitan/utils.py`, and a new test file (disjoint from the other branches), so it's mergeable in any order. As before, I'd merge #1527 first: its `NullPresenterTest` characterizes the current `--yaml-dump-null-as-empty` output, and this PR's fallback keeps that test green.

## Verification

`tests/test_helpers_explicit.py tests/test_jinja2.py tests/test_utils.py tests/test_refs.py tests/test_compile.py::CompileTestResourcesTestObjs` gives 123 passed; ruff lint + format clean.