### PR TITLE
ci(docs): publish versioned docs on every stable release

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,10 @@ concurrency:
 
 on:
   workflow_dispatch:
+  release:
+    # Publish a versioned docs set (e.g. /0.36/) and move the "latest" alias
+    # on every stable GitHub release. See the "Deploy release docs" step.
+    types: [published]
   pull_request:
     paths:
       - 'docs/**'
@@ -47,10 +51,24 @@ jobs:
       - name: Verify rendering
         run: uv run pytest tests/test_docs_rendering.py -v --no-cov
 
-      - name: Deploy docs
-        if: github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch
+      # On master pushes (and manual dispatch): refresh the rolling "dev" docs.
+      - name: Deploy dev docs
+        if: github.event_name != 'pull_request' && github.event_name != 'release' && github.ref_name == github.event.repository.default_branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_COMMITTER_NAME: mike-mkdocs-bot
           GIT_COMMITTER_EMAIL: admins@kapicorp
         run: uv run mike deploy --push dev master
+
+      # On a stable release (tag v0.36.0): publish the docs under the
+      # major.minor version (0.36) and point the "latest" alias at it.
+      - name: Deploy release docs
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_COMMITTER_NAME: mike-mkdocs-bot
+          GIT_COMMITTER_EMAIL: admins@kapicorp
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"   # 0.36.0
+          DOCS_VERSION="${VERSION%.*}"     # 0.36
+          uv run mike deploy --push --update-aliases "$DOCS_VERSION" latest


### PR DESCRIPTION
## What

The docs site only ever deployed the rolling `dev` version on master pushes — versioned sets (`/0.x/`) and the `latest` alias were updated by hand. So 0.35 and 0.36 shipped without docs versions, and `latest` was stuck on 0.33.

This adds a `release` trigger to the documentation workflow. A stable GitHub release now publishes the docs under its major.minor version and moves `latest` to it:

```
v0.36.0  ->  mike deploy --push --update-aliases 0.36 latest
```

## Why

Versioning was a manual step that got skipped, leaving the published docs out of sync with releases.

## Approach

- Added `release: types: [published]` to the workflow triggers.
- New **Deploy release docs** step: strips the leading `v` from the tag, derives major.minor (`v0.36.0` → `0.36`), and runs `mike deploy --update-aliases <X.Y> latest`.
- The existing **dev** deploy is unchanged, now explicitly skipped on release events.
- Versioned deploys commit under the existing `mike-mkdocs-bot` identity (no human committer).

## Verification

- Backfilled the gap directly on `gh-pages`: removed an accidental `0.1` version and the stray `unstable` alias, deployed `0.36`, and moved `latest` → `0.36`. Current versions: `dev [master]`, `0.36 [latest]`, `0.34`, `0.33`.
- The new step mirrors the verified backfill command, parameterized by the release tag.

Note: automation only applies to future releases — 0.35 is intentionally not backfilled.