### PR TITLE
test: bound vault test-server startup so an unreachable VAULT_ADDR can't hang the suite

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ from kapitan.cli import build_parser
 from kapitan.cli import main as kapitan
 from kapitan.errors import KapitanError
 from kapitan.refs.secrets.vaultkv import VaultSecret
-from tests.vault_server import get_shared_vault_server
+from tests.vault_server import VaultServerError, get_shared_vault_server
 
 
 REFS_PATH = tempfile.mkdtemp()
@@ -61,12 +61,17 @@ class CliFuncsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # setup vault server (running in container)
-        cls.server = get_shared_vault_server()
+        try:
+            cls.server = get_shared_vault_server()
+        except VaultServerError as exc:
+            raise unittest.SkipTest(f"vault server unavailable: {exc}") from exc
 
     @classmethod
     def tearDownClass(cls):
         # close connection
-        cls.server.close_container()
+        server = getattr(cls, "server", None)
+        if server is not None:
+            server.close_container()
         shutil.rmtree(REFS_PATH, ignore_errors=True)
 
     def test_cli_secret_reveal_tag(self):

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -17,7 +17,7 @@ import unittest
 from kapitan.inventory.model.references import KapitanReferenceVaultKVConfig
 from kapitan.refs.base import RefController, RefParams, Revealer
 from kapitan.refs.secrets.vaultkv import VaultClient, VaultError, VaultSecret
-from tests.vault_server import get_shared_vault_server
+from tests.vault_server import VaultServerError, get_shared_vault_server
 
 
 logger = logging.getLogger(__name__)
@@ -33,12 +33,17 @@ class VaultSecretTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # setup vault server (running in container)
-        cls.server = get_shared_vault_server()
+        try:
+            cls.server = get_shared_vault_server()
+        except VaultServerError as exc:
+            raise unittest.SkipTest(f"vault server unavailable: {exc}") from exc
 
     @classmethod
     def tearDownClass(cls):
         # close connection
-        cls.server.close_container()
+        server = getattr(cls, "server", None)
+        if server is not None:
+            server.close_container()
         shutil.rmtree(REFS_PATH, ignore_errors=True)
 
     def test_token_authentication(self):

--- a/tests/test_vault_server.py
+++ b/tests/test_vault_server.py
@@ -1,0 +1,40 @@
+# Copyright 2019 The Kapitan Authors
+# SPDX-FileCopyrightText: 2020 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for the vault test-server helper."""
+
+import os
+import time
+import unittest
+
+from tests.vault_server import VaultServer, VaultServerError
+
+
+class VaultServerTimeoutTest(unittest.TestCase):
+    def test_unreachable_vault_addr_raises_instead_of_hanging(self):
+        """When VAULT_ADDR points at an unreachable vault, VaultServer must
+        give up and raise VaultServerError instead of retrying forever.
+
+        Uses 127.0.0.1:1 (connection refused immediately, no DNS dependency)
+        and a short setup timeout so the bounded retry loop trips quickly.
+        """
+        saved = {
+            k: os.environ.get(k)
+            for k in ("VAULT_ADDR", "VAULT_TOKEN", "KAPITAN_VAULT_SETUP_TIMEOUT")
+        }
+        os.environ["VAULT_ADDR"] = "http://127.0.0.1:1"
+        os.environ["KAPITAN_VAULT_SETUP_TIMEOUT"] = "3"
+        try:
+            start = time.monotonic()
+            with self.assertRaises(VaultServerError):
+                VaultServer()
+            elapsed = time.monotonic() - start
+            self.assertLess(elapsed, 30, "VaultServer hung instead of timing out")
+        finally:
+            for key, value in saved.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value

--- a/tests/test_vault_transit.py
+++ b/tests/test_vault_transit.py
@@ -9,7 +9,11 @@ import unittest
 from kapitan.refs.base import RefController, Revealer
 from kapitan.refs.secrets.vaulttransit import VaultTransit
 from kapitan.refs.vault_resources import VaultClient
