### PR TITLE
fix: add kustomize binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN uv pip install .[gojsonnet,omegaconf,reclass-rs,rapidyaml]
 ARG PYTHON_VERSION=3.11
 FROM golang:1 AS go-builder
 RUN GOBIN=$(pwd)/ go install cuelang.org/go/cmd/cue@latest
+RUN GOBIN=$(pwd)/ go install sigs.k8s.io/kustomize/kustomize/v5@latest
 
 # Final image with virtualenv built in previous step
 FROM ghcr.io/astral-sh/uv:python${PYTHON_VERSION}-trixie-slim
@@ -88,6 +89,7 @@ RUN apt-get update \
 RUN useradd --create-home --no-log-init --user-group kapitan
 
 COPY --from=go-builder /go/cue /usr/bin/cue
+COPY --from=go-builder /go/kustomize /usr/bin/kustomize
 COPY --from=python-builder ${VIRTUAL_ENV} ${VIRTUAL_ENV}
 
 USER kapitan


### PR DESCRIPTION
## Summary

Adds the `kustomize` binary to the Docker image so the existing `kustomize` input type actually works at runtime.

## Motivation

Kapitan already ships a `kustomize` input type (`kapitan/inputs/kustomize.py`), but the Dockerfile only installed the `cue` binary in the go-builder stage. Any use of the `kustomize` input type inside the container would fail because the `kustomize` executable was missing from the final image.

## Affected files or URLs

- `Dockerfile` — install `sigs.k8s.io/kustomize/kustomize/v5` in the `go-builder` stage and copy the resulting binary to `/usr/bin/kustomize` in the final image.

## Test plan

- [X] `make lint` passes
- [X] `make format` passes (or no formatting changes needed)
- [X] Full test suite passes (`uv run pytest tests/ --no-cov`)

## Risk assessment

Low risk — purely additive change to the Docker build (one extra `go install` and one extra `COPY`). Does not modify any existing binaries, Python code, or behavior. If it causes issues (e.g. build time, image size), it can be reverted by removing the two added lines.
