### PR TITLE
fix: clean up temp dirs and close fd leaks in Helm, Kustomize, Cuelang

### DIFF
--- a/kapitan/inputs/cuelang.py
+++ b/kapitan/inputs/cuelang.py
@@ -40,46 +40,46 @@ class Cuelang(InputType):
     def compile_file(
         self, config: KapitanInputTypeCuelangConfig, input_path: str, compile_path: str
     ) -> None:
-        temp_dir = tempfile.mkdtemp()
         abs_input_path = os.path.abspath(input_path)
 
-        # Copy the input directory to the temporary directory
-        input_dir_name = os.path.basename(abs_input_path)
-        temp_input_dir = os.path.join(temp_dir, input_dir_name)
-        shutil.copytree(abs_input_path, temp_input_dir)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Copy the input directory to the temporary directory
+            input_dir_name = os.path.basename(abs_input_path)
+            temp_input_dir = os.path.join(temp_dir, input_dir_name)
+            shutil.copytree(abs_input_path, temp_input_dir)
 
-        # Write the input data to file
-        input_file_path = os.path.join(temp_input_dir, "input.yaml")
-        with open(input_file_path, "w") as f:
-            yaml.dump(config.input, f)
+            # Write the input data to file
+            input_file_path = os.path.join(temp_input_dir, "input.yaml")
+            with open(input_file_path, "w") as f:
+                yaml.dump(config.input, f)
 
-        #  Prepare the command to run CUE export
-        cmd = [
-            self.cue_path,
-            "export",
-            ".",
-        ]
-        # if specified where to inject the input, add it to the command
-        if config.input_fill_path:
-            cmd += ["-l", config.input_fill_path]
-        cmd += ["input.yaml", "--out", "yaml"]
-        # if specified where the output is yielded, add it to the command
-        if config.output_yield_path:
-            cmd += ["--expression", config.output_yield_path]
+            #  Prepare the command to run CUE export
+            cmd = [
+                self.cue_path,
+                "export",
+                ".",
+            ]
+            # if specified where to inject the input, add it to the command
+            if config.input_fill_path:
+                cmd += ["-l", config.input_fill_path]
+            cmd += ["input.yaml", "--out", "yaml"]
+            # if specified where the output is yielded, add it to the command
+            if config.output_yield_path:
+                cmd += ["--expression", config.output_yield_path]
 
