### PR TITLE
fix: fix context for CI action test build publish

### DIFF
--- a/.github/workflows/test-build-publish.yml
+++ b/.github/workflows/test-build-publish.yml
@@ -282,6 +282,10 @@ jobs:
         if: needs.check-changes.outputs.has-code-changes == 'true'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
+          # Use the local checkout rather than the default Git context: a PR's
+          # refs/pull/<n>/merge ref is deleted once the PR is merged, which can
+          # race with an in-flight build and cause buildx to fail resolving it.
+          context: .
           platforms: ${{ matrix.platform.platform }}
           push: false
           load: true
@@ -356,6 +360,7 @@ jobs:
         if: needs.check-changes.outputs.has-code-changes == 'true' && env.DOCKERHUB_USERNAME != '' && github.event_name != 'pull_request'
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
+          context: .
           platforms: ${{ matrix.platform.platform }}
           push: true
           tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
## Summary

The docker/build-push-action step at .github/workflows/test-build-publish.yml:281 doesn't set a context:, so it defaults to the Git context — a URL like https://github.com/kapicorp/kapitan.git#refs/pull/1574/merge. Buildx then re-fetches that ref instead of using the local checkout.

Fix: point the action at the local checkout by adding context: . to both docker/build-push-action steps (the "Build Kapitan image" step at line 281 and the "Push image to DockerHub" step at line 353). That way the build uses the files actions/checkout already put on disk and no longer depends on the PR merge ref staying alive.

Fixes #

## Motivation

<!-- Why is this change needed? What problem does it solve? -->

## Affected files or URLs

<!-- List the key files, pages, or URLs changed. -->

## Test plan

<!-- Checklist of what you have tested or verified. -->
- [ ] Tests added or updated
- [ ] Documentation updated (if user-facing behavior changed)
- [ ] `make lint` passes
- [ ] `make format` passes (or no formatting changes needed)
- [ ] Full test suite passes (`uv run pytest tests/ --no-cov`)

## Risk assessment

<!-- What could go wrong? How can it be reverted? -->

## Follow-up work intentionally left out

<!-- What is deliberately not included so the PR stays reviewable? -->
