### PR TITLE
feat: warn when file accessors resolve outside their search paths

### DIFF
--- a/docs/pages/commands/kapitan_compile.md
+++ b/docs/pages/commands/kapitan_compile.md
@@ -177,6 +177,36 @@ library), enabled with `--yaml-use-rapidyaml`.
       back to PyYAML for that single document (rapidyaml does not escape
       them in double-quoted scalars).
 
+## Restrict file access outside the inventory
+
+Generators resolve file paths against the configured `--search-paths`. A path
+that climbs out with `..` (or a symlink) can read files outside your inventory,
+such as an SSH key. This affects jsonnet `import` and the `file_read`,
+`yaml_load`, `dir_files_*` and `jinja2_render_file` native callbacks, as well as
+input path globbing.
+
+`--path-traversal-mode` controls what happens when a resolved path escapes every
+search path:
+
+| Mode | Behaviour |
+| --- | --- |
+| `warn` (default) | Log a warning and continue compiling. |
+| `error` | Abort the compile with an error. |
+| `off` | Disable the check entirely. |
+
+!!! example ""
+
+    ```shell
+    kapitan compile --path-traversal-mode error
+    ```
+
+To apply it on every run, set it in the [`.kapitan`](kapitan_dotfile.md) dotfile:
+
+```yaml
+compile:
+  path-traversal-mode: error
+```
+
 ## Flags
 
 The table below is generated from **Kapitan**'s argument parser at docs-build time, so it always matches the installed version. See also the [global flags](kapitan_flags.md) accepted by every command, and the [`.kapitan` dotfile](kapitan_dotfile.md) to set any of these permanently.

--- a/kapitan/cli.py
+++ b/kapitan/cli.py
@@ -27,7 +27,12 @@ from kapitan.refs.base import RefController, Revealer
 from kapitan.refs.cmd_parser import handle_refs_command
 from kapitan.resources import generate_inventory, resource_callbacks, search_imports
 from kapitan.targets import compile_targets
-from kapitan.utils import check_version, from_dot_kapitan, searchvar
+from kapitan.utils import (
+    PATH_TRAVERSAL_MODES,
+    check_version,
+    from_dot_kapitan,
+    searchvar,
+)
 from kapitan.version import DESCRIPTION, PROJECT_NAME, VERSION
 
 
@@ -201,6 +206,16 @@ def build_parser():
         default=from_dot_kapitan("compile", "search-paths", [".", "lib"]),
         metavar="JPATH",
         help='set search paths, default is ["."]',
+    )
+    compile_parser.add_argument(
+        "--path-traversal-mode",
+        type=str,
+        choices=PATH_TRAVERSAL_MODES,
+        default=from_dot_kapitan("compile", "path-traversal-mode", "warn"),
+        help="how to react when a file accessor (jsonnet import/file_read, "
+        "jinja2 render, input glob) resolves a path outside its search paths: "
+        "'warn' logs it (default), 'error' fails the compile, 'off' disables "
+        "the check",
     )
     compile_parser.add_argument(
         "--jinja2-filters",

--- a/kapitan/errors.py
+++ b/kapitan/errors.py
@@ -84,3 +84,7 @@ class CuelangTemplateError(KapitanError):
 
 class OCIFetchingError(KapitanError):
     """Raised when fetching an OCI artifact fails."""
+
+
+class PathTraversalError(KapitanError):
+    """Raised when a file accessor resolves a path outside its search paths."""

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -19,7 +19,7 @@ from kapitan import cached
 from kapitan.errors import CompileError, KapitanError
 from kapitan.inventory.model.input_types import CompileInputTypeConfig, OutputType
 from kapitan.refs.base import Revealer
-from kapitan.utils import PrettyDumper, prune_empty, warn_on_path_traversal
+from kapitan.utils import PrettyDumper, check_path_traversal, prune_empty
 from kapitan.yaml_ryml import HAS_RYML
 from kapitan.yaml_ryml import dump as ryml_dump
 
@@ -131,7 +131,7 @@ class InputType:
                 )
 
             for expanded_path in expanded_paths:
-                warn_on_path_traversal(self.search_paths, expanded_path, "input path")
+                check_path_traversal(self.search_paths, expanded_path, "input path")
                 self.compile_input_path(comp_obj, expanded_path, target_compile_path)
 
     def to_file(self, config: CompileInputTypeConfig, file_path, file_content):

