### PR TITLE
fix(ci): always push docker image on release

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -62,7 +62,10 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       has-docs-changes: ${{ steps.filter.outputs.docs }}
-      has-code-changes: ${{ steps.filter.outputs.code }}
+      # On a release event the tag rides on top of master, so paths-filter diffs an
+      # empty range (master...tag) and reports no code changes. Force-enable the code
+      # path on releases so the docker build/push and multi-arch manifest always run.
+      has-code-changes: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'release' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## What

Releases stopped publishing docker images. This forces the docker build/push path to always run on `release` events.

## Why

On a `release` event the tag (e.g. `v0.36.0`) sits on the same commit as `master` HEAD. `dorny/paths-filter` diffs the range `master...<tag>`, which is empty, so it reports zero changed files and sets `has-code-changes=false`.

That single output gates ~15 docker steps plus the whole `build-multi-architecture` and `upload-docker-sboms` jobs. The result: the per-platform `build` jobs reported success while doing nothing, and the manifest/SBOM jobs were skipped. So `latest`, the semver tags, the multi-arch manifest, and the release SBOMs never got published on a release.

I confirmed this on the v0.36.0 run: the log shows `Changes will be detected between master and v0.36.0` with both pointing at the same commit, `combine platform images` and `upload Docker SBOMs to release` both **skipped**.

## Approach

Fix it at the source — the `check-changes` job output — so every downstream gate inherits the change without touching each condition:

```yaml
has-code-changes: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'release' }}
```

Push events (code vs docs/ci-only) keep their existing behaviour; PRs are still blocked from pushing by the separate `event_name != 'pull_request'` guard on the push steps.

## Verification

YAML parses; actionlint pre-commit hook passes. A release event can't be dry-run locally — real confirmation is the next release, where `combine platform images` and `upload Docker SBOMs to release` should go from skipped to success and the `latest`/semver tags should appear on DockerHub.
