### PR TITLE
fix(sbom): pin SBOM tool to Python 3.13 to avoid lxml source build

### DIFF
--- a/scripts/generate_sbom.sh
+++ b/scripts/generate_sbom.sh
@@ -57,7 +57,13 @@ echo "Exported $(wc -l < "${REQUIREMENTS_FILE}") dependency lines"
 # Note: --pyproject is intentionally omitted; it crashes cyclonedx-bom 4.x
 #       (observed in 4.6.1 with "'str' object has no attribute 'get'").
 #       Re-evaluate when bumping to cyclonedx-bom 5.x.
-uvx --from 'cyclonedx-bom>=4,<5' cyclonedx-py requirements \
+# --python 3.13: run the tool under a Python with prebuilt lxml wheels. lxml is
+#       a transitive dep of cyclonedx-python-lib[validation] and has no cp314
+#       wheels yet, so on Python 3.14 uv builds it from source and fails on
+#       runners lacking libxml2/libxslt dev headers. Pinning the tool's
+#       interpreter keeps it independent of the project's Python, which tracks
+#       pyproject's requires-python upper bound (<3.15) and may select 3.14.
+uvx --python 3.13 --from 'cyclonedx-bom>=4,<5' cyclonedx-py requirements \
     --mc-type application \
     --of JSON \
     --output-reproducible \


### PR DESCRIPTION
## What

The `Generate SBOM` step in `python-pypi-publish` started failing on the 0.36.0 release ([run](https://github.com/kapicorp/kapitan/actions/runs/27443948160/job/81156573258)):

```
× Failed to build `lxml==5.4.0`
  Error: Please make sure the libxml2 and libxslt development packages are installed.
hint: `lxml` (v5.4.0) was included because `cyclonedx-bom` (v4.6.1) depends on
      `cyclonedx-python-lib[validation]` (v7.6.2) which depends on `lxml`
```

This pins the `uvx` interpreter that runs the SBOM generator to `--python 3.13`, so it uses a Python that has prebuilt lxml wheels.

## Why

Nothing in our code changed — a new runner Python tripped a latent assumption. The `Generate SBOM` step uses `setup-python` with `python-version-file: pyproject.toml`, and our `requires-python = ">=3.10,<3.15"` now resolves to **Python 3.14.5** on GitHub runners. The script then runs `cyclonedx-bom` through `uvx` under that ambient Python.

`cyclonedx-python-lib[validation]` pulls in `lxml`, and lxml 5.4.0 has no cp314 wheels yet, so uv falls back to building it from source — which dies on the runner because the libxml2/libxslt dev headers aren't there. On 3.13 lxml ships a wheel and the step passed, which is why this only surfaced now.

Worth noting lxml is *only* a dependency of the SBOM tooling, not of kapitan itself — the dependency export earlier in the same job completes fine.

## Approach

I pinned the tool's interpreter rather than installing the dev headers or pinning the whole job to 3.13. The SBOM generator only reads an already-exported requirements file, so the Python it runs under is independent of the versions kapitan supports. Pinning it keeps the fix contained to the one tool that needs lxml, and leaves the project Python free to track `requires-python`. The alternatives (apt-installing headers for a slow source build, or capping the whole job's Python) both have a wider blast radius for no benefit here.

## Verification

Locally, `uvx --python 3.13 --from 'cyclonedx-bom>=4,<5' cyclonedx-py --version` installs lxml as a **wheel** (no source build) and runs clean (reports 4.6.1). Under the runner's 3.14 the same command builds lxml from source and fails. shellcheck + pre-commit pass on the change.