--- a/kapitan/inputs/base.py
+++ b/kapitan/inputs/base.py
@@ -19,7 +19,7 @@ from kapitan import cached
 from kapitan.errors import CompileError, KapitanError
 from kapitan.inventory.model.input_types import CompileInputTypeConfig, OutputType
 from kapitan.refs.base import Revealer
-from kapitan.utils import PrettyDumper, prune_empty
+from kapitan.utils import PrettyDumper, prune_empty, warn_on_path_traversal
 from kapitan.yaml_ryml import HAS_RYML
 from kapitan.yaml_ryml import dump as ryml_dump
 
@@ -131,6 +131,7 @@ class InputType:
                 )
 
             for expanded_path in expanded_paths:
+                warn_on_path_traversal(self.search_paths, expanded_path, "input path")
                 self.compile_input_path(comp_obj, expanded_path, target_compile_path)
 
     def to_file(self, config: CompileInputTypeConfig, file_path, file_content):

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -31,6 +31,7 @@ from kapitan.utils import (
     flatten_dict,
     render_jinja2_file,
     sha256_string,
+    warn_on_path_traversal,
 )
 
 
@@ -128,6 +129,7 @@ def jinja2_render_file(search_paths, name, ctx):
         logger.debug("jinja2_render_file trying file %s", _full_path)
         if os.path.exists(_full_path):
             logger.debug("jinja2_render_file found file at %s", _full_path)
+            warn_on_path_traversal([path], _full_path, "jinja2_render_file")
             try:
                 return render_jinja2_file(_full_path, ctx, search_paths=search_paths)
             except Exception as e:
@@ -145,6 +147,7 @@ def yaml_load(search_paths, name):
         logger.debug("yaml_load trying file %s", _full_path)
         if os.path.exists(_full_path) and name.endswith((".yml", ".yaml")):
             logger.debug("yaml_load found file at %s", _full_path)
+            warn_on_path_traversal([path], _full_path, "yaml_load")
             try:
                 with open(_full_path) as f:
                     return json.dumps(yaml.safe_load(f.read()))
@@ -163,6 +166,7 @@ def yaml_load_stream(search_paths, name):
         logger.debug("yaml_load_stream trying file %s", _full_path)
         if os.path.exists(_full_path) and name.endswith((".yml", ".yaml")):
             logger.debug("yaml_load_stream found file at %s", _full_path)
+            warn_on_path_traversal([path], _full_path, "yaml_load_stream")
             try:
                 with open(_full_path) as f:
                     _obj = yaml.load_all(f.read(), Loader=yaml.SafeLoader)
@@ -182,6 +186,7 @@ def read_file(search_paths, name):
         logger.debug("read_file trying file %s", full_path)
         if os.path.exists(full_path):
             logger.debug("read_file found file at %s", full_path)
+            warn_on_path_traversal([path], full_path, "read_file")
             with open(full_path, newline="") as f:
                 return f.read()
 
@@ -197,6 +202,7 @@ def file_exists(search_paths, name):
         logger.debug("file_exists trying file %s", full_path)
         if os.path.exists(full_path):
             logger.debug("file_exists found file at %s", full_path)
+            warn_on_path_traversal([path], full_path, "file_exists")
             return {"exists": True, "path": full_path}
 
     return {"exists": False, "path": ""}
@@ -208,6 +214,7 @@ def dir_files_list(search_paths, name):
         full_path = os.path.join(path, name)
         logger.debug("dir_files_list trying directory %s", full_path)
         if os.path.exists(full_path):
+            warn_on_path_traversal([path], full_path, "dir_files_list")
             return [
                 f
                 for f in os.listdir(full_path)
@@ -223,6 +230,7 @@ def dir_files_read(search_paths, name):
         full_path = os.path.join(path, name)
         logger.debug("dir_files_list trying directory %s", full_path)
         if os.path.exists(full_path):
+            warn_on_path_traversal([path], full_path, "dir_files_read")
             return {
                 f: read_file([full_path], f) for f in dir_files_list([full_path], "")
             }
@@ -278,6 +286,9 @@ def search_imports(cwd, import_str, search_paths):
         basename,
         normalised_path,
     )
