### PR TITLE
fix: filter out consumers from topics output

### DIFF
--- a/kapitan/inventory/inventory.py
+++ b/kapitan/inventory/inventory.py
@@ -102,19 +102,18 @@ class Inventory(ABC):
         for target in self.targets.values():
             target_topics = getattr(target.parameters.kapitan, "topics", None) or {}
             for topic_name, topic_values in target_topics.items():
-                # A target only counts as a *producer* of a topic if it actually
-                # declares a ``parameters:`` node — declaring just ``consume: true``
-                # (consumer-only) must not surface as an empty entry in the
-                # aggregated view. Support both pydantic-style attribute access
-                # and the raw-dict fallback the omegaconf backend produces.
+                # support both pydantic model and raw dict
                 if isinstance(topic_values, dict):
-                    if "parameters" not in topic_values:
-                        continue
-                    topic_params = topic_values["parameters"] or {}
+                    topic_params = topic_values.get("parameters")
                 else:
                     topic_params = getattr(topic_values, "parameters", None)
-                    if topic_params is None:
-                        continue
+                # A target that only declared ``consume: true`` (i.e. no
+                # ``parameters`` sub-block) is a consumer, not a contributor;
+                # skip it so it doesn't self-appear as an empty entry in the
+                # aggregated view.
+                if topic_params is None:
+                    continue
+
                 topics.setdefault(topic_name, {})[target.name] = topic_params
 
         return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,7 @@ omit = [
 
 [tool.coverage.report]
 precision = 2
-fail_under = 64
+fail_under = 72
 show_missing = true
 skip_covered = false
 exclude_lines = [

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -119,6 +119,7 @@ class InventoryTopicsTestBase(unittest.TestCase):
             "parameters:\n  colour: blue\n  kapitan:\n    topics:\n      colours:\n        parameters:\n          colour: ${colour}\n",
         )
         write("target-3.yml", "parameters:\n  unrelated: true\n")
+
         # Consumer-only target: declares consume but produces no parameters.
         write(
             "consumer.yml",
@@ -146,9 +147,34 @@ class InventoryTopicsTestBase(unittest.TestCase):
         self.assertEqual(targets["target-1"]["colour"], "red")
         self.assertEqual(targets["target-2"]["colour"], "blue")
         self.assertNotIn("target-3", targets)
+
         # Consumer-only target has no ``parameters:`` node on the topic so it
         # must not appear as a producer in the aggregated view.
         self.assertNotIn("consumer", targets)
+
+    def test_topics_cli_excludes_consumer_only_targets(self):
+        """``kapitan inventory --topics`` must not list targets that only
+        declared ``consume: true`` (no ``parameters:`` sub-block) — those are
+        consumers of the topic, not contributors to it.
+        """
+        from kapitan.topics import topics as topics_view
+
+        inventory(inventory_path=self.inventory_path)
+
+        # Full mapping path: ``kapitan inventory --topics``.
+        all_topics = topics_view()
+        self.assertIn("colours", all_topics)
+        all_targets = all_topics["colours"]["parameters"]["targets"]
+        self.assertIn("target-1", all_targets)
+        self.assertIn("target-2", all_targets)
+        self.assertNotIn("consumer", all_targets)
+
+        # Single-topic path: ``kapitan inventory --topics colours``.
+        one_topic = topics_view("colours")
+        single_targets = one_topic["parameters"]["targets"]
+        self.assertIn("target-1", single_targets)
+        self.assertIn("target-2", single_targets)
+        self.assertNotIn("consumer", single_targets)
 
     def test_consumed_topics_reflects_declaration(self):
         inventory(inventory_path=self.inventory_path)


### PR DESCRIPTION
## Summary

Filter out consumers from topics output.

Fixes #1584 

## Motivation

<!-- Why is this change needed? What problem does it solve? -->

## Affected files or URLs

<!-- List the key files, pages, or URLs changed. -->

## Test plan

<!-- Checklist of what you have tested or verified. -->
- [x] Tests added or updated
- [ ] Documentation updated (if user-facing behavior changed)
- [x] `make lint` passes
- [x] `make format` passes (or no formatting changes needed)
- [x] Full test suite passes (`uv run pytest tests/ --no-cov`)

## Risk assessment

<!-- What could go wrong? How can it be reverted? -->

## Follow-up work intentionally left out

<!-- What is deliberately not included so the PR stays reviewable? -->
