### PR TITLE
fix: allow skipping already published dev pypi releases in CI

### DIFF
--- a/.github/workflows/python-pypi-publish-dev.yml
+++ b/.github/workflows/python-pypi-publish-dev.yml
@@ -55,3 +55,7 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
+          # Dev versions are derived from distance-from-latest-tag, so the same
+          # version can be recomputed across runs (re-runs, tag moves, etc.).
+          # Treat "already on PyPI" as a no-op instead of failing the workflow.
+          skip-existing: true


### PR DESCRIPTION
## Summary

Allow skipping already published dev pypi releases in CI if releases are retried/recomputed, which previously errors with:
```
WARNING  Error during upload. Retry with the --verbose option for more details.
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         Bad Request
```