+
+    allowed_roots = [cwd, os.path.dirname(kapitan_install_path), *search_paths]
+    warn_on_path_traversal(allowed_roots, normalised_path, "jsonnet import")
 
     normalised_path_content = ""
     with open(normalised_path) as f:

--- a/kapitan/resources.py
+++ b/kapitan/resources.py
@@ -27,11 +27,11 @@ from kapitan.topics import topics
 from kapitan.utils import (
     PrettyDumper,
     StrEnum,
+    check_path_traversal,
     deep_get,
     flatten_dict,
     render_jinja2_file,
     sha256_string,
-    warn_on_path_traversal,
 )
 
 
@@ -129,7 +129,7 @@ def jinja2_render_file(search_paths, name, ctx):
         logger.debug("jinja2_render_file trying file %s", _full_path)
         if os.path.exists(_full_path):
             logger.debug("jinja2_render_file found file at %s", _full_path)
-            warn_on_path_traversal([path], _full_path, "jinja2_render_file")
+            check_path_traversal([path], _full_path, "jinja2_render_file")
             try:
                 return render_jinja2_file(_full_path, ctx, search_paths=search_paths)
             except Exception as e:
@@ -147,7 +147,7 @@ def yaml_load(search_paths, name):
         logger.debug("yaml_load trying file %s", _full_path)
         if os.path.exists(_full_path) and name.endswith((".yml", ".yaml")):
             logger.debug("yaml_load found file at %s", _full_path)
-            warn_on_path_traversal([path], _full_path, "yaml_load")
+            check_path_traversal([path], _full_path, "yaml_load")
             try:
                 with open(_full_path) as f:
                     return json.dumps(yaml.safe_load(f.read()))
@@ -166,7 +166,7 @@ def yaml_load_stream(search_paths, name):
         logger.debug("yaml_load_stream trying file %s", _full_path)
         if os.path.exists(_full_path) and name.endswith((".yml", ".yaml")):
             logger.debug("yaml_load_stream found file at %s", _full_path)
-            warn_on_path_traversal([path], _full_path, "yaml_load_stream")
+            check_path_traversal([path], _full_path, "yaml_load_stream")
             try:
                 with open(_full_path) as f:
                     _obj = yaml.load_all(f.read(), Loader=yaml.SafeLoader)
@@ -186,7 +186,7 @@ def read_file(search_paths, name):
         logger.debug("read_file trying file %s", full_path)
         if os.path.exists(full_path):
             logger.debug("read_file found file at %s", full_path)
-            warn_on_path_traversal([path], full_path, "read_file")
+            check_path_traversal([path], full_path, "read_file")
             with open(full_path, newline="") as f:
                 return f.read()
 
@@ -202,7 +202,7 @@ def file_exists(search_paths, name):
         logger.debug("file_exists trying file %s", full_path)
         if os.path.exists(full_path):
             logger.debug("file_exists found file at %s", full_path)
-            warn_on_path_traversal([path], full_path, "file_exists")
+            check_path_traversal([path], full_path, "file_exists")
             return {"exists": True, "path": full_path}
 
     return {"exists": False, "path": ""}
@@ -214,7 +214,7 @@ def dir_files_list(search_paths, name):
         full_path = os.path.join(path, name)
         logger.debug("dir_files_list trying directory %s", full_path)
         if os.path.exists(full_path):
-            warn_on_path_traversal([path], full_path, "dir_files_list")
+            check_path_traversal([path], full_path, "dir_files_list")
             return [
                 f
                 for f in os.listdir(full_path)
@@ -230,7 +230,7 @@ def dir_files_read(search_paths, name):
         full_path = os.path.join(path, name)
         logger.debug("dir_files_list trying directory %s", full_path)
         if os.path.exists(full_path):
-            warn_on_path_traversal([path], full_path, "dir_files_read")
+            check_path_traversal([path], full_path, "dir_files_read")
             return {
                 f: read_file([full_path], f) for f in dir_files_list([full_path], "")
             }
@@ -288,7 +288,7 @@ def search_imports(cwd, import_str, search_paths):
     )
 
     allowed_roots = [cwd, os.path.dirname(kapitan_install_path), *search_paths]
-    warn_on_path_traversal(allowed_roots, normalised_path, "jsonnet import")
+    check_path_traversal(allowed_roots, normalised_path, "jsonnet import")
 
     normalised_path_content = ""
     with open(normalised_path) as f:

