### PR TITLE
Introduce kadet HelmCache and input based Helm cache

### DIFF
--- a/kapitan/cached.py
+++ b/kapitan/cached.py
@@ -38,6 +38,12 @@ inv_sources: set[str] = set()
 # Kadet caches
 kapitan_input_kadet = None
 
+# Helm cache: rendered manifests keyed on (chart_dir content, helm_values,
+# helm_params, helm_path). Lets HelmChart() callers skip the helm subprocess
+# even when their kadet cache misses (e.g. when an unrelated inventory key
+# changed but helm-relevant inputs did not).
+kapitan_input_helm = None
+
 # Shared cache metrics for the compile pool, keyed by input_type_name.
 # Populated by compile_targets() only when caching is enabled, then propagated
 # to workers via the pool initializer so every InputCache(input_type_name=N)

--- a/kapitan/dependency_manager/base.py
+++ b/kapitan/dependency_manager/base.py
@@ -353,6 +353,62 @@ def fetch_helm_archive(helm_path, repo, chart_name, version, save_path):
     )
 
 
+def helm_dependencies_digest(target_name: str) -> bytes | None:
+    """Stable digest over the on-disk helm charts declared as dependencies of ``target_name``.
+
+    Returns ``None`` when the target declares no helm dependencies — callers
+    should skip mixing into their cache key in that case, so non-helm users
+    keep their existing keys (mirrors :func:`kapitan.topics.consumed_topics_digest`).
+
+    Each helm dep's ``output_path`` is walked recursively via the same
+    ``walk_and_hash`` helper kadet uses for its component dir; the digest
+    therefore captures every chart-file change including subchart content
+    and ``Chart.yaml`` version bumps. ``cached.inv`` holds the model-dumped
+    inventory captured before ``fetch_dependencies`` normalized
+    ``output_path`` on the live pydantic objects, so the path is resolved
+    here the same way ``fetch_dependencies`` does.
+    """
+    # Local imports to avoid cycles: kapitan.inputs.cache → cache helpers,
+    # and kapitan.cached → runtime state. dependency_manager is imported
+    # eagerly at startup; deferring keeps that path lean.
+    from kapitan import cached
+    from kapitan.inputs.cache import InputCache, walk_and_hash
+    from kapitan.utils import normalise_join_path
+
+    try:
+        target_params = cached.inv[target_name]["parameters"]["kapitan"]
+    except (KeyError, TypeError):
+        return None
+
+    deps = target_params.get("dependencies") or []
+    helm_deps = [d for d in deps if d.get("type") == KapitanDependencyTypes.HELM]
+    if not helm_deps:
+        return None
+
+    helm_deps.sort(
+        key=lambda d: (
+            d.get("output_path", ""),
+            d.get("chart_name", ""),
+            d.get("version") or "",
+        )
+    )
+
+    base = getattr(cached.args, "output_path", ".") or "."
+    input_cache = getattr(cached, "kapitan_input_kadet", None)
+
+    h = InputCache.hash_object()
+    for dep in helm_deps:
+        rel_output_path = dep.get("output_path", "")
+        out_path = normalise_join_path(base, rel_output_path)
+        # Mix the declared path itself so a rename of the dep (with identical
+        # file content) still moves the digest.
+        h.update(rel_output_path.encode("utf-8"))
+        h.update(b"\x00")
+        walk_and_hash(Path(out_path), input_cache, h)
+        h.update(b"\x00")
+    return h.digest()
+
+
 def exists_in_cache(item_path):
     return os.path.exists(item_path)
 

--- a/kapitan/helm_cli.py
+++ b/kapitan/helm_cli.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import os
 import subprocess
@@ -5,6 +6,37 @@ from subprocess import DEVNULL, PIPE
 
 
 logger = logging.getLogger(__name__)
+
+
+@functools.cache
+def helm_version(helm_path: str | None = None) -> str:
+    """Return ``helm version --short`` output for cache-key purposes.
+
+    Resolves the binary the same way :func:`helm_cli` does (explicit
+    ``helm_path``, then ``KAPITAN_HELM_PATH`` env var, then ``"helm"`` via
+    PATH). Memoized per resolved binary so we incur at most one
+    ``helm version`` subprocess per distinct binary per worker process.
+
+    On failure (binary missing, timeout, non-zero exit), returns a sentinel
+    string derived from the path so callers that include it in a cache key
+    still differentiate user-supplied paths. The render itself will fail
+    loudly downstream if the binary is truly broken.
+    """
+    binary = helm_path or os.getenv("KAPITAN_HELM_PATH", "helm")
+    try:
+        res = subprocess.run(
+            [binary, "version", "--short"],
+            stdout=PIPE,
+            stderr=DEVNULL,
+            check=False,
+            timeout=10,
+        )
+        if res.returncode == 0:
+            return res.stdout.decode().strip()
+        logger.debug("helm version probe for %s returned %d", binary, res.returncode)
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        logger.debug("helm version probe failed for %s: %s", binary, e)
+    return f"unresolved:{binary}"
 
 
 def helm_cli(helm_path, args, stdout=None, verbose=False, timeout=None):

