### PR TITLE
refactor(resources): accept explicit get_inventory params, fall back to cached.args

### DIFF
--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -373,48 +373,56 @@ def generate_inventory(args):
         raise
 
 
-def get_inventory(inventory_path, ignore_class_not_found: bool = False) -> Inventory:
+def get_inventory(
+    inventory_path,
+    ignore_class_not_found: bool = False,
+    *,
+    backend_id=None,
+    compose_target_name=None,
+    migrate=None,
+    enable_class_wildcards=None,
+) -> Inventory:
     """
     generic inventory function that makes inventory backend pluggable
     default backend is reclass
+
+    Backend selection and rendering flags may be passed explicitly. When left
+    as None they fall back to the parsed CLI args in ``kapitan.cached.args`` so
+    existing call sites keep working; library callers can pass them directly
+    and avoid depending on the global cache.
     """
 
     # if inventory is already cached there is nothing to do
     if cached.inv and cached.inv.targets:
         return cached.inv
 
-    compose_target_name = (
-        hasattr(cached.args, "compose_target_name") and cached.args.compose_target_name
-    )
-    if hasattr(cached.args, "compose_node_name") and cached.args.compose_node_name:
-        logger.warning(
-            "inventory flag '--compose-node-name' is deprecated and scheduled to be dropped with the next release. "
-            "Please use '--compose-target-name' instead."
-        )
-        compose_target_name = True
+    # fall back to CLI args when a flag is not passed explicitly
+    if backend_id is None:
+        backend_id = getattr(cached.args, "inventory_backend", False)
+    if compose_target_name is None:
+        compose_target_name = getattr(cached.args, "compose_target_name", False)
+        if getattr(cached.args, "compose_node_name", False):
+            logger.warning(
+                "inventory flag '--compose-node-name' is deprecated and scheduled to be dropped with the next release. "
+                "Please use '--compose-target-name' instead."
+            )
+            compose_target_name = True
+    if migrate is None:
+        migrate = getattr(cached.args, "migrate", False)
+    if enable_class_wildcards is None:
+        enable_class_wildcards = getattr(cached.args, "enable_class_wildcards", False)
 
-    # select inventory backend
-    backend_id = (
-        hasattr(cached.args, "inventory_backend") and cached.args.inventory_backend
-    )
-    compose_target_name = (
-        hasattr(cached.args, "compose_target_name") and cached.args.compose_target_name
-    )
     backend = get_inventory_backend(backend_id)
 
     # migrate inventory to selected inventory backend BEFORE instantiating,
     # because the constructor renders the inventory which would fail on
     # un-migrated syntax.
-    if hasattr(cached.args, "migrate") and cached.args.migrate:
+    if migrate:
         migrator = backend(inventory_path=inventory_path, initialise=False)
         migrator.migrate()
 
     logger.debug(f"Using {backend.__name__} as inventory backend")
     try:
-        enable_class_wildcards = (
-            hasattr(cached.args, "enable_class_wildcards")
-            and cached.args.enable_class_wildcards
-        )
         inventory_backend = backend(
             inventory_path=inventory_path,
             compose_target_name=compose_target_name,

--- a/tests/test_get_inventory_explicit.py
+++ b/tests/test_get_inventory_explicit.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""get_inventory explicit-parameter tests.
+
+Proves get_inventory honors backend_id / compose_target_name / migrate /
+enable_class_wildcards passed explicitly, without reading them from
+kapitan.cached.args. cached.args is left deliberately empty so any reliance on
+the global would surface.
+"""
+
+import importlib
+import os
+import shutil
+import tempfile
+import unittest
+from argparse import Namespace
+
+import kapitan.cached
+from kapitan.inventory import InventoryBackends
+from kapitan.resources import get_inventory
+
+
+TEST_PWD = os.getcwd()
+TEST_KUBERNETES_INVENTORY = os.path.join(TEST_PWD, "examples/kubernetes/inventory")
+
+
+class GetInventoryExplicitParamsTest(unittest.TestCase):
+    backend_id = InventoryBackends.RECLASS
+
+    def setUp(self):
+        if not importlib.util.find_spec(self.backend_id.replace("-", "_")):
+            self.skipTest(f"backend module {self.backend_id} not available")
+        # collision inventory: env1 duplicates every target -> only compose
+        # resolves the name clash
+        self.tmp = tempfile.mkdtemp()
+        inv = os.path.join(self.tmp, "inventory")
+        shutil.copytree(TEST_KUBERNETES_INVENTORY, inv)
+        targets = os.path.join(inv, "targets")
+        shutil.copytree(targets, os.path.join(targets, "env1"))
+        self.inventory_path = inv
+        # deliberately empty args: explicit params must drive behavior
+        kapitan.cached.reset_cache()
+        kapitan.cached.args = Namespace()
+
+    def tearDown(self):
+        kapitan.cached.reset_cache()
+        shutil.rmtree(self.tmp)
+
+    def test_compose_true_via_explicit_param(self):
+        inv = get_inventory(
+            self.inventory_path,
+            backend_id=self.backend_id,
+            compose_target_name=True,
+        )
+        names = inv.targets.keys()
+        self.assertIn("minikube-es", names)
+        self.assertIn("env1.minikube-es", names)
+
+    def test_compose_false_via_explicit_param_collides(self):
+        with self.assertRaises(SystemExit):
+            get_inventory(
+                self.inventory_path,
+                backend_id=self.backend_id,
+                compose_target_name=False,
+            )
+
+
+class GetInventoryExplicitParamsTestReclassRs(GetInventoryExplicitParamsTest):
+    backend_id = InventoryBackends.RECLASS_RS


### PR DESCRIPTION
## What

Part of #1510: lets `get_inventory` be driven by explicit arguments instead of reading the parsed CLI args out of the global cache (this covers the "library code can't call get_inventory without populating cached.args" coupling in the issue).

- `get_inventory` gains keyword-only params `backend_id`, `compose_target_name`, `migrate`, `enable_class_wildcards`. When `None` (the default), each falls back to `kapitan.cached.args`, so every existing call site keeps working unchanged.
- Library callers can now load an inventory without populating `cached.args`.
- Drops a redundant duplicate read of `compose_target_name`. The `--compose-node-name` deprecation warning now only fires on the `cached.args` fallback path (the explicit API doesn't carry the deprecated flag).

`cached.inv` / `cached.global_inv` writes stay as the inventory store (removed in a later cleanup step).

Scope: inventory loading only. The `cached.inv` access in `kadet.py` / `inputs/base.py` is a separate concern (inventory access vs loading) and is a follow-up. I kept it out to keep this diff reviewable.

No call-site or public-signature changes (the params are additive keyword-only).

Adds `tests/test_get_inventory_explicit.py` proving the explicit path drives backend + compose selection with an empty `cached.args` (reclass + reclass-rs).

## Relationship to #1527 / #1528 / #1529 (independent, #1527 recommended first)

Independent. It branches from `master`, touches only `kapitan/resources.py` and a new test file (disjoint from the other branches), so it's mergeable in any order. As before, I'd merge #1527 first: its `InventoryComposeFlagSeamTest` exercises the `cached.args` fallback path this PR preserves.

## Verification

- `tests/test_get_inventory_explicit.py tests/test_inventory.py` gives 11 passed (explicit path with empty args, plus existing fallback path).
- `CompileTestResourcesTestObjs / TestKadet / TestJinja2InputParams` gives 7 passed (CLI/fallback path through real compiles).
- ruff lint + format clean.