### PR TITLE
fix(yaml): quote leading-zero numeric strings in compiled output (#1595)

### DIFF
--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -20,7 +20,7 @@ from kapitan.inputs.base import InputType
 from kapitan.inputs.cache import InputCache, walk_and_hash
 from kapitan.inputs.kadet import BaseModel, BaseObj
 from kapitan.inventory.model.input_types import KapitanInputTypeHelmConfig
-from kapitan.utils import is_leading_zero_int_string
+from kapitan.utils import leading_zero_str_representer
 
 
 logger = logging.getLogger(__name__)
@@ -214,17 +214,6 @@ def render_chart(
         return ("", error_message)
 
 
-def _helm_str_representer(dumper, data):
-    """Quote leading-zero digit strings so Helm's Go YAML parser keeps them as
-    strings. ``is_leading_zero_int_string`` guards the compiled-manifest
-    serializer too, so the value stays quoted end to end.
-
-    See https://github.com/kapicorp/kapitan/issues/1370 and #1595.
-    """
-    style = "'" if is_leading_zero_int_string(data) else None
-    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
-
-
 def write_helm_values_file(helm_values: dict):
     """Dump helm values into a temporary YAML file.
 
@@ -237,7 +226,9 @@ def write_helm_values_file(helm_values: dict):
     _, helm_values_file = tempfile.mkstemp(".helm_values.yml", text=True)
     with open(helm_values_file, "w") as fp:
         dumper = yaml.SafeDumper
-        dumper.add_representer(str, _helm_str_representer)
+        # Quote leading-zero digit strings so Helm's Go YAML parser keeps them
+        # as strings (#1370/#1595); shared with the compiled-output serializer.
+        dumper.add_representer(str, leading_zero_str_representer)
         yaml.dump(helm_values, fp, Dumper=dumper)
 
     return helm_values_file

--- a/kapitan/inputs/helm.py
+++ b/kapitan/inputs/helm.py
@@ -20,6 +20,7 @@ from kapitan.inputs.base import InputType
 from kapitan.inputs.cache import InputCache, walk_and_hash
 from kapitan.inputs.kadet import BaseModel, BaseObj
 from kapitan.inventory.model.input_types import KapitanInputTypeHelmConfig
+from kapitan.utils import is_leading_zero_int_string
 
 
 logger = logging.getLogger(__name__)
@@ -214,15 +215,13 @@ def render_chart(
 
 
 def _helm_str_representer(dumper, data):
-    """Quote strings that could be misinterpreted by Helm's Go YAML parser.
+    """Quote leading-zero digit strings so Helm's Go YAML parser keeps them as
+    strings. ``is_leading_zero_int_string`` guards the compiled-manifest
+    serializer too, so the value stays quoted end to end.
 
-    Fixes https://github.com/kapicorp/kapitan/issues/1370 where strings like
-    "03190301" are converted to scientific notation (3.190301e+06).
+    See https://github.com/kapicorp/kapitan/issues/1370 and #1595.
     """
-    style = None
-    # Quote digit-only strings starting with 0 or large numeric strings
-    if data and len(data) > 1 and data.isdigit() and (data[0] == "0" or len(data) > 6):
-        style = "'"
+    style = "'" if is_leading_zero_int_string(data) else None
     return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
 
 

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -181,6 +181,19 @@ def prune_empty(d):
 _SUPPORTED_MULTILINE_STYLES = {"literal": "|", "folded": ">", "double-quotes": '"'}
 
 
+def is_leading_zero_int_string(data: str) -> bool:
+    """True if ``data`` is a leading-zero digit string like ``"03190301"``.
+
+    PyYAML emits these unquoted (YAML 1.1 rejects them as octal), but Helm and
+    Kubernetes (Go/YAML 1.2) read them as ints and drop the leading zero, so
+    callers force-quote them. Other int-looking strings are already quoted by
+    PyYAML's emitter and by ``_str_is_ambiguous``.
+
+    See https://github.com/kapicorp/kapitan/issues/1595 (follows #1370/#1372).
+    """
+    return len(data) > 1 and data[0] == "0" and data.isdigit()
+
+
 class PrettyDumper(yaml.SafeDumper):
     """
     Increases indent of nested lists.
@@ -210,18 +223,14 @@ class PrettyDumper(yaml.SafeDumper):
         # This avoids the per-call ``functools.partial`` allocation and the
         # ``dict.get`` lookup that the previous implementation did inside
         # ``multiline_str_presenter`` for every string node.
-        if style_char is None:
-
-            def _str_presenter(dumper, data):
-                return dumper.represent_scalar("tag:yaml.org,2002:str", data)
-        else:
-
-            def _str_presenter(dumper, data, _style=style_char):
-                if "\n" in data:
-                    return dumper.represent_scalar(
-                        "tag:yaml.org,2002:str", data, style=_style
-                    )
-                return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+        def _str_presenter(dumper, data, _style=style_char):
+            if _style is not None and "\n" in data:
+                style = _style
+            elif is_leading_zero_int_string(data):
+                style = "'"
+            else:
+                style = None
+            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
 
         dumper_cls = type(
             f"PrettyDumper_{style_selection or 'default'}",

--- a/kapitan/utils.py
+++ b/kapitan/utils.py
@@ -194,6 +194,19 @@ def is_leading_zero_int_string(data: str) -> bool:
     return len(data) > 1 and data[0] == "0" and data.isdigit()
 
 
+def leading_zero_str_representer(dumper, data):
+    """Force-quote leading-zero digit strings (#1595); emit other strings plainly.
+
+    Single source of truth for the quoting rule, shared by the base
+    ``PrettyDumper``, its ``get_dumper_for_style`` subclasses, and helm's
+    values-file dumper. Bare-``PrettyDumper`` call sites (``refs reveal`` via
+    ``_reveal_file``, ``kapitan inventory``) would otherwise re-emit
+    ``"03190301"`` unquoted and reintroduce the error.
+    """
+    style = "'" if is_leading_zero_int_string(data) else None
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+
+
 class PrettyDumper(yaml.SafeDumper):
     """
     Increases indent of nested lists.
@@ -224,13 +237,13 @@ class PrettyDumper(yaml.SafeDumper):
         # ``dict.get`` lookup that the previous implementation did inside
         # ``multiline_str_presenter`` for every string node.
         def _str_presenter(dumper, data, _style=style_char):
+            # Force the configured multiline style; defer every other string
+            # (including the leading-zero case) to the shared representer.
             if _style is not None and "\n" in data:
-                style = _style
-            elif is_leading_zero_int_string(data):
-                style = "'"
-            else:
-                style = None
-            return dumper.represent_scalar("tag:yaml.org,2002:str", data, style=style)
+                return dumper.represent_scalar(
+                    "tag:yaml.org,2002:str", data, style=_style
+                )
+            return leading_zero_str_representer(dumper, data)
 
         dumper_cls = type(
             f"PrettyDumper_{style_selection or 'default'}",
@@ -267,6 +280,7 @@ def null_presenter(dumper, data):
 
 
 PrettyDumper.add_representer(type(None), null_presenter)
+PrettyDumper.add_representer(str, leading_zero_str_representer)
 
 
 def flatten_dict(d, parent_key="", sep="."):

--- a/kapitan/yaml_ryml.py
+++ b/kapitan/yaml_ryml.py
@@ -51,6 +51,8 @@ except ImportError:  # pragma: no cover - the optional dep is missing
 
 from yaml.resolver import Resolver as _PyYAMLResolver
 
+from kapitan.utils import is_leading_zero_int_string
+
 
 logger = logging.getLogger(__name__)
 
@@ -147,10 +149,12 @@ def _scalar_for_ryml(
     if isinstance(value, str):
         if "\n" in value:
             return value, multiline_flag
-        if _str_is_ambiguous(value):
+        if _str_is_ambiguous(value) or is_leading_zero_int_string(value):
             # Single-quotes are the cheapest safe quoting for plain strings
             # with no embedded special characters; ryml will pick double
-            # quotes itself if escaping is required.
+            # quotes itself if escaping is required. ``is_leading_zero_int_string``
+            # covers leading-zero digit strings PyYAML's resolver misses but a
+            # Go/YAML-1.2 parser (Helm, Kubernetes) would read as a number.
             return value, ryml.VAL_SQUO  # type: ignore[union-attr]
         # Let ryml decide (plain unless it needs quotes for chars like leading
         # whitespace, leading '-', embedded ': ', etc.).
@@ -173,7 +177,7 @@ def _key_for_ryml(key: Any) -> tuple[str, int]:
     if isinstance(key, float):
         return repr(key), ryml.KEY_PLAIN  # type: ignore[union-attr]
     if isinstance(key, str):
-        if _str_is_ambiguous(key) or "\n" in key:
+        if _str_is_ambiguous(key) or is_leading_zero_int_string(key) or "\n" in key:
             return key, ryml.KEY_SQUO  # type: ignore[union-attr]
         return key, 0
     return str(key), ryml.KEY_SQUO  # type: ignore[union-attr]

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -327,21 +327,21 @@ class HelmInputTest(unittest.TestCase):
         apply``. Assert on raw text: ``yaml.safe_load`` reads "03190301" as a
         string whether or not it is quoted, so it cannot detect the defect.
         """
-        temp = tempfile.mkdtemp()
-        kapitan("compile", "--output-path", temp, "-t", "helm-string-values")
+        with tempfile.TemporaryDirectory() as temp:
+            kapitan("compile", "--output-path", temp, "-t", "helm-string-values")
 
-        deployment_file = os.path.join(
-            temp,
-            "compiled",
-            "helm-string-values",
-            "string-values-test",
-            "templates",
-            "deployment.yaml",
-        )
-        self.assertTrue(os.path.isfile(deployment_file))
+            deployment_file = os.path.join(
+                temp,
+                "compiled",
+                "helm-string-values",
+                "string-values-test",
+                "templates",
+                "deployment.yaml",
+            )
+            self.assertTrue(os.path.isfile(deployment_file))
 
-        with open(deployment_file) as fp:
-            content = fp.read()
+            with open(deployment_file) as fp:
+                content = fp.read()
 
         # The env value is a string-typed field: it must be emitted quoted so
         # kubectl/the API server does not parse it as an integer (which also
@@ -373,6 +373,7 @@ class HelmInputTest(unittest.TestCase):
             "leading_zero": "03190301",  # Leading zero string - causes the bug
             "octal_like": "0755",  # Octal-looking string
             "all_zeros": "00000000",  # All zeros string
+            "plain_int_string": "1234567",  # Int-looking, no leading zero
             "normal_string": "hello",  # Normal string for comparison
             "actual_number": 12345,  # Actual number
         }
@@ -383,15 +384,18 @@ class HelmInputTest(unittest.TestCase):
         with open(values_file) as fp:
             content = fp.read()
 
-        # The key check: verify that numeric-looking strings are QUOTED in the YAML output
-        # This is what matters for Helm's Go YAML parser
-
-        # Check that leading_zero string is quoted (single or double quotes)
-        self.assertTrue(
-            "'03190301'" in content or '"03190301"' in content,
-            f"Leading zero string '03190301' should be quoted in YAML output to prevent "
-            f"Helm (Go YAML) from parsing it as an integer. Current YAML content:\n{content}",
-        )
+        # Numeric-looking strings must be QUOTED so Helm's Go YAML parser keeps
+        # them as strings. "03190301" is quoted by our representer; "1234567"
+        # (no leading zero) is quoted by PyYAML's emitter on its own -- pinning
+        # it guards the intentionally-dropped len>6 branch against a dumper
+        # setup change.
+        for value in ("03190301", "1234567"):
+            with self.subTest(value=value):
+                self.assertTrue(
+                    f"'{value}'" in content or f'"{value}"' in content,
+                    f"'{value}' should be quoted so Helm (Go YAML) does not parse "
+                    f"it as an integer. Current YAML content:\n{content}",
+                )
 
     def test_safe_load_all_filters_none_docs(self):
         """Empty YAML documents (None) from multi-doc streams should be filtered out.

--- a/tests/test_helm_input.py
+++ b/tests/test_helm_input.py
@@ -318,6 +318,41 @@ class HelmInputTest(unittest.TestCase):
                 "This indicates the string was converted to a number and displayed in scientific notation.",
             )
 
+    def test_numeric_string_quoted_in_compiled_output(self):
+        """Numeric strings must stay quoted in the compiled manifest (#1595).
+
+        The #1372 fix quoted only helm's values file, not the output serializer,
+        so it re-emitted "03190301" unquoted. A Deployment ``env[].value`` is
+        string-typed with no coercion, so an unquoted value fails ``kubectl
+        apply``. Assert on raw text: ``yaml.safe_load`` reads "03190301" as a
+        string whether or not it is quoted, so it cannot detect the defect.
+        """
+        temp = tempfile.mkdtemp()
+        kapitan("compile", "--output-path", temp, "-t", "helm-string-values")
+
+        deployment_file = os.path.join(
+            temp,
+            "compiled",
+            "helm-string-values",
+            "string-values-test",
+            "templates",
+            "deployment.yaml",
+        )
+        self.assertTrue(os.path.isfile(deployment_file))
+
+        with open(deployment_file) as fp:
+            content = fp.read()
+
+        # The env value is a string-typed field: it must be emitted quoted so
+        # kubectl/the API server does not parse it as an integer (which also
+        # drops the leading zero: 03190301 -> 3190301).
+        self.assertTrue(
+            "'03190301'" in content or '"03190301"' in content,
+            "Numeric string '03190301' must be quoted in the compiled manifest so "
+            "it stays a string on string-typed fields (e.g. Deployment env value). "
+            f"Compiled deployment:\n{content}",
+        )
+
     def test_write_helm_values_file_preserves_numeric_strings(self):
         """
         Unit test for write_helm_values_file to verify that numeric-looking strings

--- a/tests/test_resources/charts/string-values-test/templates/deployment.yaml
+++ b/tests/test_resources/charts/string-values-test/templates/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-deploy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: app
+          image: busybox
+          env:
+            - name: NUMERIC_STRING
+              value: {{ .Values.numeric_string | quote }}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ from kapitan.utils import (
     flatten_dict,
     force_copy_file,
     get_entropy,
+    is_leading_zero_int_string,
     prune_empty,
     sha256_string,
 )
@@ -488,3 +489,19 @@ class CompareVersionsTest(unittest.TestCase):
 
     def test_compare_versions_major_diff(self):
         self.assertEqual(compare_versions("2.0.0", "1.9.9"), "greater")
+
+
+class IsLeadingZeroIntStringTest(unittest.TestCase):
+    """is_leading_zero_int_string flags leading-zero digit strings a Go/YAML 1.2
+    parser (Helm, Kubernetes) would re-read as a number (#1370, #1595)."""
+
+    def test_flags_leading_zero_digit_strings(self):
+        self.assertTrue(is_leading_zero_int_string("03190301"))
+
+    def test_does_not_flag_other_strings(self):
+        # One case per guard: no leading zero (other int-looking strings are
+        # PyYAML's job, not this predicate's), non-digit, single char (len > 1
+        # guard), empty.
+        for value in ("1234567", "12a", "0", ""):
+            with self.subTest(value=value):
+                self.assertFalse(is_leading_zero_int_string(value))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import yaml
 
 from kapitan.utils import (
+    PrettyDumper,
     SafeCopyError,
     YamlLoader,
     available_cpu_count,
@@ -505,3 +506,16 @@ class IsLeadingZeroIntStringTest(unittest.TestCase):
         for value in ("1234567", "12a", "0", ""):
             with self.subTest(value=value):
                 self.assertFalse(is_leading_zero_int_string(value))
+
+
+class PrettyDumperLeadingZeroTest(unittest.TestCase):
+    """The bare PrettyDumper must quote leading-zero strings so ``refs reveal``
+    (_reveal_file) and ``kapitan inventory``, which dump with the base class
+    rather than a get_dumper_for_style subclass, don't reintroduce #1595."""
+
+    def test_bare_dumper_quotes_leading_zero_string(self):
+        out = yaml.dump({"value": "03190301"}, Dumper=PrettyDumper)
+        self.assertTrue(
+            "'03190301'" in out or '"03190301"' in out,
+            f"bare PrettyDumper must quote leading-zero strings. Got:\n{out}",
+        )

--- a/tests/test_yaml_use_rapidyaml.py
+++ b/tests/test_yaml_use_rapidyaml.py
@@ -70,6 +70,20 @@ class TestRymlDump:
             f"{buf.getvalue()!r}"
         )
 
+    def test_leading_zero_numeric_strings_are_quoted(self):
+        """Leading-zero digit strings must be quoted in the raw output (#1595).
+
+        "08"/"09" are invalid octal, so ``_str_is_ambiguous`` ignores them and
+        only ``is_leading_zero_int_string`` flags them — isolating this fix and
+        covering both the value and key paths. Assert on raw text: PyYAML reads
+        them back as strings quoted or not, so ``safe_load`` cannot detect it.
+        """
+        buf = io.StringIO()
+        yaml_ryml.dump({"08": "09"}, buf)
+        out = buf.getvalue()
+        assert "'08'" in out, out  # key path
+        assert "'09'" in out, out  # value path
+
     def test_keys_are_sorted_alphabetically(self):
         """Mapping keys are emitted in sorted order for deterministic output."""
         buf = io.StringIO()


### PR DESCRIPTION
## Summary

Quote leading-zero numeric strings (e.g. `"03190301"`) in the compiled
manifest serializer so they survive as strings end to end.

Fixes #1595

## Motivation

PyYAML's YAML 1.1 resolver treats `"03190301"` as a string and emits it
unquoted, but the Go/YAML 1.2 parsers in Helm and the Kubernetes API server
read it as an integer and drop the leading zero. #1370/#1372 fixed this only
for helm's *input* values file; the serializer that writes the final
`compiled/.../*.yaml` manifests still re-emitted the value unquoted. It loads
where the schema coerces scalars (ConfigMap `data`) but is rejected on
`string`-typed fields like Deployment `env[].value` (`cannot unmarshal number
into ... of type string`).

## Affected files or URLs

- `kapitan/utils.py` — `is_leading_zero_int_string()` predicate; applied in `PrettyDumper` (PyYAML output path)
- `kapitan/yaml_ryml.py` — same guard on the rapidyaml output path (value + key)
- `kapitan/inputs/helm.py` — `_helm_str_representer` reuses the shared predicate
- `tests/` — predicate unit tests, ryml raw-text test, helm end-to-end Deployment `env` regression test + fixture

## Test plan

- [x] Tests added or updated
- [x] Documentation updated (if user-facing behavior changed) — N/A, correctness fix, no new flag/config
- [x] `make lint` passes
- [x] `make format` passes (or no formatting changes needed)
- [~] Full test suite passes (`uv run pytest tests/ --no-cov`) — all serializer/helm/compile/util tests pass (678 passed); the only local failures are Vault/cue/kustomize tests that need external tooling not installed in my sandbox, unrelated to this change. CI has that tooling.

## Risk assessment

Low. The output serializer is shared across all input types, but the change
only adds quoting for leading-zero digit strings — a class PyYAML previously
emitted plain. Other numeric strings are unaffected (already quoted by PyYAML's
emitter / rapidyaml's resolver mirror), so no existing golden output changes;
all `test_compile.py` goldens (reclass, reclass-rs, omegaconf) pass unchanged.
Quoting is lossless. Revert is a single-commit revert.

## Follow-up work intentionally left out

None.