--- a/kapitan/inputs/__init__.py
+++ b/kapitan/inputs/__init__.py
@@ -14,7 +14,7 @@ from .base import InputType
 # compile_targets() pre-allocates one CacheMetrics per entry so all workers
 # share counters across the multiprocessing pool. Add an entry here when a
 # new input type adopts InputCache.
-CACHEABLE_INPUT_TYPES: tuple[str, ...] = ("kadet",)
+CACHEABLE_INPUT_TYPES: tuple[str, ...] = ("kadet", "helm")
 
 
 @functools.cache  # Use lru_cache for caching

--- a/kapitan/inputs/cache.py
+++ b/kapitan/inputs/cache.py
@@ -163,3 +163,47 @@ class InputCache:
                 pass
             else:
                 raise
+
+
+def walk_and_hash(path: Path, input_cache: InputCache | None, path_hash):
+    """
+    Recursively walk a path and update a hash object with the contents of all files.
+    This implementation is deterministic.
+
+    ``input_cache`` may be ``None`` or a falsy ``InputCache``; when truthy its
+    ``kv_cache`` dict is used to memoize per-file digests across calls so the
+    same file isn't re-read for every walk within a worker process.
+    """
+    if not path.exists() or str(path).endswith("__pycache__"):
+        return
+
+    if path.is_file():
+        if cached_hash_digest := get_path_hash_from_input_kv(path, input_cache):
+            path_hash.update(cached_hash_digest)
+            logger.debug(
+                "KV Memory hit for path: %s, digest: %s", path, path_hash.hexdigest()
+            )
+            return
+
+        with open(path, "rb") as fp:
+            file_hash = InputCache.hash_file_digest(fp)
+            digest = file_hash.digest()
+            set_path_hash_input_kv(path, digest, input_cache)
+            path_hash.update(digest)
+
+    elif path.is_dir():
+        for item in sorted(path.iterdir(), key=lambda p: p.name):
+            walk_and_hash(item, input_cache, path_hash)
+
+
+def get_path_hash_from_input_kv(path: Path, input_cache: InputCache | None):
+    try:
+        if input_cache:
+            return input_cache.kv_cache[str(path)]
+    except KeyError:
+        return None
+
+
+def set_path_hash_input_kv(path: Path, h_file, input_cache: InputCache | None):
+    if input_cache:
+        input_cache.kv_cache[str(path)] = h_file

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -5,15 +5,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 import tempfile
+from pathlib import Path
 
 import yaml
 
+from kapitan import cached
 from kapitan.errors import HelmTemplateError
-from kapitan.helm_cli import helm_cli
+from kapitan.helm_cli import helm_cli, helm_version
 from kapitan.inputs.base import InputType
+from kapitan.inputs.cache import InputCache, walk_and_hash
 from kapitan.inputs.kadet import BaseModel, BaseObj
 from kapitan.inventory.model.input_types import KapitanInputTypeHelmConfig
 
@@ -240,6 +244,45 @@ def write_helm_values_file(helm_values: dict):
     return helm_values_file
 
 