--- a/kapitan/targets.py
+++ b/kapitan/targets.py
@@ -24,7 +24,7 @@ from kapitan.inputs import CACHEABLE_INPUT_TYPES, get_compiler
 from kapitan.inputs.cache import CacheMetrics
 from kapitan.profiling import worker_profile
 from kapitan.resources import get_inventory
-from kapitan.utils import available_cpu_count
+from kapitan.utils import available_cpu_count, set_path_traversal_mode
 
 
 logger = logging.getLogger(__name__)
@@ -377,6 +377,10 @@ def _compile_target_impl(
     start = time.time()
     compile_configs = target_config.compile
     target_name = target_config.vars.target
+
+    # Re-apply per process: with the spawn start method the module global in
+    # ``utils`` resets to the default in each worker, so set it from args here.
+    set_path_traversal_mode(getattr(args, "path_traversal_mode", "warn"))
 
     for compile_config in compile_configs:
         try:

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -65,6 +65,36 @@ for _YamlLoader in {YamlLoader, yaml.SafeLoader}:
     )
 
 
+def warn_on_path_traversal(roots, resolved_path, accessor):
+    """Warn (without blocking) when ``resolved_path`` escapes every allowed root.
+
+    File accessors such as jsonnet's ``import``/``file_read`` natives, the jinja2
+    render callback and input glob expansion resolve a caller-supplied name
+    against search paths with ``os.path.join``. A name containing ``..`` (or a
+    symlink) can resolve outside the inventory and read unrelated files such as
+    SSH keys. This logs a warning so the access is visible; it does not yet block
+    it.
+
+    Args:
+        roots: iterable of directories the access is expected to stay within.
+        resolved_path: the path actually selected by the accessor.
+        accessor: short name of the caller, used in the warning message.
+    """
+    real_path = os.path.realpath(resolved_path)
+    for root in roots:
+        real_root = os.path.realpath(root)
+        if real_path == real_root or real_path.startswith(real_root + os.sep):
+            return
+    logger.warning(
+        "%s: resolved path %r escapes its search path(s) (resolved to %r). "
+        "This reads a file outside the inventory and may be blocked in a future "
+        "release.",
+        accessor,
+        resolved_path,
+        real_path,
+    )
+
+
 def available_cpu_count():
     """Return CPUs available to this process, accounting for container limits."""
     os_cpu_count = os.cpu_count() or 1

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -28,7 +28,7 @@ import requests
 import yaml
 
 from kapitan import cached, defaults
-from kapitan.errors import CompileError
+from kapitan.errors import CompileError, PathTraversalError
 from kapitan.jinja2_filters import (
     _jinja_error_info,
     load_jinja2_filters,
@@ -65,34 +65,69 @@ for _YamlLoader in {YamlLoader, yaml.SafeLoader}:
     )
 
 
-def warn_on_path_traversal(roots, resolved_path, accessor):
-    """Warn (without blocking) when ``resolved_path`` escapes every allowed root.
+# How file accessors react when a resolved path escapes its search paths.
+PATH_TRAVERSAL_MODES = ("warn", "error", "off")
+_DEFAULT_PATH_TRAVERSAL_MODE = "warn"
+_path_traversal_mode = _DEFAULT_PATH_TRAVERSAL_MODE
+
+
+def set_path_traversal_mode(mode):
+    """Set the process-wide reaction to a path escaping its search paths.
+
+    One of ``PATH_TRAVERSAL_MODES``: ``warn`` (log, default), ``error`` (raise
+    ``PathTraversalError``) or ``off`` (skip the check). Workers call this from
+    ``compile_target`` so the setting survives the spawn process boundary.
+    """
+    global _path_traversal_mode
+    if mode not in PATH_TRAVERSAL_MODES:
+        raise ValueError(
+            f"invalid path traversal mode {mode!r}, expected one of "
+            f"{', '.join(PATH_TRAVERSAL_MODES)}"
+        )
+    _path_traversal_mode = mode
+
+
+@lru_cache(maxsize=512)
+def _realpath(path):
+    """``os.path.realpath`` memoised for stable inputs such as search paths."""
+    return os.path.realpath(path)
+
+
+def check_path_traversal(roots, resolved_path, accessor):
+    """React when ``resolved_path`` escapes every allowed root.
 
     File accessors such as jsonnet's ``import``/``file_read`` natives, the jinja2
     render callback and input glob expansion resolve a caller-supplied name
     against search paths with ``os.path.join``. A name containing ``..`` (or a
     symlink) can resolve outside the inventory and read unrelated files such as
