### PR TITLE
refactor(cached): drop orphaned KMS globals + trim worker payload (#1510 tail, PR-4+5)

### DIFF
--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -44,6 +44,16 @@ kapitan_input_kadet = None
 # bumps the same shared CacheMetrics across processes.
 input_cache_metrics: dict | None = None
 
+# Memoized secret-handler factories register their ``cache_clear`` here so
+# ``reset_cache`` can flush them without importing the optional cloud SDK
+# modules. Populated lazily as each refs.secrets.* module is imported.
+_handler_cache_clearers: list = []
+
+
+def register_handler_cache_clearer(clear_fn) -> None:
+    """Register a callable that clears a memoized secret-handler factory cache."""
+    _handler_cache_clearers.append(clear_fn)
+
 
 def reset_cache():
     global \
@@ -70,6 +80,10 @@ def reset_cache():
     dot_kapitan = {}
     ref_controller_obj = None
     revealer_obj = None
+
+    # flush memoized secret-handler factories (lru_cache stores)
+    for clear_fn in _handler_cache_clearers:
+        clear_fn()
 
 
 def from_dict(cache_dict: dict[str, Any]) -> None:

--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -23,10 +23,9 @@ inventory_global_kadet: dict[str, Any] = {}
 inv_cache: dict[str, Any] = {}
 
 # Secrets handlers
+# gkms/awskms/azkms clients are memoized in their own modules via
+# functools.cache (flushed through the clearer registry below); gpg remains here.
 gpg_obj: Any = None
-gkms_obj: Any = None
-awskms_obj: Any = None
-azkms_obj: Any = None
 
 # Configuration and control objects
 dot_kapitan: dict[str, Any] = {}
@@ -61,9 +60,6 @@ def reset_cache():
         global_inv, \
         inv_cache, \
         gpg_obj, \
-        gkms_obj, \
-        awskms_obj, \
-        azkms_obj, \
         dot_kapitan, \
         ref_controller_obj, \
         revealer_obj, \
@@ -74,9 +70,6 @@ def reset_cache():
     inv_cache = {}
     inv_sources = set()
     gpg_obj = None
-    gkms_obj = None
-    awskms_obj = None
-    azkms_obj = None
     dot_kapitan = {}
     ref_controller_obj = None
     revealer_obj = None
@@ -98,9 +91,6 @@ def from_dict(cache_dict: dict[str, Any]) -> None:
         global_inv, \
         inv_cache, \
         gpg_obj, \
-        gkms_obj, \
-        awskms_obj, \
-        azkms_obj, \
         dot_kapitan, \
         ref_controller_obj, \
         revealer_obj, \
@@ -112,9 +102,6 @@ def from_dict(cache_dict: dict[str, Any]) -> None:
     inv_cache = cache_dict["inv_cache"]
     inv_sources = cache_dict["inv_sources"]
     gpg_obj = cache_dict["gpg_obj"]
-    gkms_obj = cache_dict["gkms_obj"]
-    awskms_obj = cache_dict["awskms_obj"]
-    azkms_obj = cache_dict["azkms_obj"]
     dot_kapitan = cache_dict["dot_kapitan"]
     ref_controller_obj = cache_dict["ref_controller_obj"]
     revealer_obj = cache_dict["revealer_obj"]
@@ -134,9 +121,6 @@ def as_dict() -> dict[str, Any]:
         "inv_cache": inv_cache,
         "inv_sources": inv_sources,
         "gpg_obj": gpg_obj,
-        "gkms_obj": gkms_obj,
-        "awskms_obj": awskms_obj,
-        "azkms_obj": azkms_obj,
         "dot_kapitan": dot_kapitan,
         "ref_controller_obj": ref_controller_obj,
         "revealer_obj": revealer_obj,

--- a/kapitan/jinja2_filters.py
+++ b/kapitan/jinja2_filters.py
@@ -93,11 +93,26 @@ def load_jinja2_filters_from_file(env, jinja2_filters):
 
 
 # Custom filters
+def make_reveal_maybe(reveal, revealer):
+    """Build a ``reveal_maybe`` filter bound to an explicit reveal flag and revealer.
+
+    Keeps the filter unit-testable without mutating global state; callers that
+    have the reveal flag and revealer to hand should prefer this over the
+    cache-reading ``reveal_maybe`` shim below.
+    """
+
+    def reveal_maybe(ref_tag):
+        "Will reveal ref_tag if valid and --reveal flag is used"
+        if reveal:
+            return revealer.reveal_raw(ref_tag)
+        return ref_tag
+
+    return reveal_maybe
+
+
 def reveal_maybe(ref_tag):
-    "Will reveal ref_tag if valid and --reveal flag is used"
-    if cached.args.reveal:
-        return cached.revealer_obj.reveal_raw(ref_tag)
-    return ref_tag
+    "Backward-compatible filter reading the global cache; see make_reveal_maybe."
+    return make_reveal_maybe(cached.args.reveal, cached.revealer_obj)(ref_tag)
 
 
 def base64_encode(string):

--- a/kapitan/refs/secrets/awskms.py
+++ b/kapitan/refs/secrets/awskms.py
@@ -27,10 +27,7 @@ def _awskms_client():
 
 
 def awskms_obj():
-    # cached.awskms_obj kept as a backward-compatible mirror (pool seeding,
-    # serialization); the memoized factory above is the source of truth.
-    cached.awskms_obj = _awskms_client()
-    return cached.awskms_obj
+    return _awskms_client()
 
 
 cached.register_handler_cache_clearer(_awskms_client.cache_clear)

--- a/kapitan/refs/secrets/awskms.py
+++ b/kapitan/refs/secrets/awskms.py
@@ -6,6 +6,7 @@
 "awskms secrets module"
 
 import base64
+import functools
 
 import boto3
 
@@ -20,10 +21,19 @@ class AWSKMSError(KapitanError):
     """Generic AWS KMS errors"""
 
 
+@functools.cache
+def _awskms_client():
+    return boto3.session.Session().client("kms")
+
+
 def awskms_obj():
-    if not cached.awskms_obj:
-        cached.awskms_obj = boto3.session.Session().client("kms")
+    # cached.awskms_obj kept as a backward-compatible mirror (pool seeding,
+    # serialization); the memoized factory above is the source of truth.
+    cached.awskms_obj = _awskms_client()
     return cached.awskms_obj
+
+
+cached.register_handler_cache_clearer(_awskms_client.cache_clear)
 
 
 class AWSKMSSecret(Base64Ref):

--- a/kapitan/refs/secrets/azkms.py
+++ b/kapitan/refs/secrets/azkms.py
@@ -49,10 +49,7 @@ def azkms_obj(key_id):
     """
     Return Azure Key Vault Object
     """
-    # cached.azkms_obj kept as a backward-compatible mirror (pool seeding,
-    # serialization); the memoized factory above is the source of truth.
-    cached.azkms_obj = _azkms_client(key_id)
-    return cached.azkms_obj
+    return _azkms_client(key_id)
 
 
 cached.register_handler_cache_clearer(_azkms_client.cache_clear)

--- a/kapitan/refs/secrets/azkms.py
+++ b/kapitan/refs/secrets/azkms.py
@@ -1,6 +1,7 @@
 "azkms secret module"
 
 import base64
+import functools
 import logging
 from urllib.parse import urlparse
 
@@ -24,31 +25,37 @@ class AzureKMSError(KapitanError):
     """
 
 
+@functools.cache
+def _azkms_client(key_id):
+    # e.g of key_id https://kapitanbackend.vault.azure.net/keys/myKey/deadbeef
+    url = urlparse(key_id)
+    # ['', 'keys', 'myKey', 'deadbeef'] or ['kapitanbackend.vault.azure.net', 'keys', 'myKey', 'deadbeef']
+    # depending on if key_id is prefixed with https://
+    attrs = url.path.split("/")
+    key_vault_uri = url.hostname or attrs[0]
+    key_name = attrs[-2]
+    key_version = attrs[-1]
+
+    # If --verbose is set, show requests from azure
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        logging.getLogger("azure").setLevel(logging.ERROR)
+    credential = DefaultAzureCredential()
+    key_client = KeyClient(vault_url=f"https://{key_vault_uri}", credential=credential)
+    key = key_client.get_key(key_name, key_version)
+    return CryptographyClient(key, credential)
+
+
 def azkms_obj(key_id):
     """
     Return Azure Key Vault Object
     """
-    # e.g of key_id https://kapitanbackend.vault.azure.net/keys/myKey/deadbeef
-    if not cached.azkms_obj:
-        url = urlparse(key_id)
-        # ['', 'keys', 'myKey', 'deadbeef'] or ['kapitanbackend.vault.azure.net', 'keys', 'myKey', 'deadbeef']
-        # depending on if key_id is prefixed with https://
-        attrs = url.path.split("/")
-        key_vault_uri = url.hostname or attrs[0]
-        key_name = attrs[-2]
-        key_version = attrs[-1]
-
-        # If --verbose is set, show requests from azure
-        if logger.getEffectiveLevel() > logging.DEBUG:
-            logging.getLogger("azure").setLevel(logging.ERROR)
-        credential = DefaultAzureCredential()
-        key_client = KeyClient(
-            vault_url=f"https://{key_vault_uri}", credential=credential
-        )
-        key = key_client.get_key(key_name, key_version)
-        cached.azkms_obj = CryptographyClient(key, credential)
-
+    # cached.azkms_obj kept as a backward-compatible mirror (pool seeding,
+    # serialization); the memoized factory above is the source of truth.
+    cached.azkms_obj = _azkms_client(key_id)
     return cached.azkms_obj
+
+
+cached.register_handler_cache_clearer(_azkms_client.cache_clear)
 
 
 class AzureKMSSecret(Base64Ref):

--- a/kapitan/refs/secrets/gkms.py
+++ b/kapitan/refs/secrets/gkms.py
@@ -41,10 +41,7 @@ def _gkms_client():
 
 
 def gkms_obj():
-    # cached.gkms_obj kept as a backward-compatible mirror (pool seeding,
-    # serialization); the memoized factory above is the source of truth.
-    cached.gkms_obj = _gkms_client()
-    return cached.gkms_obj
+    return _gkms_client()
 
 
 cached.register_handler_cache_clearer(_gkms_client.cache_clear)

--- a/kapitan/refs/secrets/gkms.py
+++ b/kapitan/refs/secrets/gkms.py
@@ -6,6 +6,7 @@
 "gkms secrets module"
 
 import base64
+import functools
 import logging
 import warnings
 
@@ -30,14 +31,23 @@ class GoogleKMSError(KapitanError):
     """Generic Google KMS errors"""
 
 
+@functools.cache
+def _gkms_client():
+    # If --verbose is set, show requests from googleapiclient (which are actually logging.INFO)
+    if logger.getEffectiveLevel() > logging.DEBUG:
+        logging.getLogger("googleapiclient.discovery").setLevel(logging.ERROR)
+    kms_client = gcloud.build("cloudkms", "v1", cache_discovery=False)
+    return kms_client.projects().locations().keyRings().cryptoKeys()
+
+
 def gkms_obj():
-    if not cached.gkms_obj:
-        # If --verbose is set, show requests from googleapiclient (which are actually logging.INFO)
-        if logger.getEffectiveLevel() > logging.DEBUG:
-            logging.getLogger("googleapiclient.discovery").setLevel(logging.ERROR)
-        kms_client = gcloud.build("cloudkms", "v1", cache_discovery=False)
-        cached.gkms_obj = kms_client.projects().locations().keyRings().cryptoKeys()
+    # cached.gkms_obj kept as a backward-compatible mirror (pool seeding,
+    # serialization); the memoized factory above is the source of truth.
+    cached.gkms_obj = _gkms_client()
     return cached.gkms_obj
+
+
+cached.register_handler_cache_clearer(_gkms_client.cache_clear)
 
 
 class GoogleKMSSecret(Base64Ref):

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -373,48 +373,56 @@ def generate_inventory(args):
         raise
 
 
-def get_inventory(inventory_path, ignore_class_not_found: bool = False) -> Inventory:
+def get_inventory(
+    inventory_path,
+    ignore_class_not_found: bool = False,
+    *,
+    backend_id=None,
+    compose_target_name=None,
+    migrate=None,
+    enable_class_wildcards=None,
+) -> Inventory:
     """
     generic inventory function that makes inventory backend pluggable
     default backend is reclass
+
+    Backend selection and rendering flags may be passed explicitly. When left
+    as None they fall back to the parsed CLI args in ``kapitan.cached.args`` so
+    existing call sites keep working; library callers can pass them directly
+    and avoid depending on the global cache.
     """
 
     # if inventory is already cached there is nothing to do
     if cached.inv and cached.inv.targets:
         return cached.inv
 
-    compose_target_name = (
-        hasattr(cached.args, "compose_target_name") and cached.args.compose_target_name
-    )
-    if hasattr(cached.args, "compose_node_name") and cached.args.compose_node_name:
-        logger.warning(
-            "inventory flag '--compose-node-name' is deprecated and scheduled to be dropped with the next release. "
-            "Please use '--compose-target-name' instead."
-        )
-        compose_target_name = True
+    # fall back to CLI args when a flag is not passed explicitly
+    if backend_id is None:
+        backend_id = getattr(cached.args, "inventory_backend", False)
+    if compose_target_name is None:
+        compose_target_name = getattr(cached.args, "compose_target_name", False)
+        if getattr(cached.args, "compose_node_name", False):
+            logger.warning(
+                "inventory flag '--compose-node-name' is deprecated and scheduled to be dropped with the next release. "
+                "Please use '--compose-target-name' instead."
+            )
+            compose_target_name = True
+    if migrate is None:
+        migrate = getattr(cached.args, "migrate", False)
+    if enable_class_wildcards is None:
+        enable_class_wildcards = getattr(cached.args, "enable_class_wildcards", False)
 
-    # select inventory backend
-    backend_id = (
-        hasattr(cached.args, "inventory_backend") and cached.args.inventory_backend
-    )
-    compose_target_name = (
-        hasattr(cached.args, "compose_target_name") and cached.args.compose_target_name
-    )
     backend = get_inventory_backend(backend_id)
 
     # migrate inventory to selected inventory backend BEFORE instantiating,
     # because the constructor renders the inventory which would fail on
     # un-migrated syntax.
-    if hasattr(cached.args, "migrate") and cached.args.migrate:
+    if migrate:
         migrator = backend(inventory_path=inventory_path, initialise=False)
         migrator.migrate()
 
     logger.debug(f"Using {backend.__name__} as inventory backend")
     try:
-        enable_class_wildcards = (
-            hasattr(cached.args, "enable_class_wildcards")
-            and cached.args.enable_class_wildcards
-        )
         inventory_backend = backend(
             inventory_path=inventory_path,
             compose_target_name=compose_target_name,

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -250,8 +250,16 @@ def multiline_str_presenter(dumper, data, style_selection="double-quotes"):
 
 
 def null_presenter(dumper, data):
-    """Configures yaml for omitting value from null-datatype"""
-    flag_value = getattr(cached.args, "yaml_dump_null_as_empty", False)
+    """Configures yaml for omitting value from null-datatype.
+
+    The flag is read from the dumper instance (``dumper.yaml_dump_null_as_empty``)
+    when set explicitly, falling back to the global cache otherwise. Setting the
+    attribute on the dumper makes this representer testable without mutating
+    global state.
+    """
+    flag_value = getattr(dumper, "yaml_dump_null_as_empty", None)
+    if flag_value is None:
+        flag_value = getattr(cached.args, "yaml_dump_null_as_empty", False)
     if flag_value:
         return dumper.represent_scalar("tag:yaml.org,2002:null", "")
     return dumper.represent_scalar("tag:yaml.org,2002:null", "null")

--- a/tests/test_cached.py
+++ b/tests/test_cached.py
@@ -23,9 +23,6 @@ class TestResetCache:
         cached.inv_cache = {"cache": "entry"}
         cached.inv_sources = {"source1", "source2"}
         cached.gpg_obj = "gpg"
-        cached.gkms_obj = "gkms"
-        cached.awskms_obj = "awskms"
-        cached.azkms_obj = "azkms"
         cached.dot_kapitan = {"dot": "kapitan"}
         cached.ref_controller_obj = "ref"
         cached.revealer_obj = "revealer"
@@ -39,9 +36,6 @@ class TestResetCache:
         assert cached.inv_cache == {}
         assert cached.inv_sources == set()
         assert cached.gpg_obj is None
-        assert cached.gkms_obj is None
-        assert cached.awskms_obj is None
-        assert cached.azkms_obj is None
         assert cached.dot_kapitan == {}
         assert cached.ref_controller_obj is None
         assert cached.revealer_obj is None
@@ -68,9 +62,6 @@ class TestFromDict:
             "inv_cache": {"cache_key": "cache_value"},
             "inv_sources": {"source1", "source2"},
             "gpg_obj": "test_gpg",
-            "gkms_obj": "test_gkms",
-            "awskms_obj": "test_awskms",
-            "azkms_obj": "test_azkms",
             "dot_kapitan": {"dot_key": "dot_value"},
             "ref_controller_obj": "test_ref",
             "revealer_obj": "test_revealer",
@@ -84,9 +75,6 @@ class TestFromDict:
         assert cached.inv_cache == {"cache_key": "cache_value"}
         assert cached.inv_sources == {"source1", "source2"}
         assert cached.gpg_obj == "test_gpg"
-        assert cached.gkms_obj == "test_gkms"
-        assert cached.awskms_obj == "test_awskms"
-        assert cached.azkms_obj == "test_azkms"
         assert cached.dot_kapitan == {"dot_key": "dot_value"}
         assert cached.ref_controller_obj == "test_ref"
         assert cached.revealer_obj == "test_revealer"

--- a/tests/test_get_inventory_explicit.py
+++ b/tests/test_get_inventory_explicit.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""get_inventory explicit-parameter tests.
+
+Proves get_inventory honors backend_id / compose_target_name / migrate /
+enable_class_wildcards passed explicitly, without reading them from
+kapitan.cached.args. cached.args is left deliberately empty so any reliance on
+the global would surface.
+"""
+
+import importlib
+import os
+import shutil
+import tempfile
+import unittest
+from argparse import Namespace
+
+import kapitan.cached
+from kapitan.inventory import InventoryBackends
+from kapitan.resources import get_inventory
+
+
+TEST_PWD = os.getcwd()
+TEST_KUBERNETES_INVENTORY = os.path.join(TEST_PWD, "examples/kubernetes/inventory")
+
+
+class GetInventoryExplicitParamsTest(unittest.TestCase):
+    backend_id = InventoryBackends.RECLASS
+
+    def setUp(self):
+        if not importlib.util.find_spec(self.backend_id.replace("-", "_")):
+            self.skipTest(f"backend module {self.backend_id} not available")
+        # collision inventory: env1 duplicates every target -> only compose
+        # resolves the name clash
+        self.tmp = tempfile.mkdtemp()
+        inv = os.path.join(self.tmp, "inventory")
+        shutil.copytree(TEST_KUBERNETES_INVENTORY, inv)
+        targets = os.path.join(inv, "targets")
+        shutil.copytree(targets, os.path.join(targets, "env1"))
+        self.inventory_path = inv
+        # deliberately empty args: explicit params must drive behavior
+        kapitan.cached.reset_cache()
+        kapitan.cached.args = Namespace()
+
+    def tearDown(self):
+        kapitan.cached.reset_cache()
+        shutil.rmtree(self.tmp)
+
+    def test_compose_true_via_explicit_param(self):
+        inv = get_inventory(
+            self.inventory_path,
+            backend_id=self.backend_id,
+            compose_target_name=True,
+        )
+        names = inv.targets.keys()
+        self.assertIn("minikube-es", names)
+        self.assertIn("env1.minikube-es", names)
+
+    def test_compose_false_via_explicit_param_collides(self):
+        with self.assertRaises(SystemExit):
+            get_inventory(
+                self.inventory_path,
+                backend_id=self.backend_id,
+                compose_target_name=False,
+            )
+
+
+class GetInventoryExplicitParamsTestReclassRs(GetInventoryExplicitParamsTest):
+    backend_id = InventoryBackends.RECLASS_RS

--- a/tests/test_helpers_explicit.py
+++ b/tests/test_helpers_explicit.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the explicit (global-free) paths of leaf helpers.
+
+These exercise make_reveal_maybe and null_presenter through their explicit
+inputs, proving they work without mutating kapitan.cached. The cache-reading
+shims remain covered by the existing characterization tests.
+"""
+
+import unittest
+
+import yaml
+
+# kapitan.utils and kapitan.jinja2_filters have a circular import; importing
+# utils first (it sorts before jinja2_filters) resolves the load order.
+from kapitan import utils
+from kapitan.jinja2_filters import make_reveal_maybe
+
+
+PrettyDumper = utils.PrettyDumper
+
+
+class _FakeRevealer:
+    def __init__(self):
+        self.calls = []
+
+    def reveal_raw(self, ref_tag):
+        self.calls.append(ref_tag)
+        return f"revealed:{ref_tag}"
+
+
+class MakeRevealMaybeTest(unittest.TestCase):
+    """make_reveal_maybe binds an explicit reveal flag + revealer (no globals)."""
+
+    def test_reveal_true_calls_revealer(self):
+        revealer = _FakeRevealer()
+        filt = make_reveal_maybe(reveal=True, revealer=revealer)
+        self.assertEqual(filt("?{gpg:foo}"), "revealed:?{gpg:foo}")
+        self.assertEqual(revealer.calls, ["?{gpg:foo}"])
+
+    def test_reveal_false_passes_through(self):
+        revealer = _FakeRevealer()
+        filt = make_reveal_maybe(reveal=False, revealer=revealer)
+        self.assertEqual(filt("?{gpg:foo}"), "?{gpg:foo}")
+        self.assertEqual(revealer.calls, [])
+
+
+class _EmptyNullDumper(PrettyDumper):
+    yaml_dump_null_as_empty = True
+
+
+class _ExplicitNullDumper(PrettyDumper):
+    yaml_dump_null_as_empty = False
+
+
+class NullPresenterExplicitTest(unittest.TestCase):
+    """null_presenter reads the flag off the dumper without touching cached."""
+
+    def test_dumper_flag_true_omits_value(self):
+        out = yaml.dump({"a": None, "b": 1}, Dumper=_EmptyNullDumper)
+        self.assertEqual(out, "a:\nb: 1\n")
+
+    def test_dumper_flag_false_emits_null(self):
+        out = yaml.dump({"a": None, "b": 1}, Dumper=_ExplicitNullDumper)
+        self.assertEqual(out, "a: null\nb: 1\n")


### PR DESCRIPTION
## ⚠️ Stacked, merge after #1528, #1529, #1530

This is the dependent cleanup tail of the #1510 series. It's built on top of #1528 + #1529 + #1530, so this PR's diff currently includes those three. They'll drop out of the diff automatically as they merge, so merge this last. It combines the planned PR-4 (worker payload) and PR-5 (delete globals) into one PR, per maintainer preference.

## What (the tail-specific changes)

Now that `gkms`/`awskms`/`azkms` clients are memoized in their own modules via `functools.cache` (from #1528), the `cached.*_obj` mirrors are dead weight:

- remove the mirror writes from `gkms_obj`/`awskms_obj`/`azkms_obj` (return the memoized client directly)
- delete `cached.gkms_obj` / `cached.awskms_obj` / `cached.azkms_obj` and their entries in `reset_cache` / `as_dict` / `from_dict`
- update `test_cached.py` accordingly

Multiprocessing payload (the PR-4 part): the per-worker seed dict (`cached.as_dict`) no longer carries the three KMS client objects. Workers rebuild them lazily via `functools.cache` instead of getting them in the pickled payload. `reset_cache` still flushes those caches through the clearer registry. (Note: #1519 already made worker seeding once-per-worker, so this is a payload trim rather than a rework.)

## Deliberately retained (out of scope)

- `gpg_obj`, because its `*args`/`**kwargs` first-wins semantics need separate care.
- `cached.args` fallbacks (in `get_inventory`, `null_presenter`, `reveal_maybe`) and the `cached.inv` store. Removing these means wiring explicit params through `cli.py` / `targets.py` / `refs/cmd_parser.py`, which overlaps the in-flight OmegaConf perf PRs (#1524/#1525). Left as a further step.

## Note for #1527

#1527's `test_kms_factories.py` asserts `cached.gkms_obj is <client>` (the mirror this PR removes). When both land, those two `assertIs(cached.*_obj, ...)` lines should be dropped. The construct-once + memoize contract they check is preserved, only the global mirror is gone. Tracked as follow-up #1532.

## Verification

`tests/test_cached.py tests/test_refs.py tests/test_azure.py tests/test_targets.py tests/test_compile.py::CompileTestResourcesTestObjs` gives 84 passed; ruff lint + format clean.