+def _helmchart_cache_obj():
+    """Return the helm InputCache when caching is enabled, else ``None``.
+
+    Lazy-initialised per worker process. Shares the multiprocessing
+    CacheMetrics counter pre-allocated by ``compile_targets`` so hits/misses
+    show up in the end-of-compile summary alongside kadet's.
+    """
+    if not getattr(cached.args, "cache", False):
+        return None
+    if cached.kapitan_input_helm is None:
+        metrics = (cached.input_cache_metrics or {}).get("helm")
+        cached.kapitan_input_helm = InputCache("helm", metrics=metrics)
+    return cached.kapitan_input_helm
+
+
+def _helmchart_cache_key(chart_dir, helm_values, helm_params, helm_path, cache_obj):
+    """Hash everything that determines ``helm template`` output for HelmChart().
+
+    The chart_dir contents are walked recursively, so file edits to templates,
+    Chart.yaml, values.yaml or subcharts all move the key. ``helm_values`` and
+    ``helm_params`` are JSON-serialised with sorted keys for determinism.
+    """
+    h = InputCache.hash_object()
+    h.update(b"chart\x00")
+    walk_and_hash(Path(chart_dir), cache_obj, h)
+    h.update(b"\x00values\x00")
+    h.update(json.dumps(helm_values, sort_keys=True, default=str).encode("utf-8"))
+    h.update(b"\x00params\x00")
+    h.update(json.dumps(helm_params, sort_keys=True, default=str).encode("utf-8"))
+    h.update(b"\x00helm_path\x00")
+    h.update(str(helm_path or "").encode("utf-8"))
+    # Mix in the actual binary's version so a helm upgrade (which can change
+    # CRD handling, manifest field order, schema validation) busts the cache
+    # even when ``helm_path`` itself is unchanged or None.
+    h.update(b"\x00helm_version\x00")
+    h.update(helm_version(helm_path).encode("utf-8"))
+    return h.hexdigest()
+
+
 class HelmChart(BaseModel):
     """
     Represents a Helm chart. Renders the chart and stores the rendered objects in self.root.
@@ -264,6 +307,23 @@ class HelmChart(BaseModel):
             ] = BaseObj.from_dict(obj)
 
     def load_chart(self):
+        # Cache layer is independent of kadet's: an unrelated inventory key
+        # change invalidates kadet but leaves this hit, so the helm subprocess
+        # is only re-run when (chart_dir + helm_values + helm_params +
+        # helm_path) actually changed.
+        cache_obj = _helmchart_cache_obj()
+        cache_key = None
+        if cache_obj:
+            cache_key = _helmchart_cache_key(
+                self.chart_dir,
+                self.helm_values,
+                self.helm_params,
+                self.helm_path,
+                cache_obj,
+            )
+            if (cached_docs := cache_obj.get(cache_key)) is not None:
+                return cached_docs
+
         helm_values_file = None
         if self.helm_values != {}:
             helm_values_file = write_helm_values_file(self.helm_values)
@@ -278,4 +338,7 @@ class HelmChart(BaseModel):
         if error_message:
             raise HelmTemplateError(error_message)
 
-        return [doc for doc in yaml.safe_load_all(output) if doc is not None]
+        docs = [doc for doc in yaml.safe_load_all(output) if doc is not None]
+        if cache_obj is not None:
+            cache_obj.set(cache_key, docs)
+        return docs

--- a/kapitan/inputs/kadet.py
+++ b/kapitan/inputs/kadet.py
@@ -20,9 +20,10 @@ from kadet import BaseModel, BaseObj, Dict
 
 from kapitan import cached
 from kapitan.defaults import KADET_COMPONENT_MODULE_PREFIX
+from kapitan.dependency_manager.base import helm_dependencies_digest
 from kapitan.errors import CompileError
 from kapitan.inputs.base import InputType
-from kapitan.inputs.cache import InputCache
+from kapitan.inputs.cache import InputCache, walk_and_hash
 from kapitan.inventory.model.input_types import KapitanInputTypeKadetConfig
 from kapitan.topics import consumed_topics_digest, current_target
 
@@ -152,6 +153,16 @@ class Kadet(InputType):
                 extra_inputs: list = []
                 if topics_digest := consumed_topics_digest(target_name):
                     extra_inputs.append(topics_digest)
+
+                # Mix in a digest of every helm chart this target declared
+                # under ``parameters.kapitan.dependencies``. Without this,
+                # editing files under a fetched chart_dir (which lives
+                # outside the kadet component path that walk_and_hash sees)
+                # would not invalidate the kadet cache, and HelmChart()
+                # callers would get stale renders. ``None`` for targets
+                # with no helm deps so non-helm users keep current keys.
+                if helm_deps_digest := helm_dependencies_digest(target_name):
+                    extra_inputs.append(helm_deps_digest)
 
                 inputs_hash = self.inputs_hash(
                     inventory_digest(current_target.get()),
@@ -301,48 +312,6 @@ class Kadet(InputType):
 
             return cached.kapitan_input_kadet
         return False
-
-
-def walk_and_hash(path: Path, input_cache: InputCache, path_hash):
-    """
-    Recursively walk a path and update a hash object with the contents of all files.
-    This implementation is deterministic.
-    """
-    if not path.exists() or str(path).endswith("__pycache__"):
-        return
-
-    if path.is_file():
-        if cached_hash_digest := get_path_hash_from_input_kv(path, input_cache):
-            path_hash.update(cached_hash_digest)
-            logger.debug(
-                "KV Memory hit for path: %s, digest: %s", path, path_hash.hexdigest()
-            )
-            return
-
-        with open(path, "rb") as fp:
-            file_hash = InputCache.hash_file_digest(fp)
-            digest = file_hash.digest()
-            set_path_hash_input_kv(path, digest, input_cache)
-            path_hash.update(digest)
-
-    elif path.is_dir():
-        for item in sorted(path.iterdir(), key=lambda p: p.name):
-            walk_and_hash(item, input_cache, path_hash)
-
-
-def get_path_hash_from_input_kv(path: Path, input_cache: InputCache):
-    try:
-        # TODO temp hack to avoid input_cache being False
-        if input_cache:
-            return input_cache.kv_cache[str(path)]
-    except KeyError:
-        return None
-
-
-def set_path_hash_input_kv(path: Path, h_file, input_cache: InputCache):
-    # TODO temp hack to avoid input_cache being False
-    if input_cache:
-        input_cache.kv_cache[str(path)] = h_file
 
 
 def _to_dict(obj):

--- a/tests/test_dependency_manager.py
+++ b/tests/test_dependency_manager.py
@@ -26,6 +26,7 @@ from kapitan.dependency_manager.base import (
     fetch_helm_chart,
     fetch_http_source,
     fetch_oci_dependency,
+    helm_dependencies_digest,
 )
 from kapitan.errors import HelmFetchingError, OCIFetchingError
 from kapitan.inventory.model import KapitanInventorySettings
@@ -667,3 +668,219 @@ class OciFetchDependencyTest(unittest.TestCase):
             self.assertIn("only subdirectories", warning_text)
             self.assertIn("subpath", warning_text)
             self.assertIn("system", warning_text)
+
+
+@pytest.mark.usefixtures("reset_cached_args")
+class HelmDependenciesDigestTest(unittest.TestCase):
+    """Cover the cache-key digest derived from ``parameters.kapitan.dependencies``.
+
+    The digest is what makes HelmChart() inside kadet cache-correct: chart files
+    live outside the kadet component path, so without this their edits do not
+    perturb the kadet cache key. See PR description for the full motivation.
+    """
+
+    def _set_inv(self, deps, target="t1"):
+        from kapitan import cached
+
+        cached.inv = {target: {"parameters": {"kapitan": {"dependencies": deps}}}}
+
+    def _set_output_base(self, base):
+        from argparse import Namespace
+
+        from kapitan import cached
+
+        cached.args = Namespace(output_path=base, cache=False)
+
+    def _write_chart(self, root: Path, name: str, body: str = "v1"):
+        chart_dir = root / name
+        (chart_dir / "templates").mkdir(parents=True, exist_ok=True)
+        (chart_dir / "Chart.yaml").write_text(f"name: {name}\nversion: 1.0.0\n")
+        (chart_dir / "templates" / "deploy.yaml").write_text(body)
+        return chart_dir
+
+    def test_returns_none_when_target_has_no_deps(self):
+        self._set_inv([])
+        self._set_output_base(".")
+        self.assertIsNone(helm_dependencies_digest("t1"))
+
+    def test_returns_none_when_only_non_helm_deps(self):
+        self._set_inv(
+            [
+                {
+                    "type": "git",
+                    "source": "https://example.com/repo.git",
+                    "output_path": "vendor/repo",
+                }
+            ]
+        )
+        self._set_output_base(".")
+        self.assertIsNone(helm_dependencies_digest("t1"))
+
+    def test_returns_none_when_target_missing(self):
+        self._set_inv([], target="other")
+        self._set_output_base(".")
+        self.assertIsNone(helm_dependencies_digest("missing"))
+
+    def test_digest_changes_when_chart_file_changes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            self._write_chart(tmp_path / "charts", "foo")
+            self._set_output_base(tmp)
+            self._set_inv(
+                [
+                    {
+                        "type": "helm",
+                        "source": "https://example.com",
+                        "output_path": "charts/foo",
+                        "chart_name": "foo",
+                        "version": "1.0.0",
+                    }
+                ]
+            )
+
+            before = helm_dependencies_digest("t1")
+            self.assertIsNotNone(before)
+
+            # Edit a template file under the declared chart_dir.
+            (tmp_path / "charts" / "foo" / "templates" / "deploy.yaml").write_text("v2")
+            after = helm_dependencies_digest("t1")
+
+            self.assertNotEqual(before, after)
+
+    def test_digest_stable_when_unrelated_files_change(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            self._write_chart(tmp_path / "charts", "foo")
+            # Sibling files outside the chart_dir must not influence the digest.
+            (tmp_path / "unrelated.yaml").write_text("a")
+            self._set_output_base(tmp)
+            self._set_inv(
+                [
+                    {
+                        "type": "helm",
+                        "source": "https://example.com",
+                        "output_path": "charts/foo",
+                        "chart_name": "foo",
+                        "version": "1.0.0",
+                    }
+                ]
+            )
+
+            before = helm_dependencies_digest("t1")
+            (tmp_path / "unrelated.yaml").write_text("b")
+            after = helm_dependencies_digest("t1")
+
+            self.assertEqual(before, after)
+
+    def test_digest_order_invariant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            self._write_chart(tmp_path / "charts", "foo")
+            self._write_chart(tmp_path / "charts", "bar")
+            self._set_output_base(tmp)
+
+            dep_foo = {
+                "type": "helm",
+                "source": "https://example.com",
+                "output_path": "charts/foo",
+                "chart_name": "foo",
+                "version": "1.0.0",
+            }
+            dep_bar = {
+                "type": "helm",
+                "source": "https://example.com",
+                "output_path": "charts/bar",
+                "chart_name": "bar",
+                "version": "1.0.0",
+            }
+
+            self._set_inv([dep_foo, dep_bar])
+            d1 = helm_dependencies_digest("t1")
+
+            self._set_inv([dep_bar, dep_foo])
+            d2 = helm_dependencies_digest("t1")
+
+            self.assertEqual(d1, d2)
+
+    def test_digest_ignores_non_helm_deps_alongside(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            self._write_chart(tmp_path / "charts", "foo")
+            self._set_output_base(tmp)
+
+            helm_dep = {
+                "type": "helm",
+                "source": "https://example.com",
+                "output_path": "charts/foo",
+                "chart_name": "foo",
+                "version": "1.0.0",
+            }
+            git_dep = {
+                "type": "git",
+                "source": "https://example.com/repo.git",
+                "output_path": "vendor/repo",
+            }
+
+            self._set_inv([helm_dep])
+            with_only_helm = helm_dependencies_digest("t1")
+
+            self._set_inv([helm_dep, git_dep])
+            with_extras = helm_dependencies_digest("t1")
+
+            self.assertEqual(with_only_helm, with_extras)
+
+    def test_digest_changes_when_output_path_renamed_same_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            self._write_chart(tmp_path / "charts", "foo")
+            self._write_chart(tmp_path / "charts", "foo-alias")
+            # foo-alias has the same files as foo because of identical _write_chart;
+            # only the declared output_path label differs.
+            self._set_output_base(tmp)
+
+            self._set_inv(
+                [
+                    {
+                        "type": "helm",
+                        "source": "https://example.com",
+                        "output_path": "charts/foo",
+                        "chart_name": "foo",
+                        "version": "1.0.0",
+                    }
+                ]
+            )
+            before = helm_dependencies_digest("t1")
+
+            self._set_inv(
+                [
+                    {
+                        "type": "helm",
+                        "source": "https://example.com",
+                        "output_path": "charts/foo-alias",
+                        "chart_name": "foo",
+                        "version": "1.0.0",
+                    }
+                ]
+            )
+            after = helm_dependencies_digest("t1")
+
+            self.assertNotEqual(before, after)
+
+    def test_walks_missing_path_gracefully(self):
+        # Path does not exist on disk yet (e.g. user ran --cache without --fetch).
+        # walk_and_hash silently returns; we still fold the declared output_path
+        # in, so the digest is deterministic.
+        self._set_inv(
+            [
+                {
+                    "type": "helm",
+                    "source": "https://example.com",
+                    "output_path": "charts/missing",
+                    "chart_name": "missing",
+                    "version": "1.0.0",
+                }
+            ]
+        )
+        self._set_output_base("/nonexistent-base")
+        digest = helm_dependencies_digest("t1")
+        self.assertIsNotNone(digest)

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -381,3 +381,254 @@ class HelmInputTest(unittest.TestCase):
     def tearDown(self):
         os.chdir(TEST_PWD)
         reset_cache()
+
+
+class HelmVersionTest(unittest.TestCase):
+    """Cover the ``helm version`` probe that backs cache-key version mixing."""
+
+    def setUp(self):
+        from kapitan.helm_cli import helm_version
+
+        helm_version.cache_clear()
+
+    def tearDown(self):
+        from kapitan.helm_cli import helm_version
+
+        helm_version.cache_clear()
+
+    def test_returns_unresolved_sentinel_for_missing_binary(self):
+        from kapitan.helm_cli import helm_version
+
+        result = helm_version("/nonexistent/helm-binary-12345")
+        self.assertTrue(result.startswith("unresolved:"))
+        self.assertIn("helm-binary-12345", result)
+
+    def test_memoizes_per_resolved_binary(self):
+        from unittest.mock import patch
+
+        from kapitan.helm_cli import helm_version
+
+        with patch("kapitan.helm_cli.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = b"v3.19.5+g4a19a5b\n"
+
+            helm_version("/path/to/helm-a")
+            helm_version("/path/to/helm-a")  # cached
+            helm_version("/path/to/helm-b")  # distinct path → new call
+
+            self.assertEqual(mock_run.call_count, 2)
+
+    def test_helm_version_returns_real_version(self):
+        """When the real helm binary is on PATH, return its actual version string."""
+        from shutil import which
+
+        from kapitan.helm_cli import helm_version
+
+        if not which("helm"):
+            self.skipTest("helm not on PATH")
+
+        result = helm_version()
+        # helm version --short emits like "v3.19.5+g4a19a5b"
+        self.assertTrue(result.startswith("v"))
+        self.assertFalse(result.startswith("unresolved:"))
+
+
+@pytest.mark.usefixtures("reset_cached_args")
+class HelmChartCacheTest(unittest.TestCase):
+    """HelmChart() must short-circuit the helm subprocess when its actual
+    inputs (chart_dir, helm_values, helm_params, helm_path) are unchanged —
+    even if the surrounding kadet cache missed because of an unrelated
+    inventory edit.
+    """
+
+    def _make_chart_dir(self, root, version="1.0.0", template_body="kind: Deployment"):
+        chart_dir = root / "charts" / "demo"
+        (chart_dir / "templates").mkdir(parents=True, exist_ok=True)
+        (chart_dir / "Chart.yaml").write_text(
+            f"apiVersion: v2\nname: demo\nversion: {version}\n"
+        )
+        (chart_dir / "templates" / "deploy.yaml").write_text(template_body)
+        return chart_dir
+
+    def _enable_cache(self):
+        from argparse import Namespace
+
+        from kapitan import cached
+
+        cached.args = Namespace(cache=True)
+        cached.kapitan_input_helm = None  # force re-init under XDG_CACHE_HOME
+
+    def test_cache_hit_skips_render(self):
+        """Second HelmChart() with identical inputs must NOT shell out to helm."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self._make_chart_dir(Path(tmp))
+            os.environ["XDG_CACHE_HOME"] = tmp  # isolate the on-disk cache
+            self._enable_cache()
+
+            chart_dir = str(Path(tmp) / "charts" / "demo")
+            docs = [
+                {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "x"}}
+            ]
+
+            with (
+                patch(
+                    "kapitan.inputs.helm.render_chart", return_value=("", "")
+                ) as mock_render,
+                patch(
+                    "kapitan.inputs.helm.yaml.safe_load_all",
+                    side_effect=lambda *_a, **_kw: iter(docs),
+                ),
+            ):
+                HelmChart(chart_dir=chart_dir)  # new() calls load_chart()
+                self.assertEqual(mock_render.call_count, 1)
+
+            # Second instantiation with the same inputs must hit the cache.
+            with patch("kapitan.inputs.helm.render_chart") as mock_render_second:
+                second = HelmChart(chart_dir=chart_dir)
+                mock_render_second.assert_not_called()
+                # And the cached docs reach .root via new().
+                self.assertTrue(len(second.root) > 0)
+
+    def test_different_helm_values_force_re_render(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self._make_chart_dir(Path(tmp))
+            os.environ["XDG_CACHE_HOME"] = tmp
+            self._enable_cache()
+
+            chart_dir = str(Path(tmp) / "charts" / "demo")
+            docs = [
+                {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "x"}}
+            ]
+
+            with (
+                patch(
+                    "kapitan.inputs.helm.render_chart", return_value=("", "")
+                ) as mock_render,
+                patch(
+                    "kapitan.inputs.helm.yaml.safe_load_all",
+                    side_effect=lambda *_a, **_kw: iter(docs),
+                ),
+            ):
+                HelmChart(chart_dir=chart_dir, helm_values={"a": 1})
+                HelmChart(chart_dir=chart_dir, helm_values={"a": 2})
+                # Different helm_values → distinct cache keys → render runs twice.
+                self.assertEqual(mock_render.call_count, 2)
+
+                # Reusing the first values now hits the cache.
+                HelmChart(chart_dir=chart_dir, helm_values={"a": 1})
+                self.assertEqual(mock_render.call_count, 2)
+
+    def test_chart_file_edit_invalidates_cache(self):
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            chart_dir = self._make_chart_dir(Path(tmp))
+            os.environ["XDG_CACHE_HOME"] = tmp
+            self._enable_cache()
+
+            docs = [
+                {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "x"}}
+            ]
+
+            with (
+                patch(
+                    "kapitan.inputs.helm.render_chart", return_value=("", "")
+                ) as mock_render,
+                patch(
+                    "kapitan.inputs.helm.yaml.safe_load_all",
+                    side_effect=lambda *_a, **_kw: iter(docs),
+                ),
+            ):
+                HelmChart(chart_dir=str(chart_dir))
+                self.assertEqual(mock_render.call_count, 1)
+
+                # Edit a template file under the chart_dir.
+                (chart_dir / "templates" / "deploy.yaml").write_text("kind: Service\n")
+                # Bust the per-process kv memo so the new file digest is read fresh.
+                from kapitan import cached as _cached
+
+                _cached.kapitan_input_helm.kv_cache.clear()
+
+                HelmChart(chart_dir=str(chart_dir))
+                self.assertEqual(mock_render.call_count, 2)
+
+    def test_helm_version_change_invalidates_cache(self):
+        """Same chart_dir + helm_values + helm_params but a new helm binary
+        version must bust the cache (e.g. user ran `brew upgrade helm`)."""
+        from pathlib import Path
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            chart_dir = self._make_chart_dir(Path(tmp))
+            os.environ["XDG_CACHE_HOME"] = tmp
+            self._enable_cache()
+
+            docs = [
+                {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "x"}}
+            ]
+
+            with (
+                patch(
+                    "kapitan.inputs.helm.render_chart", return_value=("", "")
+                ) as mock_render,
+                patch(
+                    "kapitan.inputs.helm.yaml.safe_load_all",
+                    side_effect=lambda *_a, **_kw: iter(docs),
+                ),
+                patch("kapitan.inputs.helm.helm_version", return_value="v3.18.0+gabc"),
+            ):
+                HelmChart(chart_dir=str(chart_dir))
+                self.assertEqual(mock_render.call_count, 1)
+
+            # Simulate a helm upgrade: same path/inputs, different version output.
+            with (
+                patch(
+                    "kapitan.inputs.helm.render_chart", return_value=("", "")
+                ) as mock_render_v2,
+                patch(
+                    "kapitan.inputs.helm.yaml.safe_load_all",
+                    side_effect=lambda *_a, **_kw: iter(docs),
+                ),
+                patch("kapitan.inputs.helm.helm_version", return_value="v3.19.5+gdef"),
+            ):
+                HelmChart(chart_dir=str(chart_dir))
+                self.assertEqual(mock_render_v2.call_count, 1)
+
+    def test_cache_disabled_always_renders(self):
+        """When ``cached.args.cache`` is falsy, the cache layer must be skipped
+        entirely so behaviour is identical to pre-cache versions."""
+        from argparse import Namespace
+        from pathlib import Path
+        from unittest.mock import patch
+
+        from kapitan import cached as _cached
+
+        with tempfile.TemporaryDirectory() as tmp:
+            chart_dir = self._make_chart_dir(Path(tmp))
+            _cached.args = Namespace(cache=False)
+            _cached.kapitan_input_helm = None
+
+            docs = [
+                {"apiVersion": "v1", "kind": "ConfigMap", "metadata": {"name": "x"}}
+            ]
+
+            with (
+                patch(
+                    "kapitan.inputs.helm.render_chart", return_value=("", "")
+                ) as mock_render,
+                patch(
+                    "kapitan.inputs.helm.yaml.safe_load_all",
+                    side_effect=lambda *_a, **_kw: iter(docs),
+                ),
+            ):
+                HelmChart(chart_dir=str(chart_dir))
+                HelmChart(chart_dir=str(chart_dir))
+                self.assertEqual(mock_render.call_count, 2)
+                self.assertIsNone(_cached.kapitan_input_helm)

