### PR TITLE
feat: require consume declaration and mix into kadet cache key

### DIFF
--- a/docs/pages/inventory/advanced.md
+++ b/docs/pages/inventory/advanced.md
@@ -52,8 +52,12 @@ Topics let targets expose a subset of their parameters so that other targets can
 aggregate and consume them, without resorting to backend-specific features like
 reclass exports or expensive `inventory_global()` scans.
 
-A target opts into a topic by declaring parameters under
-`parameters.kapitan.topics.<topic_name>.parameters`:
+A target's relationship to a topic has two independent sides — **produce**
+and **consume** — both declared under
+`parameters.kapitan.topics.<topic_name>` on the same node.
+
+**Producers** declare `parameters:` to publish a slice of their own
+configuration into the topic:
 
 !!! example "`inventory/targets/target-1.yml`"
     ```yaml
@@ -77,11 +81,37 @@ A target opts into a topic by declaring parameters under
               colour: ${colour}
     ```
 
+**Consumers** declare `consume: true` to opt into reading a topic. This is
+required — calling `topics("colours")` from a target that has not declared
+`consume: true` on the `colours` node is a compile error.
+
+!!! example "`inventory/targets/painter.yml`"
+    ```yaml
+    parameters:
+      kapitan:
+        topics:
+          colours:
+            consume: true
+    ```
+
+A target can be both producer and consumer of the same topic — just declare
+`parameters:` and `consume: true` together on the same node.
+
+Why the explicit consumer declaration? Topics introduce a *cross-target*
+dependency that is otherwise invisible: if `target-1` changes its colour,
+the painter's output changes even though the painter's own inventory did
+not. Without an explicit opt-in, the input cache would serve stale results
+because it has no way to know which producers a given consumer depends on.
+Declaring `consume: true` turns that hidden dependency into an explicit one,
+and the kadet input cache (see `kapitan/inputs/cache.py`) mixes a digest of
+each declared topic's aggregated view into the consumer's cache key.
+
 Kapitan aggregates participating targets into a single topic view of the shape
 `{parameters: {targets: {<target_name>: <topic_parameters>}}}`. The `topics()`
 function is available to every input type (kadet, jinja2, jsonnet). Call it
 without arguments to get the full mapping of all topics, or with a name to get
