### PR TITLE
fix(kadet): exclude compile_path from cache key to restore cache hits

### DIFF
--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -135,12 +135,11 @@ class Kadet(InputType):
         inputs_hash = None
         output_obj = None
 
-        # set compile_path allowing kadet functions to have context on where files
-        # are being compiled on the current kapitan run
-        # we only do this if user didn't pass its own value
-        input_params.setdefault("compile_path", compile_path)
-
         if cache_obj := self.cacheable():
+            # Hash input_params before setdefault injects compile_path below, so the
+            # volatile per-run tempdir never appears in the key. Any compile_path the
+            # user explicitly included in input_params is still hashed, preserving the
+            # collision safety added by PR #1520.
             inputs_hash = self.inputs_hash(
                 inventory_digest(current_target.get()),
                 target_name,
@@ -151,6 +150,10 @@ class Kadet(InputType):
             output_obj = cache_obj.get(inputs_hash)
 
         if output_obj is None:
+            # set compile_path after the cache key is computed so the volatile tempdir
+            # path does not get baked into the hash; only inject if user didn't supply one
+            input_params.setdefault("compile_path", compile_path)
+
             kadet_module, spec = module_from_path(input_path)
             sys.modules[spec.name] = kadet_module
             spec.loader.exec_module(kadet_module)

--- a/tests/test_kadet.py
+++ b/tests/test_kadet.py
@@ -9,7 +9,6 @@
 
 import tempfile
 import unittest
-from argparse import Namespace
 from pathlib import Path
 from unittest import mock
 
@@ -203,11 +202,17 @@ class KadetCacheKeyTest(unittest.TestCase):
 
         with (
             mock.patch.object(compiler, "cacheable", return_value=cache_obj),
-            mock.patch.object(compiler, "inputs_hash", return_value="fixed-hash") as mock_hash,
-            mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inventory"),
+            mock.patch.object(
+                compiler, "inputs_hash", return_value="fixed-hash"
+            ) as mock_hash,
+            mock.patch(
+                "kapitan.inputs.kadet.inventory_digest", return_value=b"inventory"
+            ),
             mock.patch.object(compiler, "to_file"),
         ):
-            compiler.compile_file(config, "component", "/tmp/run1-abc/compiled/test-target")
+            compiler.compile_file(
+                config, "component", "/tmp/run1-abc/compiled/test-target"
+            )
 
         mock_hash.assert_called_once_with(
             b"inventory",
@@ -242,11 +247,19 @@ class KadetCacheKeyTest(unittest.TestCase):
             mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inv"),
             mock.patch.object(compiler, "to_file"),
         ):
-            compiler.compile_file(config, "component", "/tmp/run1-xyz/compiled/test-target")
-            compiler.compile_file(config, "component", "/tmp/run2-qrs/compiled/test-target")
+            compiler.compile_file(
+                config, "component", "/tmp/run1-xyz/compiled/test-target"
+            )
+            compiler.compile_file(
+                config, "component", "/tmp/run2-qrs/compiled/test-target"
+            )
 
         self.assertEqual(len(calls), 2)
-        self.assertEqual(calls[0], calls[1], "Cache key must be stable across different compile_paths")
+        self.assertEqual(
+            calls[0],
+            calls[1],
+            "Cache key must be stable across different compile_paths",
+        )
 
     def test_config_input_params_not_mutated(self):
         """compile_file must not mutate config.input_params (compile_path is injected

--- a/tests/test_kadet.py
+++ b/tests/test_kadet.py
@@ -174,41 +174,101 @@ class KadetTest(unittest.TestCase):
         self.assertEqual(output, desired_output)
 
 
-class KadetCompileCacheTest(unittest.TestCase):
-    def test_compile_cache_key_includes_input_params(self):
-        input_params = {"value": "second"}
+class KadetCacheKeyTest(unittest.TestCase):
+    """
+    Regression tests for PR-1520: compile_path must not be included in the
+    cache key because it is a per-run temporary directory that changes on every
+    invocation, which would cause every cache lookup to miss.
+    """
+
+    def _make_compiler(self):
+        compiler = Kadet.__new__(Kadet)
+        compiler.target_name = "test-target"
+        compiler.search_paths = []
+        return compiler
+
+    def test_compile_path_excluded_from_cache_key(self):
+        """inputs_hash must be called without compile_path so that volatile
+        tempdir paths do not prevent cache hits across runs."""
+        compiler = self._make_compiler()
+
         config = KapitanInputTypeKadetConfig(
             input_paths=["component"],
             output_path=".",
-            input_params=input_params,
-        )
-        compiler = Kadet(
-            "compiled",
-            ["."],
-            None,
-            "test-target",
-            Namespace(cache=True),
+            input_params={"value": "first"},
         )
 
-        cache = mock.Mock()
-        cache.get.return_value = {}
+        cache_obj = mock.Mock()
+        cache_obj.get.return_value = {"output.yml": {"key": "val"}}
 
         with (
-            mock.patch.object(compiler, "cacheable", return_value=cache),
-            mock.patch.object(
-                compiler, "inputs_hash", return_value="cache-key"
-            ) as inputs_hash,
-            mock.patch(
-                "kapitan.inputs.kadet.inventory_digest", return_value=b"inventory"
-            ),
+            mock.patch.object(compiler, "cacheable", return_value=cache_obj),
+            mock.patch.object(compiler, "inputs_hash", return_value="fixed-hash") as mock_hash,
+            mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inventory"),
+            mock.patch.object(compiler, "to_file"),
         ):
-            compiler.compile_file(config, "component", "compiled/test-target")
+            compiler.compile_file(config, "component", "/tmp/run1-abc/compiled/test-target")
 
-        inputs_hash.assert_called_once_with(
+        mock_hash.assert_called_once_with(
             b"inventory",
             "test-target",
             Path("component"),
-            {"value": "second", "compile_path": "compiled/test-target"},
+            {"value": "first"},  # compile_path must NOT be present in the hash
         )
-        cache.get.assert_called_once_with("cache-key")
-        self.assertEqual(config.input_params, input_params)
+
+    def test_different_compile_paths_yield_same_hash_args(self):
+        """Two invocations with different compile_path values must produce
+        identical inputs_hash arguments so the second call gets a cache hit."""
+        compiler = self._make_compiler()
+
+        config = KapitanInputTypeKadetConfig(
+            input_paths=["component"],
+            output_path=".",
+            input_params={"value": "second"},
+        )
+
+        cache_obj = mock.Mock()
+        cache_obj.get.return_value = {"output.yml": {"k": "v"}}
+
+        calls = []
+
+        def capture_hash(*args):
+            calls.append(args)
+            return "stable-hash"
+
+        with (
+            mock.patch.object(compiler, "cacheable", return_value=cache_obj),
+            mock.patch.object(compiler, "inputs_hash", side_effect=capture_hash),
+            mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inv"),
+            mock.patch.object(compiler, "to_file"),
+        ):
+            compiler.compile_file(config, "component", "/tmp/run1-xyz/compiled/test-target")
+            compiler.compile_file(config, "component", "/tmp/run2-qrs/compiled/test-target")
+
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0], calls[1], "Cache key must be stable across different compile_paths")
+
+    def test_config_input_params_not_mutated(self):
+        """compile_file must not mutate config.input_params (compile_path is injected
+        into a local copy only)."""
+        compiler = self._make_compiler()
+
+        original_params = {"value": "third"}
+        config = KapitanInputTypeKadetConfig(
+            input_paths=["component"],
+            output_path=".",
+            input_params=dict(original_params),
+        )
+
+        cache_obj = mock.Mock()
+        cache_obj.get.return_value = {"output.yml": {"k": "v"}}
+
+        with (
+            mock.patch.object(compiler, "cacheable", return_value=cache_obj),
+            mock.patch.object(compiler, "inputs_hash", return_value="hash"),
+            mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inv"),
+            mock.patch.object(compiler, "to_file"),
+        ):
+            compiler.compile_file(config, "component", "compiled/test-target")
+
+        self.assertEqual(dict(config.input_params), original_params)


### PR DESCRIPTION
PR #1520 correctly added input_params to the cache key to prevent collisions between inputs that differ only by input_params, but it also moved the compile_path setdefault *before* the hash computation. Since compile_path is a per-run tempfile.mkdtemp() path it changes on every invocation, making the cache key unstable and causing every lookup to miss.

Fix: copy config.input_params (preserving mutation-safety) and include it in the hash before setdefault injects compile_path. The setdefault call is moved back to after the cache lookup so the volatile tempdir never appears in the key. User-supplied input_params (without the auto-injected compile_path) continue to differentiate cache entries, so collision safety from #1520 is preserved.

Adds regression tests asserting compile_path is absent from the hashed dict and that two runs with different compile_paths produce identical hash arguments.

https://claude.ai/code/session_011AJrbdseq5WcYsdLswJoh2

## Summary

<!-- One or two sentences describing what this PR does. -->

Fixes #

## Motivation

<!-- Why is this change needed? What problem does it solve? -->

## Affected files or URLs

<!-- List the key files, pages, or URLs changed. -->

## Test plan

<!-- Checklist of what you have tested or verified. -->
- [ ] Tests added or updated
- [ ] Documentation updated (if user-facing behavior changed)
- [ ] `make lint` passes
- [ ] `make format` passes (or no formatting changes needed)
- [ ] Full test suite passes (`uv run pytest tests/ --no-cov`)

## Risk assessment

<!-- What could go wrong? How can it be reverted? -->

## Follow-up work intentionally left out

<!-- What is deliberately not included so the PR stays reviewable? -->