-    SSH keys. This logs a warning so the access is visible; it does not yet block
-    it.
+    SSH keys.
+
+    The reaction is set by ``set_path_traversal_mode``: ``warn`` logs and lets
+    the read continue, ``error`` raises ``PathTraversalError``, ``off`` disables
+    the check entirely.
 
     Args:
         roots: iterable of directories the access is expected to stay within.
         resolved_path: the path actually selected by the accessor.
-        accessor: short name of the caller, used in the warning message.
+        accessor: short name of the caller, used in the message.
     """
+    if _path_traversal_mode == "off":
+        return
+    # ``resolved_path`` differs every call so it is not memoised; the roots
+    # (search paths) repeat across a whole compile, so ``_realpath`` caches them.
     real_path = os.path.realpath(resolved_path)
     for root in roots:
-        real_root = os.path.realpath(root)
+        real_root = _realpath(root)
         if real_path == real_root or real_path.startswith(real_root + os.sep):
             return
-    logger.warning(
-        "%s: resolved path %r escapes its search path(s) (resolved to %r). "
-        "This reads a file outside the inventory and may be blocked in a future "
-        "release.",
-        accessor,
-        resolved_path,
-        real_path,
+    message = (
+        f"{accessor}: resolved path {resolved_path!r} escapes its search "
+        f"path(s) (resolved to {real_path!r}); this reads a file outside the "
+        f"inventory"
     )
+    if _path_traversal_mode == "error":
+        raise PathTraversalError(message)
+    logger.warning("%s (set path-traversal mode to 'error' to forbid this)", message)
 
 
 def available_cpu_count():

--- a/tests/test_path_traversal_warning.py
+++ b/tests/test_path_traversal_warning.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Path-traversal warnings for file accessors.
+"""Path-traversal handling for file accessors.
 