-a single topic.
+a single topic — in both cases every topic that would be returned must be
+declared `consume: true` on the calling target.
 
 !!! example "kadet (`components/painter/__init__.py`)"
     ```python

--- a/kapitan/inputs/jinja2.py
+++ b/kapitan/inputs/jinja2.py
@@ -11,7 +11,7 @@ import os
 from kapitan import cached
 from kapitan.inputs.base import CompiledFile, InputType
 from kapitan.inventory.model.input_types import KapitanInputTypeJinja2Config
-from kapitan.topics import topics
+from kapitan.topics import current_target, topics
 from kapitan.utils import render_jinja2
 
 
@@ -42,41 +42,47 @@ class Jinja2(InputType):
 
         reveal = self.args.reveal
         target_name = self.target_name
+        # Publish the calling target so topics() can enforce consume declarations
+        # when called from a template. Reset on the way out so pool workers
+        # reused across targets don't leak the value to later readers.
+        token = current_target.set(target_name)
+        try:
+            # set compile_path allowing jsonnet to have context on where files
+            # are being compiled during the current Kapitan run.  This is only done if the user
+            # did not provide their own value.
+            input_params.setdefault("compile_path", compile_path)
 
-        # set compile_path allowing jsonnet to have context on where files
-        # are being compiled during the current Kapitan run.  This is only done if the user
-        # did not provide their own value.
-        input_params.setdefault("compile_path", compile_path)
+            # set ext_vars and inventory for jinja2 context
+            context = {}
 
-        # set ext_vars and inventory for jinja2 context
-        context = {}
+            context["inventory_global"] = cached.global_inv
+            context["inventory"] = cached.global_inv[target_name]
+            context["topics"] = topics
+            context["input_params"] = input_params
+            vars = cached.global_inv[target_name]["parameters"]["kapitan"]["vars"]
+            context.update(vars)
 
-        context["inventory_global"] = cached.global_inv
-        context["inventory"] = cached.global_inv[target_name]
-        context["topics"] = topics
-        context["input_params"] = input_params
-        vars = cached.global_inv[target_name]["parameters"]["kapitan"]["vars"]
-        context.update(vars)
+            jinja2_filters = self.args.jinja2_filters
 
-        jinja2_filters = self.args.jinja2_filters
-
-        for item_key, item_value in render_jinja2(
-            input_path,
-            context,
-            jinja2_filters=jinja2_filters,
-            search_paths=self.search_paths,
-        ).items():
-            if strip_postfix and item_key.endswith(stripped_postfix):
-                item_key = item_key.rstrip(stripped_postfix)
-            full_item_path = os.path.join(compile_path, item_key)
-            with CompiledFile(
-                full_item_path,
-                self.ref_controller,
-                mode="w",
-                reveal=reveal,
-                target_name=target_name,
-            ) as fp:
-                fp.write(item_value["content"])
-                mode = item_value["mode"]
-                os.chmod(full_item_path, mode)
-                logger.debug("Wrote %s with mode %.4o", full_item_path, mode)
+            for item_key, item_value in render_jinja2(
+                input_path,
+                context,
+                jinja2_filters=jinja2_filters,
+                search_paths=self.search_paths,
+            ).items():
+                if strip_postfix and item_key.endswith(stripped_postfix):
+                    item_key = item_key.rstrip(stripped_postfix)
+                full_item_path = os.path.join(compile_path, item_key)
+                with CompiledFile(
+                    full_item_path,
+                    self.ref_controller,
+                    mode="w",
+                    reveal=reveal,
+                    target_name=target_name,
+                ) as fp:
+                    fp.write(item_value["content"])
+                    mode = item_value["mode"]
+                    os.chmod(full_item_path, mode)
+                    logger.debug("Wrote %s with mode %.4o", full_item_path, mode)
+        finally:
+            current_target.reset(token)

--- a/kapitan/inputs/jsonnet.py
+++ b/kapitan/inputs/jsonnet.py
@@ -13,6 +13,7 @@ from kapitan.errors import CompileError
 from kapitan.inputs.base import InputType
 from kapitan.inventory.model.input_types import KapitanInputTypeJsonnetConfig
 from kapitan.resources import resource_callbacks, search_imports
+from kapitan.topics import current_target
 
 
 logger = logging.getLogger(__name__)
@@ -72,33 +73,41 @@ class Jsonnet(InputType):
 
         use_go = self.args.use_go_jsonnet
         ext_vars = {"target": self.target_name}
-
-        def _search_imports(cwd, imp):
-            return search_imports(cwd, imp, self.search_paths)
-
+        # Publish the calling target so the ``topics`` native callback (see
+        # kapitan.resources.resource_callbacks) can enforce consume declarations
+        # when called from jsonnet code. Reset on the way out so pool workers
+        # reused across targets don't leak the value to later readers.
+        token = current_target.set(self.target_name)
         try:
-            jsonnet = select_jsonnet_runtime(use_go)
-            json_output = jsonnet.evaluate_file(
-                input_path,
-                import_callback=_search_imports,
-                native_callbacks=resource_callbacks(self.search_paths),
-                ext_vars=ext_vars,
-            )
 
-            output_obj = json.loads(json_output)
+            def _search_imports(cwd, imp):
+                return search_imports(cwd, imp, self.search_paths)
 
-        except (ImportError, CompileError) as e:
-            raise CompileError(f"Jsonnet Error compiling {input_path}: {e}") from e
+            try:
+                jsonnet = select_jsonnet_runtime(use_go)
+                json_output = jsonnet.evaluate_file(
+                    input_path,
+                    import_callback=_search_imports,
+                    native_callbacks=resource_callbacks(self.search_paths),
+                    ext_vars=ext_vars,
+                )
 
-        # If output_obj is not a dictionary, wrap it in a dictionary using the input filename
-        # (without extension) as the key. This ensures that even single-item outputs are handled correctly.
-        if not isinstance(output_obj, dict):
-            filename = os.path.splitext(os.path.basename(input_path))[0]
-            # Using filename as key ensures that single-item outputs are handled correctly.
-            # Prevents issues when a single item is returned and needs to be written to a file.
-            output_obj = {filename: output_obj}
+                output_obj = json.loads(json_output)
 
-        # Write each item in output_obj to a separate file.
-        for item_key, item_value in output_obj.items():
-            file_path = os.path.join(compile_path, item_key)
-            self.to_file(config, file_path, item_value)
+            except (ImportError, CompileError) as e:
+                raise CompileError(f"Jsonnet Error compiling {input_path}: {e}") from e
+
+            # If output_obj is not a dictionary, wrap it in a dictionary using the input filename
+            # (without extension) as the key. This ensures that even single-item outputs are handled correctly.
+            if not isinstance(output_obj, dict):
+                filename = os.path.splitext(os.path.basename(input_path))[0]
+                # Using filename as key ensures that single-item outputs are handled correctly.
+                # Prevents issues when a single item is returned and needs to be written to a file.
+                output_obj = {filename: output_obj}
+
+            # Write each item in output_obj to a separate file.
+            for item_key, item_value in output_obj.items():
+                file_path = os.path.join(compile_path, item_key)
+                self.to_file(config, file_path, item_value)
+        finally:
+            current_target.reset(token)

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -24,6 +24,7 @@ from kapitan.errors import CompileError
 from kapitan.inputs.base import InputType
 from kapitan.inputs.cache import InputCache
 from kapitan.inventory.model.input_types import KapitanInputTypeKadetConfig
+from kapitan.topics import consumed_topics_digest, current_target
 
 
 # Set external kadet exception to kapitan.error.CompileError
@@ -31,7 +32,6 @@ kadet.ABORT_EXCEPTION_TYPE = CompileError
 
 logger = logging.getLogger(__name__)
 search_paths = contextvars.ContextVar("current search_paths in thread")
-current_target = contextvars.ContextVar("current target in thread")
 
 
 @cache
@@ -130,65 +130,81 @@ class Kadet(InputType):
 
         input_params = dict(config.input_params)
         target_name = self.target_name
-        current_target.set(target_name)
-        search_paths.set(self.search_paths)
-        inputs_hash = None
-        output_obj = None
-
-        if cache_obj := self.cacheable():
-            # Hash input_params before setdefault injects compile_path below, so the
-            # volatile per-run tempdir never appears in the key. Any compile_path the
-            # user explicitly included in input_params is still hashed, preserving the
-            # collision safety added by PR #1520.
-            inputs_hash = self.inputs_hash(
-                inventory_digest(current_target.get()),
-                target_name,
-                Path(input_path),
-                input_params,
-            )
-
-            output_obj = cache_obj.get(inputs_hash)
-
-        if output_obj is None:
-            # set compile_path after the cache key is computed so the volatile tempdir
-            # path does not get baked into the hash; only inject if user didn't supply one
-            input_params.setdefault("compile_path", compile_path)
-
-            kadet_module, spec = module_from_path(input_path)
-            sys.modules[spec.name] = kadet_module
-            spec.loader.exec_module(kadet_module)
-            logger.debug("Kadet.compile_file: spec.name: %s", spec.name)
-            kadet_arg_spec = inspect.getfullargspec(kadet_module.main)
-            logger.debug("Kadet main args: %s", kadet_arg_spec.args)
-
-            if len(kadet_arg_spec.args) > 1:
-                raise ValueError(
-                    f"Kadet {spec.name} main parameters not equal to 1 or 0"
-                )
-
-            try:
-                if len(kadet_arg_spec.args) == 1:
-                    output_obj = kadet_module.main(input_params)
-                elif len(kadet_arg_spec.args) == 0:
-                    output_obj = kadet_module.main()
-
-            except Exception as exc:
-                raise CompileError(
-                    f"Could not load Kadet module: {spec.name[16:]}"
-                ) from exc
-
-            output_obj = _to_dict(output_obj)
+        # Reset the ContextVar in finally so workers reused across targets don't
+        # leak the value to non-input readers (e.g. ``inventory()`` called from
+        # a later component's module-level code).
+        token = current_target.set(target_name)
+        try:
+            search_paths.set(self.search_paths)
+            inputs_hash = None
+            output_obj = None
 
             if cache_obj := self.cacheable():
-                cache_obj.set(inputs_hash, output_obj)
+                # Hash input_params before setdefault injects compile_path below, so the
+                # volatile per-run tempdir never appears in the key. Any compile_path the
+                # user explicitly included in input_params is still hashed, preserving the
+                # collision safety added by PR #1520.
+                #
+                # Mix in a digest of every topic this target declared as consumed so
+                # changes to *producer* targets invalidate this target's cache. Returns
+                # ``None`` (and is omitted) for targets that consume no topics, so
+                # non-topic users keep their existing cache keys.
+                extra_inputs: list = []
+                if topics_digest := consumed_topics_digest(target_name):
+                    extra_inputs.append(topics_digest)
 
-        # Return None if output_obj has no output
-        if not output_obj:
-            return
+                inputs_hash = self.inputs_hash(
+                    inventory_digest(current_target.get()),
+                    target_name,
+                    Path(input_path),
+                    input_params,
+                    *extra_inputs,
+                )
 
-        for item_key, item_value in output_obj.items():
-            file_path = os.path.join(compile_path, item_key)
-            self.to_file(config, file_path, item_value)
+                output_obj = cache_obj.get(inputs_hash)
+
+            if output_obj is None:
+                # set compile_path after the cache key is computed so the volatile tempdir
+                # path does not get baked into the hash; only inject if user didn't supply one
+                input_params.setdefault("compile_path", compile_path)
+
+                kadet_module, spec = module_from_path(input_path)
+                sys.modules[spec.name] = kadet_module
+                spec.loader.exec_module(kadet_module)
+                logger.debug("Kadet.compile_file: spec.name: %s", spec.name)
+                kadet_arg_spec = inspect.getfullargspec(kadet_module.main)
+                logger.debug("Kadet main args: %s", kadet_arg_spec.args)
+
+                if len(kadet_arg_spec.args) > 1:
+                    raise ValueError(
+                        f"Kadet {spec.name} main parameters not equal to 1 or 0"
+                    )
+
+                try:
+                    if len(kadet_arg_spec.args) == 1:
+                        output_obj = kadet_module.main(input_params)
+                    elif len(kadet_arg_spec.args) == 0:
+                        output_obj = kadet_module.main()
+
+                except Exception as exc:
+                    raise CompileError(
+                        f"Could not load Kadet module: {spec.name[16:]}"
+                    ) from exc
+
+                output_obj = _to_dict(output_obj)
+
+                if cache_obj := self.cacheable():
+                    cache_obj.set(inputs_hash, output_obj)
+
+            # Return None if output_obj has no output
+            if not output_obj:
+                return
+
+            for item_key, item_value in output_obj.items():
+                file_path = os.path.join(compile_path, item_key)
+                self.to_file(config, file_path, item_value)
+        finally:
+            current_target.reset(token)
 
     def inputs_hash(self, *inputs):
         """

--- a/kapitan/inventory/inventory.py
+++ b/kapitan/inventory/inventory.py
@@ -102,16 +102,55 @@ class Inventory(ABC):
         for target in self.targets.values():
             target_topics = getattr(target.parameters.kapitan, "topics", None) or {}
             for topic_name, topic_values in target_topics.items():
-                # support both pydantic model and raw dict
-                topic_params = getattr(topic_values, "parameters", None)
-                if topic_params is None and isinstance(topic_values, dict):
-                    topic_params = topic_values.get("parameters", {})
-                topics.setdefault(topic_name, {})[target.name] = topic_params or {}
+                # A target only counts as a *producer* of a topic if it actually
+                # declares a ``parameters:`` node — declaring just ``consume: true``
+                # (consumer-only) must not surface as an empty entry in the
+                # aggregated view. Support both pydantic-style attribute access
+                # and the raw-dict fallback the omegaconf backend produces.
+                if isinstance(topic_values, dict):
+                    if "parameters" not in topic_values:
+                        continue
+                    topic_params = topic_values["parameters"] or {}
+                else:
+                    topic_params = getattr(topic_values, "parameters", None)
+                    if topic_params is None:
+                        continue
+                topics.setdefault(topic_name, {})[target.name] = topic_params
 
         return {
             name: {"parameters": {"targets": targets}}
             for name, targets in topics.items()
         }
+
+    def consumed_topics(self, target_name: str) -> set[str]:
+        """Return the set of topic names ``target_name`` has opted into consuming.
+
+        A target opts in by declaring ``consume: true`` on the topic node::
+
+            parameters:
+              kapitan:
+                topics:
+                  <topic_name>:
+                    consume: true
+
+        Consumption is independent of production: a target may declare
+        ``parameters:`` (produce), ``consume: true`` (consume), or both on the
+        same topic node. Only ``consume: true`` (strictly ``True``) counts —
+        accidental strings like ``"true"`` are rejected so foot-guns surface
+        as undeclared-topic errors rather than silent cache stalls.
+        """
+        target = self.targets.get(target_name)
+        if target is None:
+            return set()
+        target_topics = getattr(target.parameters.kapitan, "topics", None) or {}
+        declared: set[str] = set()
+        for topic_name, topic_values in target_topics.items():
+            consume = getattr(topic_values, "consume", None)
+            if consume is None and isinstance(topic_values, dict):
+                consume = topic_values.get("consume")
+            if consume is True:
+                declared.add(topic_name)
+        return declared
 
     def __initialise(self, ignore_class_not_found) -> bool:
         """

--- a/kapitan/topics.py
+++ b/kapitan/topics.py
@@ -13,31 +13,124 @@ participating target's topic parameters into a single view of shape::
 
     {"parameters": {"targets": {<target_name>: <topic_parameters>, ...}}}
 
-This module exposes a single :func:`topics` accessor that is independent of any
-particular input type (kadet, jinja2, jsonnet, ...).
+Consumers must explicitly declare their intent to read a topic by setting
+``parameters.kapitan.topics.<name>.consume: true``. Declaration turns a hidden
+cross-target dependency into an explicit one, which is what lets input caches
+(see :mod:`kapitan.inputs.cache`) mix producer-side digests into the consumer's
+cache key without losing correctness.
 """
 
+import contextvars
+import json
+from typing import Iterable
+
 from kapitan import cached
+from kapitan.errors import CompileError
 
 
-# Empty, well-shaped result returned when a requested topic does not exist, so
-# callers can iterate ``.parameters.targets`` safely.
+# Shared across input types so ``topics()`` knows which target is calling it.
+# kadet, jinja2, and jsonnet inputs each ``.set()`` this before evaluating user
+# code. Default ``None`` means "called outside a compile context" (e.g. the
+# ``kapitan inventory --topics`` CLI path), in which case the consume check is
+# skipped.
+current_target: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "kapitan_current_target", default=None
+)
+
 _EMPTY_TOPIC: dict = {"parameters": {"targets": {}}}
 
 
-def topics(name: str | None = None) -> dict:
+def _hint(target: str, names: Iterable[str]) -> str:
+    lines = [
+        f"  parameters.kapitan.topics.{name}.consume: true" for name in sorted(names)
+    ]
+    return (
+        f"target '{target}' must declare the topic(s) it consumes. Add to its "
+        f"inventory:\n" + "\n".join(lines)
+    )
+
+
+def topics(name: str | None = None, target: str | None = None) -> dict:
     """Return aggregated topic parameters across all targets.
 
     Args:
         name: Topic name. When ``None`` (or empty), returns the full mapping of
             every topic keyed by topic name. When provided, returns the single
             topic view, or an empty well-shaped dict if the topic is unknown.
+        target: Calling target name. Defaults to the value of the
+            :data:`current_target` ContextVar, which input types set before
+            evaluating user code. When neither is set (outside a compile
+            context — e.g. the ``kapitan inventory --topics`` CLI path) the
+            consume check is skipped.
+
+    Raises:
+        CompileError: When called from a target that has not declared the
+            requested topic(s) under ``kapitan.topics.<name>.consume: true``.
+            For ``topics()`` with no name, every topic that would be returned
+            must be declared, else the error lists the undeclared ones.
 
     Returns:
         Plain ``dict`` data suitable for any input type. Kadet additionally
         wraps the result in a ``kadet.Dict`` for attribute-style access.
     """
     all_topics = getattr(cached.inv, "topics", {}) or {}
+
+    if target is None:
+        target = current_target.get()
+
+    if target is not None:
+        declared = _declared_for(target)
+        if name:
+            if name not in declared:
+                raise CompileError(_hint(target, [name]))
+        else:
+            undeclared = set(all_topics) - declared
+            if undeclared:
+                raise CompileError(_hint(target, undeclared))
+
     if not name:
         return all_topics
     return all_topics.get(name, dict(_EMPTY_TOPIC))
+
+
+def _declared_for(target: str) -> set[str]:
+    """Topics that ``target`` has declared ``consume: true`` on.
+
+    Wraps :meth:`Inventory.consumed_topics` so callers do not need to know
+    about the inventory object shape — and so unit tests can mock the
+    inventory with a minimal stand-in.
+    """
+    consumed = getattr(cached.inv, "consumed_topics", None)
+    if callable(consumed):
+        return consumed(target)
+    return set()
+
+
+def consumed_topics_digest(target: str) -> bytes | None:
+    """Stable digest over the topic views ``target`` declared as consumed.
+
+    Returns ``None`` when the target has declared no consumes — callers should
+    skip mixing into their cache key in that case, so targets that never use
+    topics keep their pre-existing cache keys.
+
+    The digest folds in topic *name* and aggregated *value* together so a
+    rename of an unrelated topic doesn't perturb this target's key, but any
+    producer-side change to a consumed topic does.
+    """
+    # Local import to avoid a cycle: inputs.cache → topics is the only direction.
+    from kapitan.inputs.cache import InputCache
+
+    declared = _declared_for(target)
+    if not declared:
+        return None
+
+    all_topics = getattr(cached.inv, "topics", {}) or {}
+    h = InputCache.hash_object()
+    for name in sorted(declared):
+        topic_view = all_topics.get(name, dict(_EMPTY_TOPIC))
+        rep = json.dumps(topic_view, sort_keys=True, default=str)
+        h.update(name.encode("utf-8"))
+        h.update(b"\x00")  # separator so "ab" + "c" doesn't collide with "a" + "bc"
+        h.update(rep.encode("utf-8"))
+        h.update(b"\x00")
+    return h.digest()

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -90,13 +90,15 @@ class InventoryTargetTestOmegaConf(InventoryTargetTestBase):
 del InventoryTargetTestBase  # remove InventoryTargetTestBase so that it doesn't run
 
 
-class InventoryTopicsTest(unittest.TestCase):
+class InventoryTopicsTestBase(unittest.TestCase):
     """Tests for `kapitan.topics` aggregation across targets."""
 
+    backend_id = None
+
     def setUp(self) -> None:
-        backend_id = InventoryBackends.RECLASS
-        if not importlib.util.find_spec(backend_id.replace("-", "_")):
-            self.skipTest(f"backend module {backend_id} not available")
+        backend_module_name = self.backend_id.replace("-", "_")
+        if not importlib.util.find_spec(backend_module_name):
+            self.skipTest(f"backend module {backend_module_name} not available")
 
         self.tmp = tempfile.mkdtemp()
         inv_dir = os.path.join(self.tmp, "inventory")
@@ -117,10 +119,19 @@ class InventoryTopicsTest(unittest.TestCase):
             "parameters:\n  colour: blue\n  kapitan:\n    topics:\n      colours:\n        parameters:\n          colour: ${colour}\n",
         )
         write("target-3.yml", "parameters:\n  unrelated: true\n")
+        # Consumer-only target: declares consume but produces no parameters.
+        write(
+            "consumer.yml",
+            "parameters:\n  kapitan:\n    topics:\n      colours:\n        consume: true\n",
+        )
 
         self.inventory_path = inv_dir
+        if self.backend_id == InventoryBackends.OMEGACONF:
+            from kapitan.inventory.backends.omegaconf import migrate
+
+            migrate(self.inventory_path)
         args = build_parser().parse_args(["compile"])
-        args.inventory_backend = backend_id
+        args.inventory_backend = self.backend_id
         kapitan.cached.reset_cache()
         kapitan.cached.args = args
 
@@ -135,3 +146,37 @@ class InventoryTopicsTest(unittest.TestCase):
         self.assertEqual(targets["target-1"]["colour"], "red")
         self.assertEqual(targets["target-2"]["colour"], "blue")
         self.assertNotIn("target-3", targets)
+        # Consumer-only target has no ``parameters:`` node on the topic so it
+        # must not appear as a producer in the aggregated view.
+        self.assertNotIn("consumer", targets)
+
+    def test_consumed_topics_reflects_declaration(self):
+        inventory(inventory_path=self.inventory_path)
+        inv = kapitan.cached.inv
+        self.assertEqual(inv.consumed_topics("consumer"), {"colours"})
+        # Producers that did not declare ``consume: true`` are not consumers.
+        self.assertEqual(inv.consumed_topics("target-1"), set())
+        self.assertEqual(inv.consumed_topics("target-3"), set())
+        # Unknown target gracefully returns the empty set.
+        self.assertEqual(inv.consumed_topics("does-not-exist"), set())
+
+
+class InventoryTopicsTestReclass(InventoryTopicsTestBase):
+    def setUp(self):
+        self.backend_id = InventoryBackends.RECLASS
+        super().setUp()
+
+
+class InventoryTopicsTestReclassRs(InventoryTopicsTestBase):
+    def setUp(self):
+        self.backend_id = InventoryBackends.RECLASS_RS
+        super().setUp()
+
+
+class InventoryTopicsTestOmegaConf(InventoryTopicsTestBase):
+    def setUp(self):
+        self.backend_id = InventoryBackends.OMEGACONF
+        super().setUp()
+
+
+del InventoryTopicsTestBase  # remove base so it doesn't run on its own

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -13,28 +13,50 @@ import pytest
 
 from kapitan import cached
 from kapitan.cached import reset_cache
-from kapitan.topics import topics
+from kapitan.errors import CompileError
+from kapitan.topics import (
+    consumed_topics_digest,
+    current_target,
+    topics,
+)
+
+
+def _mock_inv(topics_data: dict, consumed: dict[str, set[str]] | None = None):
+    """Build a stand-in for ``cached.inv`` that mimics the bits topics() uses.
+
+    ``topics_data`` is the aggregated view ``{name: {"parameters": {"targets": ...}}}``.
+    ``consumed`` maps target_name -> set of declared consume topic names.
+    """
+    consumed = consumed or {}
+
+    class MockInv:
+        topics = topics_data
+
+        def consumed_topics(self, target):
+            return consumed.get(target, set())
+
+    return MockInv()
 
 
 @pytest.mark.usefixtures("reset_cached_args")
 class TopicsTest(unittest.TestCase):
     def setUp(self):
         reset_cache()
+        # ContextVars persist across tests within a thread. Clear explicitly so
+        # one test setting a calling target doesn't leak into the next.
+        self._cv_token = current_target.set(None)
 
     def tearDown(self):
+        current_target.reset(self._cv_token)
         reset_cache()
 
     def test_topics_returns_all_when_no_name(self):
-        cached.inv = type(
-            "MockInv",
-            (),
+        cached.inv = _mock_inv(
             {
-                "topics": {
-                    "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
-                    "shapes": {"parameters": {"targets": {"t2": {"fav": "circle"}}}},
-                }
-            },
-        )()
+                "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
+                "shapes": {"parameters": {"targets": {"t2": {"fav": "circle"}}}},
+            }
+        )
 
         result = topics()
         self.assertIn("colours", result)
@@ -44,21 +66,15 @@ class TopicsTest(unittest.TestCase):
         )
 
     def test_topics_returns_specific_topic(self):
-        cached.inv = type(
-            "MockInv",
-            (),
-            {
-                "topics": {
-                    "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
-                }
-            },
-        )()
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}}
+        )
 
         result = topics("colours")
         self.assertEqual(result["parameters"]["targets"]["t1"]["fav"], "blue")
 
     def test_topics_returns_empty_for_missing_topic(self):
-        cached.inv = type("MockInv", (), {"topics": {}})()
+        cached.inv = _mock_inv({})
 
         result = topics("nonexistent")
         self.assertEqual(result, {"parameters": {"targets": {}}})
@@ -76,15 +92,136 @@ class TopicsTest(unittest.TestCase):
         self.assertEqual(result, {"parameters": {"targets": {}}})
 
     def test_topics_name_empty_string_returns_all(self):
-        cached.inv = type(
-            "MockInv",
-            (),
-            {
-                "topics": {
-                    "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
-                }
-            },
-        )()
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}}
+        )
 
         result = topics("")
         self.assertIn("colours", result)
+
+    # --- consume declaration enforcement -------------------------------------
+
+    def test_topics_raises_when_target_did_not_declare_consume(self):
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}},
+            consumed={"consumer": set()},
+        )
+        with self.assertRaises(CompileError) as ctx:
+            topics("colours", target="consumer")
+        self.assertIn("consumer", str(ctx.exception))
+        self.assertIn("topics.colours.consume: true", str(ctx.exception))
+
+    def test_topics_succeeds_when_target_declared_consume(self):
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}},
+            consumed={"consumer": {"colours"}},
+        )
+        result = topics("colours", target="consumer")
+        self.assertEqual(result["parameters"]["targets"]["t1"]["fav"], "blue")
+
+    def test_topics_no_name_raises_listing_undeclared(self):
+        cached.inv = _mock_inv(
+            {
+                "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
+                "shapes": {"parameters": {"targets": {"t2": {"fav": "circle"}}}},
+            },
+            consumed={"consumer": {"colours"}},
+        )
+        with self.assertRaises(CompileError) as ctx:
+            topics(target="consumer")
+        msg = str(ctx.exception)
+        self.assertIn("topics.shapes.consume: true", msg)
+        # ``colours`` is declared so it must not appear in the hint
+        self.assertNotIn("topics.colours.consume: true", msg)
+
+    def test_topics_no_name_succeeds_when_all_declared(self):
+        cached.inv = _mock_inv(
+            {
+                "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
+                "shapes": {"parameters": {"targets": {"t2": {"fav": "circle"}}}},
+            },
+            consumed={"consumer": {"colours", "shapes"}},
+        )
+        result = topics(target="consumer")
+        self.assertIn("colours", result)
+        self.assertIn("shapes", result)
+
+    def test_topics_no_name_passes_when_inventory_has_no_topics(self):
+        cached.inv = _mock_inv({}, consumed={"consumer": set()})
+        # Vacuously: every topic that would be returned is declared.
+        self.assertEqual(topics(target="consumer"), {})
+
+    def test_topics_uses_contextvar_when_no_target_arg(self):
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}},
+            consumed={"consumer": set()},
+        )
+        current_target.set("consumer")
+        with self.assertRaises(CompileError):
+            topics("colours")
+
+    def test_topics_skips_check_outside_compile_context(self):
+        # No target arg, no ContextVar set — e.g. ``kapitan inventory --topics``.
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}},
+            consumed={},
+        )
+        # Should not raise even though no target ever declared ``colours``.
+        result = topics()
+        self.assertIn("colours", result)
+
+
+@pytest.mark.usefixtures("reset_cached_args")
+class ConsumedTopicsDigestTest(unittest.TestCase):
+    def setUp(self):
+        reset_cache()
+
+    def tearDown(self):
+        reset_cache()
+
+    def test_returns_none_when_target_declares_no_consumes(self):
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}},
+            consumed={"consumer": set()},
+        )
+        self.assertIsNone(consumed_topics_digest("consumer"))
+
+    def test_digest_changes_when_producer_params_change(self):
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}}},
+            consumed={"consumer": {"colours"}},
+        )
+        before = consumed_topics_digest("consumer")
+
+        # Producer flips its topic parameter — consumer's digest must move.
+        cached.inv = _mock_inv(
+            {"colours": {"parameters": {"targets": {"t1": {"fav": "red"}}}}},
+            consumed={"consumer": {"colours"}},
+        )
+        after = consumed_topics_digest("consumer")
+
+        self.assertIsNotNone(before)
+        self.assertNotEqual(before, after)
+
+    def test_digest_stable_when_unrelated_topic_changes(self):
+        # Consumer only declared ``colours``; mutating ``shapes`` must not move
+        # the digest — that's the whole point of the explicit declaration.
+        cached.inv = _mock_inv(
+            {
+                "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
+                "shapes": {"parameters": {"targets": {"t2": {"fav": "circle"}}}},
+            },
+            consumed={"consumer": {"colours"}},
+        )
+        before = consumed_topics_digest("consumer")
+
+        cached.inv = _mock_inv(
+            {
+                "colours": {"parameters": {"targets": {"t1": {"fav": "blue"}}}},
+                "shapes": {"parameters": {"targets": {"t2": {"fav": "square"}}}},
+            },
+            consumed={"consumer": {"colours"}},
+        )
+        after = consumed_topics_digest("consumer")
+
+        self.assertEqual(before, after)


### PR DESCRIPTION
## Summary

Fixes #1567 

<!-- Why is this change needed? What problem does it solve? -->

## Affected files or URLs

<!-- List the key files, pages, or URLs changed. -->

## Test plan

<!-- Checklist of what you have tested or verified. -->
- [x] Tests added or updated
- [x] Documentation updated (if user-facing behavior changed)
- [x] `make lint` passes
- [x] `make format` passes (or no formatting changes needed)
- [x] Full test suite passes (`uv run pytest tests/ --no-cov`)

## Risk assessment

<!-- What could go wrong? How can it be reverted? -->

## Follow-up work intentionally left out

<!-- What is deliberately not included so the PR stays reviewable? -->
