### PR TITLE
docs(blog): introduce inventory topics

### DIFF
--- a/docs/pages/blog/posts/2026-05-18-inventory-topics.md
+++ b/docs/pages/blog/posts/2026-05-18-inventory-topics.md
@@ -1,0 +1,146 @@
+---
+author: The Kapitan Team
+author_gh_user: kapicorp
+read_time: 5m
+date: 2026-05-18
+title: "Introducing Topics for Organising Kapitan Targets"
+description: "A backend-agnostic way to expose, aggregate, and consume parameters across Kapitan targets, without cryptic reclass queries."
+---
+
+# :kapitan-logo: **Introducing Topics for Organising Kapitan Targets**
+
+Every so often a target needs to know something about its neighbours. One target wants the list of every database another target provisions; a dashboard wants the endpoints exposed by a dozen services. Until now the answers were either reclass exports (powerful, but the query syntax makes our eyes water) or a full `inventory_global()` scan in a component (works, but it reads *everything* just to find a handful of values).
+
+We wanted something simpler: let a target say "here is the bit I'm willing to share", and let other targets collect those bits without caring which inventory backend is underneath. That's what **topics** are.
+
+<!-- more -->
+
+## Opting in
+
+A target joins a topic by declaring parameters under `parameters.kapitan.topics.<topic_name>.parameters`. Nothing else needs wiring up. Here are two targets that both publish a `colour` into a `colours` topic:
+
+!!! example "`inventory/targets/target-1.yml`"
+    ```yaml
+    parameters:
+      colour: red
+      kapitan:
+        topics:
+          colours:
+            parameters:
+              colour: ${colour}
+    ```
+
+!!! example "`inventory/targets/target-2.yml`"
+    ```yaml
+    parameters:
+      colour: blue
+      kapitan:
+        topics:
+          colours:
+            parameters:
+              colour: ${colour}
+    ```
+
+The key detail: a topic only ever carries what a target *explicitly* puts under it. A target that never mentions `topics` contributes nothing and pays no cost. There's no scanning, no opt-out, no surprise leakage of unrelated parameters.
+
+Kapitan aggregates every participating target into one view, shaped like this:
+
+```yaml
+parameters:
+  targets:
+    target-1:
+      colour: red
+    target-2:
+      colour: blue
+```
+
+A third target that doesn't touch `colours` simply won't appear. That's the whole model.
+
+## Inspecting topics from the CLI
+
+Before you write any component, you can look at the aggregated result directly. The `inventory` subcommand grew a `--topics` flag:
+
+```shell
+kapitan inventory --topics
+```
+
+That dumps every topic. Pass a name to narrow it down to one:
+
+```shell
+kapitan inventory --topics colours
+```
+
+```yaml
+parameters:
+  targets:
+    target-1:
+      colour: red
+    target-2:
+      colour: blue
+```
+
+It composes with the flags you already know. `--pattern` drills into the structure, and `--flat` gives you flat dotted keys:
+
+```shell
+kapitan inventory --topics colours --pattern parameters.targets
+kapitan inventory --topics --flat
+```
+
+!!! note
+    `--pattern` normally needs a target name. With `--topics` that requirement is relaxed, since the topic view is the thing you're drilling into.
+
+## Consuming a topic in a component
+
+There's a new `topics()` function, and it's available to every input type. Call it with no arguments for the full mapping, or with a name for a single topic.
+
+In **kadet**, import it from `kapitan.inputs.kadet` and you get attribute-style access:
+
+!!! example "`components/painter/__init__.py`"
+    ```python
+    from kapitan.inputs.kadet import topics
+
+    def main():
+        target_colours = {}
+        for target, parameters in topics("colours").parameters.targets.items():
+            target_colours[target] = {"colour": parameters.colour}
+        return target_colours
+    ```
+
+In **jinja2**, `topics` is injected into the template context:
+
+!!! example "`components/painter.j2`"
+    ```jinja
+    {% for target, parameters in topics("colours").parameters.targets.items() %}
+    {{ target }}:
+      colour: {{ parameters.colour }}
+    {% endfor %}
+    ```
+
+And in **jsonnet**, it's exposed through the Kapitan library:
+
+!!! example "`components/painter.jsonnet`"
+    ```jsonnet
+    local kap = import "lib/kapitan.libjsonnet";
+    {
+      [target]: { colour: params.parameters.colour }
+      for target in std.objectFields(kap.topics("colours").parameters.targets)
+      for params in [kap.topics("colours").parameters.targets[target]]
+    }
+    ```
+
+All three compile to the same thing:
+
+```yaml
+target-1:
+  colour: red
+target-2:
+  colour: blue
+```
+
+If you ask for a topic that nobody publishes to, you don't get an exception. You get an empty but well-shaped result, so `topics("nope").parameters.targets.items()` just iterates over nothing. We'd rather your component degrade quietly than blow up on a typo.
+
+## Why we built it this way
+
+The honest motivation was reclass exports. They solve the cross-target problem, but the query expressions are hard to reason about and they tie you to one backend. Topics are deliberately dumber: a target opts in, Kapitan collects, a component reads. No queries, no backend-specific behaviour, and it works the same under reclass, reclass-rs, and omegaconf.
+
+It won't replace exports for every case. If you need conditional inventory queries or computed lookups, reclass still has more reach. But for the common "let me gather a value from a set of targets" job, topics are a lot less to think about. Give them a spin with `kapitan inventory --topics` and see what your targets are willing to share.


### PR DESCRIPTION
> Draft until #1537 and #1538 (the SEO frontmatter gate) merge — this post depends on the title/description frontmatter those PRs enforce.

## What

A new blog post introducing the **topics** feature from #1466. It walks through opting a target into a topic, inspecting the aggregated view with `kapitan inventory --topics`, and consuming a topic from kadet, jinja2, and jsonnet components.

## Why

Topics shipped in #1466 but we hadn't told anyone the story behind them. They're our answer to the cross-target sharing problem that previously meant reclass exports or expensive `inventory_global()` scans. A post lets us explain the motivation (the original ask in #1421) and show the actual YAML and commands people will use.

## Approach

I read the merged PR diff and the linked issue before writing a word, then grounded every example against what the code actually does:

- The opt-in shape `parameters.kapitan.topics.<name>.parameters` and the aggregated `{parameters: {targets: {...}}}` view come straight from `kapitan/topics.py` and `kapitan/inventory/inventory.py`.
- The `topics()` calls for kadet, jinja2, and jsonnet are lifted from the real wirings in `kapitan/inputs/kadet.py`, `kapitan/inputs/jinja2.py`, and `kapitan/lib/kapitan.libjsonnet`.
- The `--topics` CLI flag, its `--pattern`/`--flat` composition, and the relaxed `--pattern` requirement match `kapitan/cli.py` and `kapitan/resources.py`.
- The empty-but-well-shaped fallback for unknown topics is the documented behaviour of `topics()`.

Voice follows the existing blog: first person, a couple of dry asides, real commands and output. I kept the honest caveat that topics don't replace reclass exports for every case.

## Verification

- Frontmatter parses as YAML; title is 49 chars and description is 124 chars (both inside the SEO gate ranges).
- No pytest/mkdocs run, per the task scope.