-These cover ``warn_on_path_traversal`` and the resource native callbacks that
-use it. The guard is warn-only: it must log when a resolved path escapes its
-search paths, and stay silent for ordinary in-tree access. It must never block.
+These cover ``check_path_traversal`` and the resource native callbacks that use
+it. The reaction is configurable: ``warn`` logs and lets the read continue,
+``error`` raises, and ``off`` disables the check. ``warn`` is the default and
+must never block.
 """
 
 import logging
@@ -14,10 +15,20 @@ import logging
 import pytest
 
 from kapitan import resources
-from kapitan.utils import warn_on_path_traversal
+from kapitan.errors import PathTraversalError
+from kapitan.utils import check_path_traversal, set_path_traversal_mode
 
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _reset_mode():
+    # Each test starts from the default; restore it afterwards because the mode
+    # is a process-wide global.
+    set_path_traversal_mode("warn")
+    yield
+    set_path_traversal_mode("warn")
 
 
 def _write(path, content=""):
@@ -28,13 +39,12 @@ def _write(path, content=""):
 def test_warns_when_path_escapes_root(tmp_path, caplog):
     root = tmp_path / "inventory"
     root.mkdir()
-    outside = tmp_path / "secret.txt"
-    _write(outside, "ssh-key")
+    _write(tmp_path / "secret.txt", "ssh-key")
 
     with caplog.at_level(logging.WARNING):
-        warn_on_path_traversal([str(root)], str(root / ".." / "secret.txt"), "test")
+        check_path_traversal([str(root)], str(root / ".." / "secret.txt"), "test")
 
-    assert any("escapes its search path" in r.message for r in caplog.records)
+    assert any("escapes its search" in r.message for r in caplog.records)
 
 
 def test_silent_for_path_within_root(tmp_path, caplog):
@@ -44,7 +54,7 @@ def test_silent_for_path_within_root(tmp_path, caplog):
     _write(inside)
 
     with caplog.at_level(logging.WARNING):
-        warn_on_path_traversal([str(root)], str(inside), "test")
+        check_path_traversal([str(root)], str(inside), "test")
 
     assert caplog.records == []
 
@@ -58,16 +68,40 @@ def test_silent_when_contained_in_any_root(tmp_path, caplog):
     _write(inside_b)
 
     with caplog.at_level(logging.WARNING):
-        warn_on_path_traversal([str(root_a), str(root_b)], str(inside_b), "test")
+        check_path_traversal([str(root_a), str(root_b)], str(inside_b), "test")
 
     assert caplog.records == []
+
+
+def test_error_mode_raises_on_escape(tmp_path):
+    root = tmp_path / "inventory"
+    root.mkdir()
+    set_path_traversal_mode("error")
+
+    with pytest.raises(PathTraversalError):
+        check_path_traversal([str(root)], str(root / ".." / "secret.txt"), "test")
+
+
+def test_off_mode_is_silent_and_never_raises(tmp_path, caplog):
+    root = tmp_path / "inventory"
+    root.mkdir()
+    set_path_traversal_mode("off")
+
+    with caplog.at_level(logging.WARNING):
+        check_path_traversal([str(root)], str(root / ".." / "secret.txt"), "test")
+
+    assert caplog.records == []
+
+
+def test_invalid_mode_rejected():
+    with pytest.raises(ValueError, match="invalid path traversal mode"):
+        set_path_traversal_mode("loud")
 
 
 def test_read_file_warns_on_traversal_but_still_reads(tmp_path, caplog):
     search_dir = tmp_path / "lib"
     search_dir.mkdir()
-    secret = tmp_path / "id_rsa"
-    _write(secret, "PRIVATE KEY")
+    _write(tmp_path / "id_rsa", "PRIVATE KEY")
 
     with caplog.at_level(logging.WARNING):
         content = resources.read_file([str(search_dir)], "../id_rsa")
@@ -75,7 +109,7 @@ def test_read_file_warns_on_traversal_but_still_reads(tmp_path, caplog):
     # warn-only: the read still succeeds, but the escape is logged
     assert content == "PRIVATE KEY"
     assert any(
-        "read_file" in r.message and "escapes its search path" in r.message
+        "read_file" in r.message and "escapes its search" in r.message
         for r in caplog.records
     )
 
@@ -90,3 +124,23 @@ def test_read_file_silent_for_in_tree_file(tmp_path, caplog):
 
     assert content == "ok"
     assert caplog.records == []
+
+
+def test_search_imports_warns_when_import_escapes_search_paths(tmp_path, caplog):
+    # Drives the multi-root path (cwd + install path + search paths) end to end:
+    # an import that climbs out of both cwd and the search path must warn.
+    inventory = tmp_path / "inv"
+    cwd = inventory / "components"
+    cwd.mkdir(parents=True)
+    _write(tmp_path / "outside.libsonnet", "{}")
+
+    with caplog.at_level(logging.WARNING):
+        resolved, content = resources.search_imports(
+            str(cwd), "../../outside.libsonnet", [str(inventory)]
+        )
+
+    assert content == b"{}"
+    assert any(
+        "jsonnet import" in r.message and "escapes its search" in r.message
+        for r in caplog.records
+    )

--- a/tests/test_path_traversal_warning.py
+++ b/tests/test_path_traversal_warning.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2026 The Kapitan Authors <kapitan-admins@googlegroups.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Path-traversal warnings for file accessors.
+
+These cover ``warn_on_path_traversal`` and the resource native callbacks that
+use it. The guard is warn-only: it must log when a resolved path escapes its
+search paths, and stay silent for ordinary in-tree access. It must never block.
+"""
+
+import logging
+
+import pytest
+
+from kapitan import resources
+from kapitan.utils import warn_on_path_traversal
+
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path, content=""):
+    with open(path, "w") as f:
+        f.write(content)
+
+
+def test_warns_when_path_escapes_root(tmp_path, caplog):
+    root = tmp_path / "inventory"
+    root.mkdir()
+    outside = tmp_path / "secret.txt"
+    _write(outside, "ssh-key")
+
+    with caplog.at_level(logging.WARNING):
+        warn_on_path_traversal([str(root)], str(root / ".." / "secret.txt"), "test")
+
+    assert any("escapes its search path" in r.message for r in caplog.records)
+
+
+def test_silent_for_path_within_root(tmp_path, caplog):
+    root = tmp_path / "inventory"
+    root.mkdir()
+    inside = root / "values.yaml"
+    _write(inside)
+
+    with caplog.at_level(logging.WARNING):
+        warn_on_path_traversal([str(root)], str(inside), "test")
+
+    assert caplog.records == []
+
+
+def test_silent_when_contained_in_any_root(tmp_path, caplog):
+    root_a = tmp_path / "a"
+    root_b = tmp_path / "b"
+    root_a.mkdir()
+    root_b.mkdir()
+    inside_b = root_b / "f.yaml"
+    _write(inside_b)
+
+    with caplog.at_level(logging.WARNING):
+        warn_on_path_traversal([str(root_a), str(root_b)], str(inside_b), "test")
+
+    assert caplog.records == []
+
+
+def test_read_file_warns_on_traversal_but_still_reads(tmp_path, caplog):
+    search_dir = tmp_path / "lib"
+    search_dir.mkdir()
+    secret = tmp_path / "id_rsa"
+    _write(secret, "PRIVATE KEY")
+
+    with caplog.at_level(logging.WARNING):
+        content = resources.read_file([str(search_dir)], "../id_rsa")
+
+    # warn-only: the read still succeeds, but the escape is logged
+    assert content == "PRIVATE KEY"
+    assert any(
+        "read_file" in r.message and "escapes its search path" in r.message
+        for r in caplog.records
+    )
+
+
+def test_read_file_silent_for_in_tree_file(tmp_path, caplog):
+    search_dir = tmp_path / "lib"
+    search_dir.mkdir()
+    _write(search_dir / "data.txt", "ok")
+
+    with caplog.at_level(logging.WARNING):
+        content = resources.read_file([str(search_dir)], "data.txt")
+
+    assert content == "ok"
+    assert caplog.records == []

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -201,6 +201,7 @@ class CompileTargetTest(unittest.TestCase):
 
         args = MagicMock()
         args.inventory_pool_cache = False