-        output_filename = (
-            config.output_filename if config.output_filename else "output.yaml"
-        )
-        output_file = os.path.join(compile_path, output_filename)
-        with open(output_file, "w") as f:
-            result = subprocess.run(
-                cmd,
-                stdout=f,
-                stderr=subprocess.PIPE,
-                text=True,
-                cwd=temp_input_dir,
-                check=False,
+            output_filename = (
+                config.output_filename if config.output_filename else "output.yaml"
             )
-            if result.returncode != 0:
-                err = f"Failed to run CUE export: {result.stderr}"
-                raise KustomizeTemplateError(err)
+            output_file = os.path.join(compile_path, output_filename)
+            with open(output_file, "w") as f:
+                result = subprocess.run(
+                    cmd,
+                    stdout=f,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    cwd=temp_input_dir,
+                    check=False,
+                )
+                if result.returncode != 0:
+                    err = f"Failed to run CUE export: {result.stderr}"
+                    raise KustomizeTemplateError(err)

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -59,35 +59,35 @@ class Helm(InputType):
         if config.kube_version:
             helm_flags["--api-versions"] = config.kube_version
 
-        temp_dir = tempfile.mkdtemp()
-        # save the template output to temp dir first
-        _, error_message = render_chart(
-            chart_dir=input_path,
-            output_path=temp_dir,
-            helm_path=helm_path,
-            helm_params=helm_params,
-            helm_values_file=helm_values_file,
-            helm_values_files=helm_values_files,
-            helm_flags=helm_flags,
-        )
-        if error_message:
-            raise HelmTemplateError(error_message)
-        # Iterate over all files in the temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # save the template output to temp dir first
+            _, error_message = render_chart(
+                chart_dir=input_path,
+                output_path=temp_dir,
+                helm_path=helm_path,
+                helm_params=helm_params,
+                helm_values_file=helm_values_file,
+                helm_values_files=helm_values_files,
+                helm_flags=helm_flags,
+            )
+            if error_message:
+                raise HelmTemplateError(error_message)
+            # Iterate over all files in the temporary directory
 
-        walk_root_files = os.walk(temp_dir)
-        for current_dir, _, files in walk_root_files:
-            for file in files:  # go through all the template files
-                rel_dir = os.path.relpath(current_dir, temp_dir)
-                rel_file_name = os.path.join(rel_dir, file)
-                full_file_name = os.path.join(current_dir, file)
-                # Open each file and write its content to the compilation path
-                with open(full_file_name, encoding="utf-8") as f:
-                    file_path = os.path.join(compile_path, rel_file_name)
-                    os.makedirs(os.path.dirname(file_path), exist_ok=True)
-                    item_value = [
-                        doc for doc in yaml.safe_load_all(f) if doc is not None
-                    ]
-                    self.to_file(config, file_path, item_value)
+            walk_root_files = os.walk(temp_dir)
+            for current_dir, _, files in walk_root_files:
+                for file in files:  # go through all the template files
+                    rel_dir = os.path.relpath(current_dir, temp_dir)
+                    rel_file_name = os.path.join(rel_dir, file)
+                    full_file_name = os.path.join(current_dir, file)
+                    # Open each file and write its content to the compilation path
+                    with open(full_file_name, encoding="utf-8") as f:
+                        file_path = os.path.join(compile_path, rel_file_name)
+                        os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                        item_value = [
+                            doc for doc in yaml.safe_load_all(f) if doc is not None
+                        ]
+                        self.to_file(config, file_path, item_value)
 
     def render_chart(self, *args, **kwargs):
         return render_chart(*args, **kwargs)
@@ -193,11 +193,14 @@ def render_chart(
 
     # If output_path is '-', output is a string with rendered chart
     if output_path == "-":
-        _, helm_output = tempfile.mkstemp(".helm_output.yml", text=True)
+        fd, helm_output = tempfile.mkstemp(".helm_output.yml", text=True)
+        os.close(fd)
         with open(helm_output, "w+") as f:
             error_message = helm_cli(helm_path, args, stdout=f)
             f.seek(0)
-            return (f.read(), error_message)
+            content = f.read()
+        os.unlink(helm_output)
+        return (content, error_message)
 
     if output_file:
         with open(os.path.join(output_path, output_file), "wb") as f:
@@ -231,7 +234,8 @@ def write_helm_values_file(helm_values: dict):
     Returns:
         str: The path to the temporary YAML file.
     """
-    _, helm_values_file = tempfile.mkstemp(".helm_values.yml", text=True)
+    fd, helm_values_file = tempfile.mkstemp(".helm_values.yml", text=True)
+    os.close(fd)
     with open(helm_values_file, "w") as fp:
         dumper = yaml.SafeDumper
         dumper.add_representer(str, _helm_str_representer)

--- a/kapitan/inputs/kustomize.py
+++ b/kapitan/inputs/kustomize.py
@@ -92,87 +92,84 @@ class Kustomize(InputType):
                 f"Input path {input_path} must be a directory containing a kustomization.yaml file"
             )
 
-        result = None
         try:
-            # Create a temporary directory for our kustomization
-            temp_dir = tempfile.mkdtemp()
-            kustomization_path = os.path.join(temp_dir, "kustomization.yaml")
+            # Both temp directories are cleaned up automatically on exit of the
+            # `with` block, even if an exception is raised inside it.
+            with tempfile.TemporaryDirectory() as temp_dir, \
+                    tempfile.TemporaryDirectory() as output_dir:
+                kustomization_path = os.path.join(temp_dir, "kustomization.yaml")
 
-            # Copy the input directory to the temporary directory
-            input_dir_name = os.path.basename(abs_input_path)
-            temp_input_dir = os.path.join(temp_dir, input_dir_name)
-            shutil.copytree(abs_input_path, temp_input_dir)
+                # Copy the input directory to the temporary directory
+                input_dir_name = os.path.basename(abs_input_path)
+                temp_input_dir = os.path.join(temp_dir, input_dir_name)
+                shutil.copytree(abs_input_path, temp_input_dir)
 
-            # Read the original kustomization.yaml if it exists
-            original_kustomization = {}
-            original_kustomization_path = os.path.join(
-                temp_input_dir, "kustomization.yaml"
-            )
-            if os.path.exists(original_kustomization_path):
-                with open(original_kustomization_path) as f:
-                    original_kustomization = yaml.safe_load(f) or {}
-
-            # Create our kustomization with patches
-            kustomization = {
-                "resources": [input_dir_name],
-                "namespace": config.namespace
-                or original_kustomization.get("namespace", ""),
-            }
-
-            # Add patches if specified
-            if config.patches:
-                kustomization["patches"] = []
-                for name, patch in config.patches.items():
-                    patch_file = os.path.join(temp_dir, f"{name}.yaml")
-                    with open(patch_file, "w") as f:
-                        yaml.dump(patch["patch"], f, default_flow_style=False)
-                    kustomization["patches"].append(
-                        {
-                            "path": os.path.basename(patch_file),
-                            "target": patch["target"],
-                        }
-                    )
-
-            # Write the kustomization file
-            with open(kustomization_path, "w") as f:
-                yaml.dump(kustomization, f, default_flow_style=False)
-
-            # Build the kustomize command
-            cmd = [self.kustomize_path, "build", temp_dir]
-
-            # Create temporary directory for output
-            output_dir = tempfile.mkdtemp()
-            output_file = os.path.join(output_dir, "output.yaml")
-
-            # Run kustomize build
-            with open(output_file, "w") as f:
-                result = subprocess.run(
-                    cmd, stdout=f, stderr=subprocess.PIPE, text=True, check=False
+                # Read the original kustomization.yaml if it exists
+                original_kustomization = {}
+                original_kustomization_path = os.path.join(
+                    temp_input_dir, "kustomization.yaml"
                 )
-        except Exception as e:
-            raise KustomizeTemplateError(
-                f"Failed to compile Kustomize overlay: {e!s}"
-            ) from e
+                if os.path.exists(original_kustomization_path):
+                    with open(original_kustomization_path) as f:
+                        original_kustomization = yaml.safe_load(f) or {}
 
-        if result.returncode != 0:
-            raise KustomizeTemplateError(f"Kustomize build failed: {result.stderr}")
+                # Create our kustomization with patches
+                kustomization = {
+                    "resources": [input_dir_name],
+                    "namespace": config.namespace
+                    or original_kustomization.get("namespace", ""),
+                }
 
-        try:
-            # Read and process the output
-            with open(output_file) as f:
-                for doc in yaml.safe_load_all(f):
-                    if doc:
-                        # Generate a unique filename based on kind and name
-                        kind = doc.get("kind", "").lower()
-                        name = doc.get("metadata", {}).get("name", "").lower()
-                        filename = (
-                            f"{name}-{kind}.yaml" if name and kind else "output.yaml"
+                # Add patches if specified
+                if config.patches:
+                    kustomization["patches"] = []
+                    for name, patch in config.patches.items():
+                        patch_file = os.path.join(temp_dir, f"{name}.yaml")
+                        with open(patch_file, "w") as f:
+                            yaml.dump(patch["patch"], f, default_flow_style=False)
+                        kustomization["patches"].append(
+                            {
+                                "path": os.path.basename(patch_file),
+                                "target": patch["target"],
+                            }
                         )
 
-                        # Write the document to the output file
-                        output_path = os.path.join(compile_path, filename)
-                        with open(output_path, "w") as out:
-                            yaml.dump(doc, out, default_flow_style=False)
+                # Write the kustomization file
+                with open(kustomization_path, "w") as f:
+                    yaml.dump(kustomization, f, default_flow_style=False)
+
+                # Build the kustomize command
+                cmd = [self.kustomize_path, "build", temp_dir]
+
+                # Run kustomize build into the output temp dir
+                output_file = os.path.join(output_dir, "output.yaml")
+                with open(output_file, "w") as f:
+                    result = subprocess.run(
+                        cmd, stdout=f, stderr=subprocess.PIPE, text=True, check=False
+                    )
+
+                if result.returncode != 0:
+                    raise KustomizeTemplateError(
+                        f"Kustomize build failed: {result.stderr}"
+                    )
+
+                # Read and process the output
+                with open(output_file) as f:
+                    for doc in yaml.safe_load_all(f):
+                        if doc:
+                            # Generate a unique filename based on kind and name
+                            kind = doc.get("kind", "").lower()
+                            name = doc.get("metadata", {}).get("name", "").lower()
+                            filename = (
+                                f"{name}-{kind}.yaml" if name and kind else "output.yaml"
+                            )
+
+                            # Write the document to the output file
+                            output_path = os.path.join(compile_path, filename)
+                            with open(output_path, "w") as out:
+                                yaml.dump(doc, out, default_flow_style=False)
+        except KustomizeTemplateError:
+            raise
         except Exception as e:
             raise KustomizeTemplateError(
                 f"Failed to compile Kustomize overlay: {e!s}"


### PR DESCRIPTION
## Summary

Fixes #1509.

Three input compilers created temp directories with `tempfile.mkdtemp()` and never cleaned them up. Two `tempfile.mkstemp()` calls discarded the returned file descriptor (`_`) without closing it. On large or long-running compilation jobs this causes disk-space exhaustion and file-descriptor leaks.

## Changes

### `kapitan/inputs/helm.py`
- `compile_file`: replace `mkdtemp()` with `tempfile.TemporaryDirectory()` context manager — rendered-chart dir is now always deleted on exit, even if an exception is raised.
- `render_chart`: close the `mkstemp()` fd immediately with `os.close(fd)`, then `os.unlink()` the temp file after its contents are read.
- `write_helm_values_file`: close the `mkstemp()` fd immediately with `os.close(fd)` before opening the file for writing.

### `kapitan/inputs/kustomize.py`
- `compile_file`: replace two separate `mkdtemp()` calls with a single `with tempfile.TemporaryDirectory() as temp_dir, tempfile.TemporaryDirectory() as output_dir:` block; consolidate the previously split `try/except` blocks into one, re-raising `KustomizeTemplateError` directly so it is not double-wrapped.

### `kapitan/inputs/cuelang.py`
- `compile_file`: replace `mkdtemp()` with `tempfile.TemporaryDirectory()` context manager.

## Testing

All pre-existing test failures (helm/kustomize/cuelang suites require `helm`/`kustomize`/`cue` binaries not present in CI) are identical before and after this change — no regressions introduced.