--- a/tests/test_kadet.py
+++ b/tests/test_kadet.py
@@ -285,3 +285,74 @@ class KadetCacheKeyTest(unittest.TestCase):
             compiler.compile_file(config, "component", "compiled/test-target")
 
         self.assertEqual(dict(config.input_params), original_params)
+
+    def test_helm_deps_digest_mixed_into_cache_key(self):
+        """When a target declares helm dependencies, the resulting digest must
+        be passed into inputs_hash so that chart edits invalidate the kadet
+        cache."""
+        compiler = self._make_compiler()
+
+        config = KapitanInputTypeKadetConfig(
+            input_paths=["component"],
+            output_path=".",
+            input_params={},
+        )
+
+        cache_obj = mock.Mock()
+        cache_obj.get.return_value = {"output.yml": {"k": "v"}}
+
+        with (
+            mock.patch.object(compiler, "cacheable", return_value=cache_obj),
+            mock.patch.object(
+                compiler, "inputs_hash", return_value="hash"
+            ) as mock_hash,
+            mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inv"),
+            mock.patch(
+                "kapitan.inputs.kadet.helm_dependencies_digest",
+                return_value=b"helm-deps-digest",
+            ),
+            mock.patch(
+                "kapitan.inputs.kadet.consumed_topics_digest", return_value=None
+            ),
+            mock.patch.object(compiler, "to_file"),
+        ):
+            compiler.compile_file(config, "component", "compiled/test-target")
+
+        args = mock_hash.call_args.args
+        self.assertIn(b"helm-deps-digest", args)
+
+    def test_no_helm_deps_means_no_extra_input(self):
+        """Targets without helm deps must keep their pre-existing cache key shape."""
+        compiler = self._make_compiler()
+
+        config = KapitanInputTypeKadetConfig(
+            input_paths=["component"],
+            output_path=".",
+            input_params={},
+        )
+
+        cache_obj = mock.Mock()
+        cache_obj.get.return_value = {"output.yml": {"k": "v"}}
+
+        with (
+            mock.patch.object(compiler, "cacheable", return_value=cache_obj),
+            mock.patch.object(
+                compiler, "inputs_hash", return_value="hash"
+            ) as mock_hash,
+            mock.patch("kapitan.inputs.kadet.inventory_digest", return_value=b"inv"),
+            mock.patch(
+                "kapitan.inputs.kadet.helm_dependencies_digest", return_value=None
+            ),
+            mock.patch(
+                "kapitan.inputs.kadet.consumed_topics_digest", return_value=None
+            ),
+            mock.patch.object(compiler, "to_file"),
+        ):
+            compiler.compile_file(config, "component", "compiled/test-target")
+
+        mock_hash.assert_called_once_with(
+            b"inv",
+            "test-target",
+            Path("component"),
+            {},
+        )