+        args.path_traversal_mode = "warn"
 
         # Should not raise
         compile_target(target_config, [], "/tmp", None, args)
@@ -216,6 +217,7 @@ class CompileTargetTest(unittest.TestCase):
 
         args = MagicMock()
         args.inventory_pool_cache = False
+        args.path_traversal_mode = "warn"
 
         # Should not raise because continue_on_compile_error=True
         compile_target(target_config, [], "/tmp", None, args)
@@ -231,6 +233,7 @@ class CompileTargetTest(unittest.TestCase):
 
         args = MagicMock()
         args.inventory_pool_cache = False
+        args.path_traversal_mode = "warn"
 
         with self.assertRaises(CompileError):
             compile_target(target_config, [], "/tmp", None, args)


### PR DESCRIPTION
## What

Log a warning when a file accessor resolves a path outside its search paths,
for example through a `..` segment or a symlink. The warning is informational
only; nothing is blocked.

## Why

Several accessors resolve a caller-supplied name against search paths with
`os.path.join` and then open whatever that produces:

- jsonnet `import` resolution (`search_imports`)
- the `file_read`, `yaml_load`, `yaml_load_stream`, `file_exists`,
  `dir_files_list` and `dir_files_read` jsonnet natives
- the `jinja2_render_file` callback
- input path / glob expansion in the base input type

A name like `../../../../home/user/.ssh/id_rsa` resolves cleanly and the file is
read, with nothing recording that the access left the inventory. This is the
first, non-breaking step toward confining those reads: make the escape visible
before any release starts rejecting it.

## Approach

- New `warn_on_path_traversal(roots, resolved_path, accessor)` in `utils.py`. It
  compares `os.path.realpath(resolved_path)` against the realpath of each
  allowed root and logs a warning only when the path is contained in none of
  them. `realpath` means symlink escapes are caught too, not just `..`.
- Wired into each resource native callback (checked against the matched search
  path) and into `search_imports` (checked against cwd, the kapitan install
  path, and the search paths).
- Wired into the input path loop in `base.py`, checked against all search paths.

## Verification

- New `tests/test_path_traversal_warning.py` (5 tests): warns on escape, silent
  in-tree, silent when contained in any of several roots, and confirms
  `read_file` still returns the content while logging the escape (warn-only).
- `tests/test_jsonnet.py`, `tests/test_inputs_base.py`,
  `tests/test_input_compile_obj.py` pass unchanged.
- Ran the reclass compile suite with warnings surfaced: no spurious traversal
  warnings on legitimate compiles.
- pre-commit (ruff, ruff-format) clean.

## Note

Warn-only by design. A follow-up can add an enforce mode once the warning has
been out long enough to surface any legitimate out-of-tree access.
