### PR TITLE
fix(ci): keep dist/ clean so PyPI publish does not reject SBOM/checksums

### DIFF
--- a/.github/workflows/python-pypi-publish-dev.yml
+++ b/.github/workflows/python-pypi-publish-dev.yml
@@ -46,7 +46,9 @@ jobs:
       - name: Build and check
         run: |
           uv build
-          uvx twine check dist/*
+          # Restrict to actual distributions so this stays correct if
+          # non-package artifacts (SBOM, checksums) are ever added to dist/.
+          uvx twine check dist/*.whl dist/*.tar.gz
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/python-pypi-publish.yml
+++ b/.github/workflows/python-pypi-publish.yml
@@ -51,27 +51,35 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Detected version: ${VERSION}"
+      - name: Stage release artifacts
+        run: |
+          # Keep dist/ pristine (wheel + sdist only) so the PyPI publish step,
+          # which uploads everything in dist/, is not fed non-distribution
+          # files (SBOM, SHA256SUMS) that twine rejects. Release-only extras
+          # live in release/ alongside copies of the distributions.
+          mkdir -p release
+          cp dist/kapitan-*.whl dist/kapitan-*.tar.gz release/
       - name: Generate SBOM
         timeout-minutes: 10
         run: |
-          scripts/generate_sbom.sh "${{ steps.version.outputs.version }}" dist
+          scripts/generate_sbom.sh "${{ steps.version.outputs.version }}" release
       - name: Generate SHA256 checksums
         timeout-minutes: 5
         run: |
-          scripts/generate_checksums.sh dist dist/SHA256SUMS
+          scripts/generate_checksums.sh release release/SHA256SUMS
       - name: Validate checksums
         timeout-minutes: 5
         run: |
-          (cd dist && sha256sum -c SHA256SUMS)
+          (cd release && sha256sum -c SHA256SUMS)
       - name: Upload release artifacts
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
         with:
           files: |
-            dist/kapitan-*.whl
-            dist/kapitan-*.tar.gz
-            dist/kapitan-${{ steps.version.outputs.version }}.python.sbom.cdx.json
-            dist/SHA256SUMS
+            release/kapitan-*.whl
+            release/kapitan-*.tar.gz
+            release/kapitan-${{ steps.version.outputs.version }}.python.sbom.cdx.json
+            release/SHA256SUMS
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:


### PR DESCRIPTION
## What

Fix the PyPI publish job in `python-pypi-publish.yml`, which failed on the v0.36.0 release.

## Why

The job writes the SBOM and `SHA256SUMS` into `dist/`, then `pypa/gh-action-pypi-publish` uploads everything in its `packages-dir` (`dist/` by default). twine validates every file in there and rejects the non-distribution ones:

```
Checking dist/SHA256SUMS: ERROR InvalidDistribution: Unknown distribution format: 'SHA256SUMS'
```

So the publish step died and v0.36.0 never reached PyPI. (The earlier "Build and check" `twine check dist/*` passed because it ran before those extra files existed.)

## Approach

Keep `dist/` holding only what PyPI should receive — the wheel and sdist. Stage the release-only extras in a separate `release/` dir: copies of the wheel and sdist (so the checksum manifest can reference them), the SBOM, and `SHA256SUMS`. The GitHub release upload now pulls from `release/`. Checksum validation still runs before publishing.

I considered just pointing the publish step at a clean dir via `packages-dir`, but keeping `dist/` itself clean felt less surprising for anyone reading the workflow later.

## Verification

- `actionlint` passes (pre-commit).
- `dist/` contains only `kapitan-*.whl` and `kapitan-*.tar.gz` at publish time, so twine has nothing to choke on.
- Re-running the release workflow after merge should publish v0.36.0 cleanly.
