### PR TITLE
docs: fix homepage SEO metadata and add per-page social share

### DIFF
--- a/docs/ADOPTERS.md
+++ b/docs/ADOPTERS.md
@@ -1,3 +1,8 @@
+---
+title: "Who Uses Kapitan: Adopters and Companies"
+description: "See the companies and organizations using Kapitan to manage Kubernetes, Terraform, and infrastructure configuration in production environments."
+---
+
 # Who uses **Kapitan**
 
 If you're using **Kapitan** in your organization, please let us know by adding to this list on the [docs/ADOPTERS.md](https://github.com/kapicorp/kapitan/blob/master/docs/ADOPTERS.md) file.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,6 @@
 ---
 comments: true
-title: "Kapitan FAQ"
+title: "Kapitan FAQ: Frequently Asked Questions"
 description: "Find answers to frequently asked questions about Kapitan inventory, targets, classes, compilation, references, secrets, and supported input types."
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,14 +1,14 @@
 ---
 title: "Kapitan: Configuration management for complex infrastructure"
-description: "Kapitan is an open source configuration management tool that helps teams generate, organize, reuse, validate, and manage Kubernetes, Terraform, and other configuration across environments using inventory, templates, and references."
+description: "Kapitan is an open source configuration management tool to generate, validate, and manage Kubernetes, Terraform, and infrastructure config across environments."
 ---
 
