### PR TITLE
chore(coverage): raise fail_under threshold to 70%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,7 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 64
+fail_under = 70
 show_missing = true
 skip_covered = false
 exclude_lines = [


### PR DESCRIPTION
## What

Bumps the coverage gate in `pyproject.toml` from `fail_under = 64` to `fail_under = 70`.

## Why

Total coverage already sits around 71.9%, well clear of the old 64% floor. Raising the threshold to 70% captures the coverage we already have and prevents it quietly slipping back.

## Verification

70% is below the current ~71.9% total, so the existing suite still passes the gate.

Note: the recurring flaky vault failure that was making CI red on unrelated PRs is fixed separately in #1571.