### PR DESCRIPTION
## Summary

Fixes #1588 
Adds two cache layers around HelmChart and mixes the helm binary version into the key so chart-file edits, helm upgrades, and (most importantly) unrelated inventory edits no longer waste helm template invocations or risk stale output.

- Mix helm-dep digests into the kadet cache key. When a target declares helm dependencies under parameters.kapitan.dependencies, kadet's inputs_hash now folds in a digest over the contents of each declared output_path. Chart-file edits now invalidate the kadet cache. 
- Pattern mirrors consumed_topics_digest: returns None for targets without helm deps, so non-helm users keep their existing cache keys.
- Add a second cache inside HelmChart.load_chart(). Independent of kadet's. Keyed only on helm-relevant inputs: walk_and_hash(chart_dir) + helm_values + helm_params + helm_path + helm_version. When kadet misses on an unrelated inventory edit, kadet re-runs the component, but HelmChart now finds the rendered manifests in this second cache and skips the helm template subprocess. Uses the same InputCache machinery as kadet; "helm" is registered in CACHEABLE_INPUT_TYPES so hits/misses appear in the end-of-compile metrics summary.
- Bind the cache key to the actual helm binary. New helm_version(helm_path) in helm_cli.py runs `helm version --short`, @functools.cache-memoized per resolved path. Mixed into the HelmChart key so a binary upgrade busts the cache. On failure returns unresolved:<path> so user-supplied paths still differentiate and the actual render fails loudly downstream.