-# :kapitan-logo: **Kapitan: Keep your ship together**
+# :kapitan-logo: Kapitan: Keep your ship together
 
 ![GitHub Sponsors](https://img.shields.io/github/sponsors/kapicorp?style=for-the-badge)
 ![GitHub Stars](https://img.shields.io/github/stars/kapicorp/kapitan?style=for-the-badge)
 
-**Kapitan** is an open source configuration management tool for complex infrastructure systems. It helps teams generate, organize, reuse, validate, and manage Kubernetes, Terraform, and other configuration across environments using inventory, templates, Jsonnet, Jinja2, Kadet, Helm, Kustomize, CUE, and external references.
+Kapitan is an open source configuration management tool for complex infrastructure systems. It helps teams generate, organize, reuse, validate, and manage Kubernetes, Terraform, and other configuration across environments using inventory, templates, Jsonnet, Jinja2, Kadet, Helm, Kustomize, CUE, and external references.
 
 <div class="grid cards" markdown>
 
@@ -48,7 +48,7 @@ description: "Kapitan is an open source configuration management tool that helps
 
 ## What Kapitan does
 
-Kapitan turns a hierarchical **inventory** and a set of **input templates** into compiled configuration files ready for deployment. You define reusable classes, per-environment targets, and parameters in YAML. Kapitan compiles them into Kubernetes manifests, Terraform plans, scripts, documentation, or any text-based output you need.
+Kapitan turns a hierarchical inventory and a set of input templates into compiled configuration files ready for deployment. You define reusable classes, per-environment targets, and parameters in YAML. Kapitan compiles them into Kubernetes manifests, Terraform plans, scripts, documentation, or any text-based output you need.
 
 ```mermaid
 graph LR
@@ -105,7 +105,7 @@ Kapitan requires Python 3.10 or newer.
 
 ### Why Kapitan?
 
-Read the original motivation and design thinking in the blog post: [Why do I need **Kapitan**?](pages/blog/posts/2022-12-04.md#why-do-i-need-kapitan)
+Read the original motivation and design thinking in the blog post: [Why do I need Kapitan?](pages/blog/posts/2022-12-04.md#why-do-i-need-kapitan)
 
 ### Video tutorials
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,5 +1,5 @@
 ---
-title: "Getting Started with Kapitan"
+title: "Getting Started with Kapitan in Minutes"
 description: "Install Kapitan with Docker or pip, clone a reference repository, and compile your first Kubernetes and infrastructure targets in minutes."
 ---
 

--- a/docs/related.md
+++ b/docs/related.md
@@ -1,3 +1,8 @@
+---
+title: "Kapitan Related Projects and Ecosystem Tools"
+description: "Explore projects related to Kapitan, including Tesoro, the Kapitan Reference repository, and Jsonnet editor plugins and syntax highlighting tools."
+---
+
 # :kapitan-logo: Related projects
 
 * [Tesoro](https://github.com/kapicorp/tesoro) - Kubernetes Admission Controller for Kapitan Secrets

--- a/docs/support.md
+++ b/docs/support.md
@@ -1,5 +1,5 @@
 ---
-title: "Kapitan Support"
+title: "Kapitan Support and Community Help"
 description: "Get help with Kapitan through the community Slack channel, GitHub discussions, and documentation resources."
 ---
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -17,6 +17,49 @@
 {% block extrahead %}
   {{ super() }}
 
+  {# Apple touch icon for iOS home-screen bookmarks #}
+  <link rel="apple-touch-icon" href="{{ config.site_url }}images/kapitan_logo.png" />
+
+  {# Per-page social share bar styling #}
+  <style>
+    .kapitan-share {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+      margin: 2.4rem 0 0.8rem;
+      padding-top: 1.2rem;
+      border-top: 1px solid var(--md-default-fg-color--lightest);
+    }
+    .kapitan-share__label {
+      font-size: 0.7rem;
+      font-weight: 700;
+      color: var(--md-default-fg-color--light);
+      margin-right: 0.2rem;
+    }
+    .kapitan-share__link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 1.6rem;
+      height: 1.6rem;
+      padding: 0;
+      border: none;
+      background: none;
+      cursor: pointer;
+      color: var(--md-default-fg-color--light);
+      transition: color 125ms;
+    }
+    .kapitan-share__link:hover {
+      color: var(--md-accent-fg-color);
+    }
+    .kapitan-share__link svg {
+      width: 1rem;
+      height: 1rem;
+      fill: currentColor;
+    }
+  </style>
+
   {# Resource hints for external domains #}
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="dns-prefetch" href="https://www.googletagmanager.com">
@@ -118,4 +161,5 @@
   </a>
   {% endif %}
   {{ page.content }}
+  {% include "partials/share.html" %}
 {% endblock %}

--- a/overrides/partials/share.html
+++ b/overrides/partials/share.html
@@ -1,0 +1,36 @@
+{#-
+  Per-page social share bar. Rendered at the foot of each page content.
+  Uses the page canonical URL and title so shares point at the live page.
+-#}
+{% if page and page.canonical_url %}
+{% set share_url = page.canonical_url %}
+{% set share_title = (page.meta or {}).get("title") or (page.title | striptags) or config.site_name %}
+<div class="kapitan-share" aria-label="Share this page">
+  <span class="kapitan-share__label">Share this page</span>
+  <a class="kapitan-share__link" target="_blank" rel="noopener"
+     title="Share on X" aria-label="Share on X"
+     href="https://twitter.com/intent/tweet?url={{ share_url | urlencode }}&text={{ share_title | urlencode }}">
+    {% include ".icons/fontawesome/brands/x-twitter.svg" %}
+  </a>
+  <a class="kapitan-share__link" target="_blank" rel="noopener"
+     title="Share on LinkedIn" aria-label="Share on LinkedIn"
+     href="https://www.linkedin.com/sharing/share-offsite/?url={{ share_url | urlencode }}">
+    {% include ".icons/fontawesome/brands/linkedin.svg" %}
+  </a>
+  <a class="kapitan-share__link" target="_blank" rel="noopener"
+     title="Share on Reddit" aria-label="Share on Reddit"
+     href="https://www.reddit.com/submit?url={{ share_url | urlencode }}&title={{ share_title | urlencode }}">
+    {% include ".icons/fontawesome/brands/reddit.svg" %}
+  </a>
+  <a class="kapitan-share__link" target="_blank" rel="noopener"
+     title="Share on Hacker News" aria-label="Share on Hacker News"
+     href="https://news.ycombinator.com/submitlink?u={{ share_url | urlencode }}&t={{ share_title | urlencode }}">
+    {% include ".icons/fontawesome/brands/hacker-news.svg" %}
+  </a>
+  <button class="kapitan-share__link" type="button"
+     title="Copy link" aria-label="Copy link"
+     onclick="navigator.clipboard && navigator.clipboard.writeText('{{ share_url }}')">
+    {% include ".icons/material/link-variant.svg" %}
+  </button>
+</div>
+{% endif %}

--- a/tests/test_docs_rendering.py
+++ b/tests/test_docs_rendering.py
@@ -80,10 +80,16 @@ def test_fenced_block_renders(md, name, source):
 # slot. New pages that skip frontmatter fail here instead of shipping invisible
 # to search.
 
-DOCS_PAGES_DIR = pathlib.Path(__file__).resolve().parent.parent / "docs" / "pages"
+DOCS_DIR = pathlib.Path(__file__).resolve().parent.parent / "docs"
+DOCS_PAGES_DIR = DOCS_DIR / "pages"
 
 TITLE_MIN, TITLE_MAX = 30, 65
 DESCRIPTION_MIN, DESCRIPTION_MAX = 50, 160
+
+# Top-level docs pages (homepage + nav entries) that the original gate skipped
+# but that search engines actually crawl. tags.md is a generated tag-index
+# placeholder ([TAGS]) with no prose of its own, so it is excluded.
+TOP_LEVEL_EXCLUDE = {"tags.md"}
 
 # Matches a leading YAML frontmatter block. MkDocs only recognises frontmatter
 # when it is the very first thing in the file, so anchor at the start.
@@ -91,11 +97,13 @@ _FRONTMATTER_RE = re.compile(r"\A---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
 
 
 def _docs_pages():
-    return sorted(DOCS_PAGES_DIR.rglob("*.md"))
+    pages = set(DOCS_PAGES_DIR.rglob("*.md"))
+    pages.update(p for p in DOCS_DIR.glob("*.md") if p.name not in TOP_LEVEL_EXCLUDE)
+    return sorted(pages)
 
 
 def _page_id(path):
-    return str(path.relative_to(DOCS_PAGES_DIR))
+    return str(path.relative_to(DOCS_DIR))
 
 
 def _parse_frontmatter(text):


### PR DESCRIPTION
## What

- Trim the homepage meta description from 231 to 159 characters so it fits the ~160-char search-result limit.
- Drop redundant `**bold**` tags on the homepage (17 → 12) and remove the duplicated `**Kapitan**` strong tag.
- Add an Apple touch icon link for iOS home-screen bookmarks.
- Extend the docs SEO frontmatter test to cover top-level pages (homepage + nav entries), and backfill/lengthen frontmatter on the newly-covered pages so they pass.
- Add a per-page social share bar (X, LinkedIn, Reddit, Hacker News, copy link).

## Why

An SEO audit of the homepage flagged a too-long meta description, too many strong tags, a missing Apple touch icon, and a lack of social sharing options. Digging in, I found the root cause of the metadata issues: the SEO frontmatter test only scanned `docs/pages/`, so the homepage (`docs/README.md`) and the other top-level nav pages were never gated — which is exactly how the over-length description shipped in the first place. Fixing the page without fixing the test would just let it regress.

## Approach

- Rewrote the homepage description to 159 chars and unbolded the H1, the intro `Kapitan`, `inventory`/`input templates`, and the blog-link `Kapitan`, leaving the card titles and bullet leads bold for readability.
- Added the Apple touch icon in the `extrahead` block, reusing the existing logo PNG already used for Open Graph.
- Widened `_docs_pages()` in `tests/test_docs_rendering.py` to also scan top-level `docs/*.md`, excluding `tags.md` (a generated `[TAGS]` placeholder with no prose). Then added frontmatter to `ADOPTERS.md` and `related.md` and lengthened the short titles in `FAQ.md`, `getting_started.md`, and `support.md` to clear the 30-char minimum.
- New `overrides/partials/share.html` renders the share bar at the foot of each page, using `page.canonical_url` and the page title so shares point at the live page. Styled with an inline `<style>` block (scoped to `.kapitan-share`, theme-aware via Material CSS vars) to avoid adding another render-blocking stylesheet request.

Note: `robots.txt` (`docs/robots.txt`) and the auto-generated `sitemap.xml` already exist in the repo. If the audit reports them missing, that is a hosting/serving concern with the mike-versioned paths, not something this PR changes.

## Verification

- `uv run pytest tests/test_docs_rendering.py --no-cov` — 57 passed.
- `uv run mkdocs build` (strict mode) exits 0; a missing share icon would have failed the build.
- Confirmed in the built output: meta description is 159 chars, `apple-touch-icon` link present, and all five share buttons render on the homepage.