-from tests.vault_server import VaultTransitServer, get_shared_vault_server
+from tests.vault_server import (
+    VaultServerError,
+    VaultTransitServer,
+    get_shared_vault_server,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -26,7 +30,10 @@ class VaultTransitTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # setup vaulttransit server (running in container)
-        cls.server = get_shared_vault_server(VaultTransitServer)
+        try:
+            cls.server = get_shared_vault_server(VaultTransitServer)
+        except VaultServerError as exc:
+            raise unittest.SkipTest(f"vault server unavailable: {exc}") from exc
         cls.server.vault_client.secrets.transit.create_key(name="hvac_key")
         cls.server.vault_client.secrets.transit.create_key(name="hvac_updated_key")
 
@@ -38,8 +45,12 @@ class VaultTransitTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # close connections
-        cls.client.adapter.close()
-        cls.server.close_container()
+        client = getattr(cls, "client", None)
+        if client is not None:
+            client.adapter.close()
+        server = getattr(cls, "server", None)
+        if server is not None:
+            server.close_container()
         shutil.rmtree(REFS_PATH, ignore_errors=True)
 
     def test_vault_transit_enc_data(self):

--- a/tests/vault_server.py
+++ b/tests/vault_server.py
@@ -7,7 +7,7 @@
 
 import logging
 import os
-from time import sleep
+from time import monotonic, sleep
 
 import hvac
 from hvac.exceptions import InvalidRequest
@@ -28,15 +28,31 @@ class VaultServerError(KapitanError):
     """Generic vaultserver errors"""
 
 
+# How long to wait for the vault server to come up before giving up. Bounded
+# so an unreachable VAULT_ADDR (or a container that never starts) fails fast
+# instead of retrying forever. Overridable via env for tests/slow CI.
+def _setup_timeout():
+    return float(os.environ.get("KAPITAN_VAULT_SETUP_TIMEOUT", "60"))
+
+
 # Module-level singletons so test classes can share vault server instances.
 _shared_vault_servers = {}
+# Cache construction failures so every dependent test class skips immediately
+# instead of each re-waiting the full setup timeout.
+_failed_vault_servers = {}
 
 
 def get_shared_vault_server(server_cls=None):
     """Return a shared VaultServer singleton, creating it if necessary."""
     cls = server_cls or VaultServer
+    if cls in _failed_vault_servers:
+        raise _failed_vault_servers[cls]
     if cls not in _shared_vault_servers:
-        _shared_vault_servers[cls] = cls()
+        try:
+            _shared_vault_servers[cls] = cls()
+        except VaultServerError as exc:
+            _failed_vault_servers[cls] = exc
+            raise
     return _shared_vault_servers[cls]
 
 
@@ -88,7 +104,13 @@ class VaultServer:
 
         # make sure the container is up & running before testing
 
+        deadline = monotonic() + _setup_timeout()
         while vault_container.status != "running":
+            if monotonic() >= deadline:
+                raise VaultServerError(
+                    f"Vault container did not reach 'running' within "
+                    f"{_setup_timeout():.0f}s (status: {vault_container.status})"
+                )
             sleep(2)
             vault_container.reload()
             if vault_container.status in ("exited", "dead"):
@@ -110,8 +132,14 @@ class VaultServer:
         return vault_container
 
     def setup_vault(self):
+        deadline = monotonic() + _setup_timeout()
         vault_status = {}
         while not vault_status.get("initialized", False):
+            if monotonic() >= deadline:
+                raise VaultServerError(
+                    f"Vault at {self.vault_url} did not become ready within "
+                    f"{_setup_timeout():.0f}s"
+                )
             sleep(2)
             try:
                 vault_client = hvac.Client(url=self.vault_url)


### PR DESCRIPTION
## What

The vault test-server helper (`tests/vault_server.py`) polled the server in a `while not initialized:` loop with **no timeout** and `except: continue`. If the vault it talks to is unreachable, that loop never exits.

When `VAULT_ADDR` points at a vault that doesn't resolve/respond (common locally — a stale env var, VPN off, no Docker), the whole test suite **hangs forever** instead of failing. It bites in `test_cli.py`, `test_vault.py` and `test_vault_transit.py`, whose `setUpClass` builds the shared vault server.

## Why

I hit this running the full suite locally: it stalled on `test_cli.py::CliFuncsTest::test_cli_inventory` for 20+ minutes. The process wasn't deadlocked — it was retrying a health check against an unreachable `VAULT_ADDR` in an unbounded loop, logging `status is {}` / `NameResolutionError` endlessly. CI never sees it because vault is reachable there.

## Approach

- `vault_server.py`: bound **both** startup loops (container-running wait and the health-check/init wait) with a deadline (`KAPITAN_VAULT_SETUP_TIMEOUT`, default `60`s). On timeout raise `VaultServerError` instead of looping. Cache construction failures so each dependent test class skips instantly rather than re-waiting the full timeout.
- `test_cli` / `test_vault` / `test_vault_transit`: catch `VaultServerError` in `setUpClass` and `SkipTest` — the same graceful-skip behaviour the reclass-rs tests already use when their backend is unavailable. Teardown guarded for the skipped case.
- New `tests/test_vault_server.py`: regression test asserting that an unreachable `VAULT_ADDR` makes `VaultServer()` **raise quickly** instead of hanging.

## Verification

- Regression test: red→green (infinite hang → raises in ~4s).
- Full non-slow suite on this branch with an unreachable `VAULT_ADDR`: **522 passed, 36 skipped in ~33s** (previously hung indefinitely). The 35 vault tests skip with a clear reason.
- `ruff check` / `ruff format` clean; pre-commit hooks pass.

**CI is unaffected**: vault is reachable there, so the loops exit immediately and nothing skips — behaviour is unchanged on CI.