## Test plan

All added in this PR:

- tests/test_dependency_manager.py::HelmDependenciesDigestTest — 9 cases: returns None for no deps / only non-helm deps / missing target; digest changes on chart file edit; stable when unrelated files change; order-invariant across declaration order; non-helm deps don't perturb it; output_path rename moves it; graceful handling when the chart dir doesn't exist yet.
- tests/test_kadet.py — 2 new cases: digest is passed into inputs_hash when present; call signature unchanged when both digests return None.
- tests/test_helm_input.py::HelmVersionTest — 3 cases: unresolved: sentinel for missing binary; memoization per resolved path; real binary version when helm is on PATH.
- tests/test_helm_input.py::HelmChartCacheTest — 5 cases: cache hit skips render; different helm_values force re-render; chart file edit invalidates cache; helm binary version change invalidates cache; cache disabled is a no-op.

<!-- Checklist of what you have tested or verified. -->
- [x] Tests added or updated
- [ ] Documentation updated (if user-facing behavior changed)
- [x] `make lint` passes
- [x] `make format` passes (or no formatting changes needed)
- [x] Full test suite passes (`uv run pytest tests/ --no-cov`)

## Risk assessment

<!-- What could go wrong? How can it be reverted? -->

## Follow-up work intentionally left out

<!-- What is deliberately not included so the PR stays reviewable? -->
